### PR TITLE
Add GPU buffer pool and mapper Python bindings

### DIFF
--- a/ros2_cuda_ipc_py/CMakeLists.txt
+++ b/ros2_cuda_ipc_py/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(ros2_cuda_ipc_core REQUIRED)
 ament_python_install_package(${PROJECT_NAME})
 
 pybind11_add_module(_cuda_ipc src/pybind_module.cpp src/bindings.cpp)
+target_compile_features(_cuda_ipc PRIVATE cxx_std_17)
 target_link_libraries(_cuda_ipc PRIVATE ros2_cuda_ipc_core)
 ament_target_dependencies(_cuda_ipc ros2_cuda_ipc_core)
 

--- a/ros2_cuda_ipc_py/CMakeLists.txt
+++ b/ros2_cuda_ipc_py/CMakeLists.txt
@@ -4,10 +4,17 @@ project(ros2_cuda_ipc_py)
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(pybind11 REQUIRED)
+find_package(ros2_cuda_ipc_core REQUIRED)
 
 ament_python_install_package(${PROJECT_NAME})
 
-pybind11_add_module(_cuda_ipc src/pybind_module.cpp)
-install(TARGETS _cuda_ipc DESTINATION ${PYTHON_INSTALL_DIR}/${PROJECT_NAME})
+pybind11_add_module(_cuda_ipc src/pybind_module.cpp src/bindings.cpp)
+target_link_libraries(_cuda_ipc PRIVATE ros2_cuda_ipc_core)
+ament_target_dependencies(_cuda_ipc ros2_cuda_ipc_core)
+
+install(TARGETS _cuda_ipc EXPORT export_${PROJECT_NAME}
+  DESTINATION ${PYTHON_INSTALL_DIR}/${PROJECT_NAME})
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
 ament_package()

--- a/ros2_cuda_ipc_py/CMakeLists.txt
+++ b/ros2_cuda_ipc_py/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(ros2_cuda_ipc_py)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(pybind11 REQUIRED)
@@ -9,7 +12,6 @@ find_package(ros2_cuda_ipc_core REQUIRED)
 ament_python_install_package(${PROJECT_NAME})
 
 pybind11_add_module(_cuda_ipc src/pybind_module.cpp src/bindings.cpp)
-target_compile_features(_cuda_ipc PRIVATE cxx_std_17)
 target_link_libraries(_cuda_ipc PRIVATE ros2_cuda_ipc_core)
 ament_target_dependencies(_cuda_ipc ros2_cuda_ipc_core)
 

--- a/ros2_cuda_ipc_py/package.xml
+++ b/ros2_cuda_ipc_py/package.xml
@@ -9,4 +9,5 @@
   <depend>ament_python</depend>
   <depend>rclpy</depend>
   <depend>pybind11</depend>
+  <depend>ros2_cuda_ipc_core</depend>
 </package>

--- a/ros2_cuda_ipc_py/ros2_cuda_ipc_py/__init__.py
+++ b/ros2_cuda_ipc_py/ros2_cuda_ipc_py/__init__.py
@@ -1,0 +1,3 @@
+from ._cuda_ipc import GpuBufferPool, GpuBufferMapper
+
+__all__ = ["GpuBufferPool", "GpuBufferMapper"]

--- a/ros2_cuda_ipc_py/src/bindings.cpp
+++ b/ros2_cuda_ipc_py/src/bindings.cpp
@@ -18,13 +18,13 @@ void init_bindings(py::module_ &m) {
   py::class_<rcc::GpuBufferMapper>(m, "GpuBufferMapper")
       .def(py::init<>())
       .def("open_memory", &rcc::GpuBufferMapper::open_memory,
-           py::return_value_policy::reference)
+           py::return_value_policy::reference_internal)
       .def("open_event", &rcc::GpuBufferMapper::open_event,
-           py::return_value_policy::reference)
+           py::return_value_policy::reference_internal)
       .def("get_memory", &rcc::GpuBufferMapper::get_memory,
-           py::return_value_policy::reference)
+           py::return_value_policy::reference_internal)
       .def("get_event", &rcc::GpuBufferMapper::get_event,
-           py::return_value_policy::reference)
+           py::return_value_policy::reference_internal)
       .def("wait_ready", &rcc::GpuBufferMapper::wait_ready)
       .def("close_slot", &rcc::GpuBufferMapper::close_slot)
       .def("reset", &rcc::GpuBufferMapper::reset);

--- a/ros2_cuda_ipc_py/src/bindings.cpp
+++ b/ros2_cuda_ipc_py/src/bindings.cpp
@@ -1,0 +1,31 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "ros2_cuda_ipc_core/gpu_buffer_pool.hpp"
+#include "ros2_cuda_ipc_core/gpu_buffer_mapper.hpp"
+
+namespace py = pybind11;
+namespace rcc = ros2_cuda_ipc_core;
+
+void init_bindings(py::module_ &m) {
+  py::class_<rcc::GpuBufferPool>(m, "GpuBufferPool")
+      .def(py::init<std::size_t>())
+      .def(py::init<std::size_t, std::size_t, bool>())
+      .def("borrow", &rcc::GpuBufferPool::borrow)
+      .def("release", &rcc::GpuBufferPool::release)
+      .def("capacity", &rcc::GpuBufferPool::capacity);
+
+  py::class_<rcc::GpuBufferMapper>(m, "GpuBufferMapper")
+      .def(py::init<>())
+      .def("open_memory", &rcc::GpuBufferMapper::open_memory,
+           py::return_value_policy::reference)
+      .def("open_event", &rcc::GpuBufferMapper::open_event,
+           py::return_value_policy::reference)
+      .def("get_memory", &rcc::GpuBufferMapper::get_memory,
+           py::return_value_policy::reference)
+      .def("get_event", &rcc::GpuBufferMapper::get_event,
+           py::return_value_policy::reference)
+      .def("wait_ready", &rcc::GpuBufferMapper::wait_ready)
+      .def("close_slot", &rcc::GpuBufferMapper::close_slot)
+      .def("reset", &rcc::GpuBufferMapper::reset);
+}

--- a/ros2_cuda_ipc_py/src/pybind_module.cpp
+++ b/ros2_cuda_ipc_py/src/pybind_module.cpp
@@ -2,10 +2,9 @@
 
 namespace py = pybind11;
 
-int add(int a, int b) {
-  return a + b;
-}
+// forward declaration of bindings defined in bindings.cpp
+void init_bindings(py::module_ &m);
 
 PYBIND11_MODULE(_cuda_ipc, m) {
-  m.def("add", &add, "Add two integers");
+  init_bindings(m);
 }


### PR DESCRIPTION
## Summary
- expose `GpuBufferPool` and `GpuBufferMapper` via pybind11
- link bindings against `ros2_cuda_ipc_core` and export target
- make classes importable from the `ros2_cuda_ipc_py` package
- remove leftover `add` binding from module

## Testing
- `colcon build --packages-select ros2_cuda_ipc_core ros2_cuda_ipc_py` *(command not found)*
- `apt-get update` *(403  Forbidden [IP: 172.30.0.83 8080])* 
- `apt-get install -y python3-colcon-common-extensions` *(unable to locate package)*
- `cmake ..` in `ros2_cuda_ipc_core/build` *(could not find ament_cmake)*
- `python3 - <<'PY'\ntry:\n    from ros2_cuda_ipc_py import GpuBufferPool\n    print('import success')\nexcept Exception as e:\n    print('import failed:', e)\nPY` *(cannot import name 'GpuBufferPool')*


------
https://chatgpt.com/codex/tasks/task_b_68c5f737d5f88328ba5fece777fff2e5