### PR TITLE
Use UUID for CUDA device ID

### DIFF
--- a/ros2_cuda_ipc_core/src/cuda_support.cu
+++ b/ros2_cuda_ipc_core/src/cuda_support.cu
@@ -2,6 +2,7 @@
 
 #include <cstring>
 #include <string>
+#include <cstdio>
 
 #include "ros2_cuda_ipc_core/cuda_support.hpp"
 
@@ -149,13 +150,13 @@ std::string cuda_get_device_id_string() {
   int dev = 0;
   auto err = cudaGetDevice(&dev);
   if (err != cudaSuccess) return {};
-    // Try device UUID from properties if available
-#ifdef cudaDeviceProp
+  // Try device UUID from properties if available
   cudaDeviceProp prop{};
   if (cudaGetDeviceProperties(&prop, dev) == cudaSuccess) {
 #if defined(__CUDACC_VER_MAJOR__) && (__CUDACC_VER_MAJOR__ >= 11)
     // Many toolkits expose prop.uuid.bytes (16 bytes). Serialize to hex.
-    const unsigned char* u = reinterpret_cast<const unsigned char*>(&prop.uuid);
+    const unsigned char* u =
+        reinterpret_cast<const unsigned char*>(&prop.uuid);
     char buf[64];
     int off = 0;
     for (int i = 0; i < 16 && off + 2 < static_cast<int>(sizeof(buf)); ++i) {
@@ -164,8 +165,7 @@ std::string cuda_get_device_id_string() {
     if (off > 0) return std::string(buf, buf + off);
 #endif
   }
-#endif
-  // Fallback to PCI bus id string
+  // Fallback to PCI bus id string when UUID isn't available
   char busid[64] = {0};
   if (cudaDeviceGetPCIBusId(busid, sizeof(busid), dev) == cudaSuccess) {
     return std::string(busid);


### PR DESCRIPTION
## Summary
- include `<cstdio>` for `std::snprintf`
- always compile device UUID logic and fall back to PCI bus id
- clarify fallback when UUID isn't available

## Testing
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pre-commit run --files ros2_cuda_ipc_core/src/cuda_support.cu` *(command not found)*
- `colcon test --packages-select ros2_cuda_ipc_core` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c5ed7a0244832880b6ee09de07147b