### PR TITLE
Add initial ROS 2 packages for CUDA IPC

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,8 +1,8 @@
 name: style
 
 on:
-  push:
   pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   clang-format:

--- a/README.md
+++ b/README.md
@@ -4,15 +4,23 @@ ROS 2 CUDA IPC Zero-Copy Transport
 
 ## 概要
 
-`ros2_cuda_ipc` は、**ROS 2 ノード間で GPU メモリをゼロコピー共有**するためのライブラリ／メッセージ定義を提供します。  
-同一ホスト・同一GPUデバイスを前提に、CUDA IPC（`cudaIpcMemHandle_t` / `cudaIpcEventHandle_t`）を利用し、Publisher ノードが所有するメモリープールを Subscriber が read-only 参照できます。  
+`ros2_cuda_ipc` は、**ROS 2 ノード間で GPU メモリをゼロコピー共有**するためのライブラリ／メッセージ定義を提供します。
+同一ホスト・同一GPUデバイスを前提に、CUDA IPC（`cudaIpcMemHandle_t` / `cudaIpcEventHandle_t`）を利用し、Publisher ノードが所有するメモリープールを Subscriber が read-only 参照できます。
 
 主な用途は以下です：
-- カメラドライバー → CUDA 前処理 → 複数ノード（エンコード／プレビュー／DNN推論）へのゼロコピー分配  
-- 画像（NV12, BGR, RGBA 等）、点群（AoS/SoA）など大規模GPUデータの効率的な伝搬  
-- C++ / Python 双方から利用可能  
+- カメラドライバー → CUDA 前処理 → 複数ノード（エンコード／プレビュー／DNN推論）へのゼロコピー分配
+- 画像（NV12, BGR, RGBA 等）、点群（AoS/SoA）など大規模GPUデータの効率的な伝搬
+- C++ / Python 双方から利用可能
 
 詳細な設計は [doc/design.md](doc/design.md) を参照してください。
+
+## パッケージ構成
+
+このリポジトリは以下の ROS 2 パッケージを含みます：
+
+- `ros2_cuda_ipc_msgs` — GPU バッファ共有のためのメッセージ／サービス定義
+- `ros2_cuda_ipc_core` — メモリープールなどコア機能の C++ 実装
+- `sample_nodes` — メッセージ送受信を確認する簡単なサンプルノード
 
 ## 開発環境セットアップ
 
@@ -44,25 +52,16 @@ colcon build --symlink-install
 
 # ビルド成果を反映
 source install/setup.bash
-````
+```
 
-### Python バインディング
-
-Python バインディングは `ros2_cuda_ipc_py` としてビルドされ、
-`import ros2_cuda_ipc_py` で利用可能です。
-DLPack ブリッジを通じて PyTorch / CuPy 等にゼロコピーで渡すことができます。
-
-### サンプルノード実行（予定）
+### サンプルノード実行
 
 ```bash
-# Publisher (疑似カメラ + YUV->BGR)
-ros2 run ros2_cuda_ipc sample_publisher
+# Publisher
+ros2 run sample_nodes gpu_buffer_publisher
 
