### PR TITLE
Add field documentation to GPU IPC messages

### DIFF
--- a/ros2_cuda_ipc_msgs/msg/GpuBuffer.msg
+++ b/ros2_cuda_ipc_msgs/msg/GpuBuffer.msg
@@ -1,15 +1,22 @@
-uint32 abi_version
-string device_uuid
-uint64 seq_id
-uint32 pool_slot_id
-uint8 plane_count
-uint8 format
-uint8 layout
-uint32 width
-uint32 height
-uint32 channels
-GpuPlane[] planes
-uint8[64] ipc_event_handle
-builtin_interfaces/Time stamp
-string frame_id
-string shm_name
+uint32 abi_version                # ABI version; increment when incompatible changes are made
+string device_uuid                # Target CUDA device UUID (cudaDeviceProp::uuid); ensures same GPU
+uint64 seq_id                     # Monotonic sequence number for the buffer/frame (0..2^64-1)
+uint32 pool_slot_id               # Index of slot in publisher's pool [0..N-1]
+uint8 plane_count                 # Number of valid entries in 'planes'; range 1-255 (typ. 1 for RGB(A), 2 for NV12)
+
+# format enum: 1=BGR8, 2=RGBA8, 10=NV12, 11=YUV420, 20=FP16, 21=FP32, 30=PCL_XYZ
+uint8 format                      # Pixel/element format code describing memory contents
+
+# layout enum: 0=LINEAR, 1=PITCHED, 10=CHW, 11=NCHW, 20=AOS, 21=SOA
+uint8 layout                      # Memory layout of each plane
+
+uint32 width                      # Width in pixels/elements; must be > 0
+uint32 height                     # Height in pixels/elements; must be > 0
+uint32 channels                   # Channels per pixel/element; typical range 1-4
+
+GpuPlane[] planes                 # Per-plane memory descriptors (length == plane_count)
+uint8[64] ipc_event_handle        # cudaIpcEventHandle_t (64 bytes); open via cudaIpcOpenEventHandle and wait before use
+
+builtin_interfaces/Time stamp     # ROS timestamp when buffer was produced
+string frame_id                   # Frame of reference, follows standard ROS usage
+string shm_name                   # Optional shared memory control block name; may be empty

--- a/ros2_cuda_ipc_msgs/msg/GpuPlane.msg
+++ b/ros2_cuda_ipc_msgs/msg/GpuPlane.msg
@@ -1,3 +1,3 @@
-uint64 size_bytes
-uint64 pitch_bytes
-uint8[64] ipc_mem_handle
+uint64 size_bytes           # Total size of this plane in bytes (>0)
+uint64 pitch_bytes          # Row stride in bytes; 0 when data is tightly packed
+uint8[64] ipc_mem_handle    # cudaIpcMemHandle_t (64 bytes); open via cudaIpcOpenMemHandle for read-only access

--- a/ros2_cuda_ipc_msgs/srv/GpuBufferRelease.srv
+++ b/ros2_cuda_ipc_msgs/srv/GpuBufferRelease.srv
@@ -1,5 +1,5 @@
-uint64 seq_id
-uint32 pool_slot_id
-string consumer_id
+uint64 seq_id        # Sequence number of the buffer to release
+uint32 pool_slot_id  # Slot index in publisher's pool [0..N-1]
+string consumer_id   # Identifier of releasing consumer (e.g., node name)
 ---
-bool ok
+bool ok              # True if the buffer was successfully released


### PR DESCRIPTION
## Summary
- annotate GpuBuffer message fields with units, ranges and usage notes
- document GpuPlane memory handle semantics
- describe release service request/response fields

## Testing
- `colcon test --event-handlers console_cohesion+ --packages-select ros2_cuda_ipc_msgs ros2_cuda_ipc_core` *(command not found)*
- `apt-get update` *(403 Forbidden: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68c5eda925188328825f1054dcde71f3