### PR TITLE
Return success from CUDA stub

### DIFF
--- a/sample_nodes/src/sample_cuda_utils_stub.cpp
+++ b/sample_nodes/src/sample_cuda_utils_stub.cpp
@@ -2,6 +2,10 @@
 
 namespace sample_nodes {
 
-bool cuda_simulate_work_ms(int /*ms*/, void* /*stream*/) { return false; }
+// This stub is used when CUDA is not available.
+// The function is a no-op but returns true so callers treat it as success.
+bool cuda_simulate_work_ms(int /*ms*/, void* /*stream*/) {
+  return true;
+}
 
 }  // namespace sample_nodes


### PR DESCRIPTION
## Summary
- Ensure cuda_simulate_work_ms stub reports success
- Document that stub does no work in non-CUDA builds

## Testing
- `colcon build --packages-select sample_nodes` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `g++ -std=c++17 -I sample_nodes/include -c sample_nodes/src/sample_cuda_utils_stub.cpp -o /tmp/sample_cuda_utils_stub.o`


------
https://chatgpt.com/codex/tasks/task_b_68c5ed99a78883289a65c750d355bd97