-# Subscriber (プレビュー縮小)
-ros2 run ros2_cuda_ipc sample_preview
-
-# Subscriber (エンコーダ)
-ros2 run ros2_cuda_ipc sample_encoder
+# Subscriber
+ros2 run sample_nodes gpu_buffer_subscriber
 ```
 
 ---
@@ -71,7 +70,7 @@ ros2 run ros2_cuda_ipc sample_encoder
 
 * 設計は [doc/design.md](doc/design.md) に従う
 * Issue / PR ベースで進める
-* コードスタイル: clang-format, ament\_lint
+* コードスタイル: clang-format, ament_lint
 * CI: GitHub Actions (予定)
 
 ---
@@ -79,4 +78,3 @@ ros2 run ros2_cuda_ipc sample_encoder
 ## ライセンス
 
 Apache License 2.0
-

--- a/ros2_cuda_ipc_core/CMakeLists.txt
+++ b/ros2_cuda_ipc_core/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(ros2_cuda_ipc_core)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(ros2_cuda_ipc_msgs REQUIRED)

--- a/ros2_cuda_ipc_core/CMakeLists.txt
+++ b/ros2_cuda_ipc_core/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.5)
+project(ros2_cuda_ipc_core)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(ros2_cuda_ipc_msgs REQUIRED)
+
+add_library(${PROJECT_NAME} src/gpu_buffer_pool.cpp)
+target_include_directories(${PROJECT_NAME} PUBLIC include)
+ament_target_dependencies(${PROJECT_NAME} rclcpp ros2_cuda_ipc_msgs)
+
+install(TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)
+install(DIRECTORY include/ DESTINATION include)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_gpu_buffer_pool test/test_gpu_buffer_pool.cpp)
+  if(TARGET test_gpu_buffer_pool)
+    target_link_libraries(test_gpu_buffer_pool ${PROJECT_NAME})
+  endif()
+endif()
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(rclcpp ros2_cuda_ipc_msgs)
+ament_package()

--- a/ros2_cuda_ipc_core/CMakeLists.txt
+++ b/ros2_cuda_ipc_core/CMakeLists.txt
@@ -9,7 +9,11 @@ find_package(rclcpp REQUIRED)
 find_package(ros2_cuda_ipc_msgs REQUIRED)
 
 add_library(${PROJECT_NAME} src/gpu_buffer_pool.cpp)
-target_include_directories(${PROJECT_NAME} PUBLIC include)
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
 ament_target_dependencies(${PROJECT_NAME} rclcpp ros2_cuda_ipc_msgs)
 
 install(TARGETS ${PROJECT_NAME}

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_pool.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_pool.hpp
@@ -2,9 +2,9 @@
 #define ROS2_CUDA_IPC_CORE_GPU_BUFFER_POOL_HPP_
 
 #include <cstddef>
-#include <vector>
 #include <mutex>
 #include <optional>
+#include <vector>
 
 namespace ros2_cuda_ipc_core {
 
@@ -13,12 +13,13 @@ struct Slot {
 };
 
 class GpuBufferPool {
-public:
+ public:
   explicit GpuBufferPool(std::size_t size);
   std::optional<std::size_t> borrow();
   bool release(std::size_t id);
   std::size_t capacity() const { return slots_.size(); }
-private:
+
+ private:
   std::vector<Slot> slots_;
   std::mutex mutex_;
 };

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_pool.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_pool.hpp
@@ -1,0 +1,28 @@
+#ifndef ROS2_CUDA_IPC_CORE_GPU_BUFFER_POOL_HPP_
+#define ROS2_CUDA_IPC_CORE_GPU_BUFFER_POOL_HPP_
+
+#include <cstddef>
+#include <vector>
+#include <mutex>
+#include <optional>
+
+namespace ros2_cuda_ipc_core {
+
+struct Slot {
+  bool in_use{false};
+};
+
+class GpuBufferPool {
+public:
+  explicit GpuBufferPool(std::size_t size);
+  std::optional<std::size_t> borrow();
+  void release(std::size_t id);
+  std::size_t capacity() const { return slots_.size(); }
+private:
+  std::vector<Slot> slots_;
+  std::mutex mutex_;
+};
+
+}  // namespace ros2_cuda_ipc_core
+
+#endif  // ROS2_CUDA_IPC_CORE_GPU_BUFFER_POOL_HPP_

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_pool.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_pool.hpp
@@ -16,7 +16,7 @@ class GpuBufferPool {
 public:
   explicit GpuBufferPool(std::size_t size);
   std::optional<std::size_t> borrow();
-  void release(std::size_t id);
+  bool release(std::size_t id);
   std::size_t capacity() const { return slots_.size(); }
 private:
   std::vector<Slot> slots_;

--- a/ros2_cuda_ipc_core/package.xml
+++ b/ros2_cuda_ipc_core/package.xml
@@ -3,8 +3,8 @@
   <name>ros2_cuda_ipc_core</name>
   <version>0.0.1</version>
   <description>C++ core utilities for ROS2 CUDA IPC transport.</description>
-  <maintainer email="example@example.com">Maintainer</maintainer>
-  <license>Apache-2.0</license>
+  <maintainer email="kato.daisuke429@gmail.com">dskkato</maintainer>
+  <license>MIT</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>ros2_cuda_ipc_msgs</build_depend>

--- a/ros2_cuda_ipc_core/package.xml
+++ b/ros2_cuda_ipc_core/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>ros2_cuda_ipc_core</name>
+  <version>0.0.1</version>
+  <description>C++ core utilities for ROS2 CUDA IPC transport.</description>
+  <maintainer email="example@example.com">Maintainer</maintainer>
+  <license>Apache-2.0</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>ros2_cuda_ipc_msgs</build_depend>
+  <build_depend>ament_cmake_gtest</build_depend>
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>ros2_cuda_ipc_msgs</exec_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+</package>

--- a/ros2_cuda_ipc_core/src/gpu_buffer_pool.cpp
+++ b/ros2_cuda_ipc_core/src/gpu_buffer_pool.cpp
@@ -1,0 +1,25 @@
+#include "ros2_cuda_ipc_core/gpu_buffer_pool.hpp"
+
+namespace ros2_cuda_ipc_core {
+
+GpuBufferPool::GpuBufferPool(std::size_t size) : slots_(size) {}
+
+std::optional<std::size_t> GpuBufferPool::borrow() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (std::size_t i = 0; i < slots_.size(); ++i) {
+    if (!slots_[i].in_use) {
+      slots_[i].in_use = true;
+      return i;
+    }
+  }
+  return std::nullopt;
+}
+
+void GpuBufferPool::release(std::size_t id) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (id < slots_.size()) {
+    slots_[id].in_use = false;
+  }
+}
+
+}  // namespace ros2_cuda_ipc_core

--- a/ros2_cuda_ipc_core/src/gpu_buffer_pool.cpp
+++ b/ros2_cuda_ipc_core/src/gpu_buffer_pool.cpp
@@ -15,11 +15,13 @@ std::optional<std::size_t> GpuBufferPool::borrow() {
   return std::nullopt;
 }
 
-void GpuBufferPool::release(std::size_t id) {
+bool GpuBufferPool::release(std::size_t id) {
   std::lock_guard<std::mutex> lock(mutex_);
-  if (id < slots_.size()) {
+  if (id < slots_.size() && slots_[id].in_use) {
     slots_[id].in_use = false;
+    return true;
   }
+  return false;
 }
 
 }  // namespace ros2_cuda_ipc_core

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_pool.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_pool.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+
 #include "ros2_cuda_ipc_core/gpu_buffer_pool.hpp"
 
 using ros2_cuda_ipc_core::GpuBufferPool;

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_pool.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_pool.cpp
@@ -11,7 +11,8 @@ TEST(GpuBufferPool, BorrowRelease) {
   ASSERT_TRUE(s1.has_value());
   auto s2 = pool.borrow();
   EXPECT_FALSE(s2.has_value());
-  pool.release(*s0);
+  EXPECT_TRUE(pool.release(*s0));
+  EXPECT_FALSE(pool.release(pool.capacity()));
   auto s3 = pool.borrow();
   EXPECT_TRUE(s3.has_value());
 }

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_pool.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_pool.cpp
@@ -1,0 +1,22 @@
+#include <gtest/gtest.h>
+#include "ros2_cuda_ipc_core/gpu_buffer_pool.hpp"
+
+using ros2_cuda_ipc_core::GpuBufferPool;
+
+TEST(GpuBufferPool, BorrowRelease) {
+  GpuBufferPool pool(2);
+  auto s0 = pool.borrow();
+  ASSERT_TRUE(s0.has_value());
+  auto s1 = pool.borrow();
+  ASSERT_TRUE(s1.has_value());
+  auto s2 = pool.borrow();
+  EXPECT_FALSE(s2.has_value());
+  pool.release(*s0);
+  auto s3 = pool.borrow();
+  EXPECT_TRUE(s3.has_value());
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/ros2_cuda_ipc_msgs/CMakeLists.txt
+++ b/ros2_cuda_ipc_msgs/CMakeLists.txt
@@ -2,12 +2,14 @@ cmake_minimum_required(VERSION 3.5)
 project(ros2_cuda_ipc_msgs)
 
 find_package(rosidl_default_generators REQUIRED)
+find_package(builtin_interfaces REQUIRED)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/GpuPlane.msg"
   "msg/GpuBuffer.msg"
   "srv/GpuBufferRelease.srv"
+  DEPENDENCIES builtin_interfaces
 )
 
-ament_export_dependencies(rosidl_default_runtime)
+ament_export_dependencies(rosidl_default_runtime builtin_interfaces)
 ament_package()

--- a/ros2_cuda_ipc_msgs/CMakeLists.txt
+++ b/ros2_cuda_ipc_msgs/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.5)
+project(ros2_cuda_ipc_msgs)
+
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/GpuPlane.msg"
+  "msg/GpuBuffer.msg"
+  "srv/GpuBufferRelease.srv"
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+ament_package()

--- a/ros2_cuda_ipc_msgs/msg/GpuBuffer.msg
+++ b/ros2_cuda_ipc_msgs/msg/GpuBuffer.msg
@@ -1,0 +1,15 @@
+uint32 abi_version
+string device_uuid
+uint64 seq_id
+uint32 pool_slot_id
+uint8 plane_count
+uint8 format
+uint8 layout
+uint32 width
+uint32 height
+uint32 channels
+GpuPlane[] planes
+uint8[64] ipc_event_handle
+builtin_interfaces/Time stamp
+string frame_id
+string shm_name

--- a/ros2_cuda_ipc_msgs/msg/GpuPlane.msg
+++ b/ros2_cuda_ipc_msgs/msg/GpuPlane.msg
@@ -1,0 +1,3 @@
+uint64 size_bytes
+uint64 pitch_bytes
+uint8[64] ipc_mem_handle

--- a/ros2_cuda_ipc_msgs/package.xml
+++ b/ros2_cuda_ipc_msgs/package.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>ros2_cuda_ipc_msgs</name>
+  <version>0.0.1</version>
+  <description>Messages and services for ROS2 CUDA IPC zero-copy transport.</description>
+  <maintainer email="example@example.com">Maintainer</maintainer>
+  <license>Apache-2.0</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+</package>

--- a/ros2_cuda_ipc_msgs/package.xml
+++ b/ros2_cuda_ipc_msgs/package.xml
@@ -3,10 +3,12 @@
   <name>ros2_cuda_ipc_msgs</name>
   <version>0.0.1</version>
   <description>Messages and services for ROS2 CUDA IPC zero-copy transport.</description>
-  <maintainer email="example@example.com">Maintainer</maintainer>
-  <license>Apache-2.0</license>
+  <maintainer email="kato.daisuke429@gmail.com">dskkato</maintainer>
+  <license>MIT</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>rosidl_default_generators</build_depend>
+  <build_depend>builtin_interfaces</build_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>builtin_interfaces</exec_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>
 </package>

--- a/ros2_cuda_ipc_msgs/srv/GpuBufferRelease.srv
+++ b/ros2_cuda_ipc_msgs/srv/GpuBufferRelease.srv
@@ -1,0 +1,5 @@
+uint64 seq_id
+uint32 pool_slot_id
+string consumer_id
+---
+bool ok

--- a/sample_nodes/CMakeLists.txt
+++ b/sample_nodes/CMakeLists.txt
@@ -1,17 +1,10 @@
 cmake_minimum_required(VERSION 3.5)
 project(sample_nodes)
 
-find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
-find_package(ros2_cuda_ipc_msgs REQUIRED)
-find_package(ros2_cuda_ipc_core REQUIRED)
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
 
-add_executable(gpu_buffer_publisher src/gpu_buffer_publisher.cpp)
-ament_target_dependencies(gpu_buffer_publisher rclcpp ros2_cuda_ipc_msgs ros2_cuda_ipc_core)
+ament_auto_add_executable(gpu_buffer_publisher src/gpu_buffer_publisher.cpp)
+ament_auto_add_executable(gpu_buffer_subscriber src/gpu_buffer_subscriber.cpp)
 
-add_executable(gpu_buffer_subscriber src/gpu_buffer_subscriber.cpp)
-ament_target_dependencies(gpu_buffer_subscriber rclcpp ros2_cuda_ipc_msgs ros2_cuda_ipc_core)
-
-install(TARGETS gpu_buffer_publisher gpu_buffer_subscriber DESTINATION lib/${PROJECT_NAME})
-
-ament_package()
+ament_auto_package()

--- a/sample_nodes/CMakeLists.txt
+++ b/sample_nodes/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.5)
+project(sample_nodes)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(ros2_cuda_ipc_msgs REQUIRED)
+find_package(ros2_cuda_ipc_core REQUIRED)
+
+add_executable(gpu_buffer_publisher src/gpu_buffer_publisher.cpp)
+ament_target_dependencies(gpu_buffer_publisher rclcpp ros2_cuda_ipc_msgs ros2_cuda_ipc_core)
+
+add_executable(gpu_buffer_subscriber src/gpu_buffer_subscriber.cpp)
+ament_target_dependencies(gpu_buffer_subscriber rclcpp ros2_cuda_ipc_msgs ros2_cuda_ipc_core)
+
+install(TARGETS gpu_buffer_publisher gpu_buffer_subscriber DESTINATION lib/${PROJECT_NAME})
+
+ament_package()

--- a/sample_nodes/package.xml
+++ b/sample_nodes/package.xml
@@ -3,8 +3,8 @@
   <name>sample_nodes</name>
   <version>0.0.1</version>
   <description>Sample publisher and subscriber nodes for ROS2 CUDA IPC transport.</description>
-  <maintainer email="example@example.com">Maintainer</maintainer>
-  <license>Apache-2.0</license>
+  <maintainer email="kato.daisuke429@gmail.com">dskkato</maintainer>
+  <license>MIT</license>
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>rclcpp</build_depend>
   <build_depend>ros2_cuda_ipc_msgs</build_depend>

--- a/sample_nodes/package.xml
+++ b/sample_nodes/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>sample_nodes</name>
+  <version>0.0.1</version>
+  <description>Sample publisher and subscriber nodes for ROS2 CUDA IPC transport.</description>
+  <maintainer email="example@example.com">Maintainer</maintainer>
+  <license>Apache-2.0</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>rclcpp</build_depend>
+  <build_depend>ros2_cuda_ipc_msgs</build_depend>
+  <build_depend>ros2_cuda_ipc_core</build_depend>
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>ros2_cuda_ipc_msgs</exec_depend>
+  <exec_depend>ros2_cuda_ipc_core</exec_depend>
+</package>

--- a/sample_nodes/src/gpu_buffer_publisher.cpp
+++ b/sample_nodes/src/gpu_buffer_publisher.cpp
@@ -1,0 +1,38 @@
+#include <rclcpp/rclcpp.hpp>
+#include "ros2_cuda_ipc_msgs/msg/gpu_buffer.hpp"
+
+class DummyPublisher : public rclcpp::Node {
+public:
+  DummyPublisher() : Node("dummy_gpu_buffer_publisher") {
+    pub_ = this->create_publisher<ros2_cuda_ipc_msgs::msg::GpuBuffer>("gpu_buffer", 10);
+    timer_ = this->create_wall_timer(std::chrono::seconds(1), [this]() { publish_once(); });
+  }
+private:
+  void publish_once() {
+    ros2_cuda_ipc_msgs::msg::GpuBuffer msg;
+    msg.abi_version = 1;
+    msg.device_uuid = "dummy";
+    msg.seq_id = count_++;
+    msg.pool_slot_id = 0;
+    msg.plane_count = 0;
+    msg.format = 1;
+    msg.layout = 0;
+    msg.width = 0;
+    msg.height = 0;
+    msg.channels = 0;
+    msg.stamp = this->now();
+    msg.frame_id = "frame";
+    msg.shm_name = "";
+    pub_->publish(msg);
+  }
+  rclcpp::Publisher<ros2_cuda_ipc_msgs::msg::GpuBuffer>::SharedPtr pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  uint64_t count_{0};
+};
+
+int main(int argc, char **argv) {
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<DummyPublisher>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/sample_nodes/src/gpu_buffer_publisher.cpp
+++ b/sample_nodes/src/gpu_buffer_publisher.cpp
@@ -1,13 +1,17 @@
 #include <rclcpp/rclcpp.hpp>
+
 #include "ros2_cuda_ipc_msgs/msg/gpu_buffer.hpp"
 
 class DummyPublisher : public rclcpp::Node {
-public:
+ public:
   DummyPublisher() : Node("dummy_gpu_buffer_publisher") {
-    pub_ = this->create_publisher<ros2_cuda_ipc_msgs::msg::GpuBuffer>("gpu_buffer", 10);
-    timer_ = this->create_wall_timer(std::chrono::seconds(1), [this]() { publish_once(); });
+    pub_ = this->create_publisher<ros2_cuda_ipc_msgs::msg::GpuBuffer>(
+        "gpu_buffer", 10);
+    timer_ = this->create_wall_timer(std::chrono::seconds(1),
+                                     [this]() { publish_once(); });
   }
-private:
+
+ private:
   void publish_once() {
     ros2_cuda_ipc_msgs::msg::GpuBuffer msg;
     msg.abi_version = 1;

--- a/sample_nodes/src/gpu_buffer_subscriber.cpp
+++ b/sample_nodes/src/gpu_buffer_subscriber.cpp
@@ -1,0 +1,22 @@
+#include <rclcpp/rclcpp.hpp>
+#include "ros2_cuda_ipc_msgs/msg/gpu_buffer.hpp"
+
+class DummySubscriber : public rclcpp::Node {
+public:
+  DummySubscriber() : Node("dummy_gpu_buffer_subscriber") {
+    sub_ = this->create_subscription<ros2_cuda_ipc_msgs::msg::GpuBuffer>(
+      "gpu_buffer", 10,
+      [this](const ros2_cuda_ipc_msgs::msg::GpuBuffer & msg) {
+        RCLCPP_INFO(this->get_logger(), "Received seq_id %lu", msg.seq_id);
+      });
+  }
+private:
+  rclcpp::Subscription<ros2_cuda_ipc_msgs::msg::GpuBuffer>::SharedPtr sub_;
+};
+
+int main(int argc, char **argv) {
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<DummySubscriber>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/sample_nodes/src/gpu_buffer_subscriber.cpp
+++ b/sample_nodes/src/gpu_buffer_subscriber.cpp
@@ -1,16 +1,18 @@
 #include <rclcpp/rclcpp.hpp>
+
 #include "ros2_cuda_ipc_msgs/msg/gpu_buffer.hpp"
 
 class DummySubscriber : public rclcpp::Node {
-public:
+ public:
   DummySubscriber() : Node("dummy_gpu_buffer_subscriber") {
     sub_ = this->create_subscription<ros2_cuda_ipc_msgs::msg::GpuBuffer>(
-      "gpu_buffer", 10,
-      [this](const ros2_cuda_ipc_msgs::msg::GpuBuffer & msg) {
-        RCLCPP_INFO(this->get_logger(), "Received seq_id %lu", msg.seq_id);
-      });
+        "gpu_buffer", 10,
+        [this](const ros2_cuda_ipc_msgs::msg::GpuBuffer &msg) {
+          RCLCPP_INFO(this->get_logger(), "Received seq_id %lu", msg.seq_id);
+        });
   }
-private:
+
+ private:
   rclcpp::Subscription<ros2_cuda_ipc_msgs::msg::GpuBuffer>::SharedPtr sub_;
 };
 


### PR DESCRIPTION
## Summary
- add ros2_cuda_ipc_msgs with GPU buffer messages and release service
- add ros2_cuda_ipc_core with simple GPU buffer pool and unit test
- add sample_nodes showing basic publish/subscribe usage

## Testing
- `colcon build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68c56d09af048328a1e4b5c4dc64c295