### PR TITLE
Add initial Python pybind11 package

### DIFF
--- a/ros2_cuda_ipc_py/CMakeLists.txt
+++ b/ros2_cuda_ipc_py/CMakeLists.txt
@@ -8,6 +8,6 @@ find_package(pybind11 REQUIRED)
 ament_python_install_package(${PROJECT_NAME})
 
 pybind11_add_module(_cuda_ipc src/pybind_module.cpp)
-install(TARGETS _cuda_ipc DESTINATION lib/${PROJECT_NAME})
+install(TARGETS _cuda_ipc DESTINATION ${PYTHON_INSTALL_DIR}/${PROJECT_NAME})
 
 ament_package()

--- a/ros2_cuda_ipc_py/CMakeLists.txt
+++ b/ros2_cuda_ipc_py/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.5)
+project(ros2_cuda_ipc_py)
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+find_package(pybind11 REQUIRED)
+
+ament_python_install_package(${PROJECT_NAME})
+
+pybind11_add_module(_cuda_ipc src/pybind_module.cpp)
+install(TARGETS _cuda_ipc DESTINATION lib/${PROJECT_NAME})
+
+ament_package()

--- a/ros2_cuda_ipc_py/package.xml
+++ b/ros2_cuda_ipc_py/package.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>ros2_cuda_ipc_py</name>
+  <version>0.0.1</version>
+  <description>Python bindings for ROS2 CUDA IPC transport.</description>
+  <maintainer email="kato.daisuke429@gmail.com">dskkato</maintainer>
+  <license>MIT</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>ament_python</depend>
+  <depend>rclpy</depend>
+  <depend>pybind11</depend>
+</package>

--- a/ros2_cuda_ipc_py/setup.py
+++ b/ros2_cuda_ipc_py/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup
+
+package_name = 'ros2_cuda_ipc_py'
+
+setup(
+    name=package_name,
+    version='0.0.1',
+    packages=[package_name],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    maintainer='dskkato',
+    maintainer_email='kato.daisuke429@gmail.com',
+    description='Python bindings for ROS2 CUDA IPC transport.',
+    license='MIT',
+)

--- a/ros2_cuda_ipc_py/setup.py
+++ b/ros2_cuda_ipc_py/setup.py
@@ -5,7 +5,6 @@ package_name = 'ros2_cuda_ipc_py'
 setup(
     name=package_name,
     version='0.0.1',
-    packages=[package_name],
     install_requires=['setuptools'],
     zip_safe=True,
     maintainer='dskkato',

--- a/ros2_cuda_ipc_py/src/pybind_module.cpp
+++ b/ros2_cuda_ipc_py/src/pybind_module.cpp
@@ -1,0 +1,11 @@
+#include <pybind11/pybind11.h>
+
+namespace py = pybind11;
+
+int add(int a, int b) {
+  return a + b;
+}
+
+PYBIND11_MODULE(_cuda_ipc, m) {
+  m.def("add", &add, "Add two integers");
+}


### PR DESCRIPTION
## Summary
- add `ros2_cuda_ipc_py` package for Python bindings
- set up CMake and setup.py with `ament_python_install_package` and `pybind11_add_module`
- include Python, rclpy, and pybind11 dependencies

## Testing
- `colcon build --packages-select ros2_cuda_ipc_py` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_68c5f012899c83289b0c143575303154