### PR TITLE
Add clang-format style checks with pre-commit

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,14 @@
+name: style
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v17.0.6
+    hooks:
+      - id: clang-format


### PR DESCRIPTION
## Summary
- configure pre-commit to run clang-format
- add GitHub Actions workflow to enforce style check

## Testing
- `pip install pre-commit` *(fails: Could not connect to proxy)*
- `pre-commit run --files README.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c56d5109f08328a44f278a0db7134f