### PR TITLE
Add format and layout constants for GpuBuffer

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -91,8 +91,8 @@ string   device_uuid  // `cudaDeviceProp::uuid` 文字列
 uint64   seq_id       // フレーム番号
 uint32   pool_slot_id // プール内スロット
 uint8    plane_count
-uint8    format       // enum: BGR8=1, RGBA8=2, NV12=10, YUV420=11, FP16=20, FP32=21, PCL\_XYZ=30, ...
-uint8    layout       // enum: LINEAR=0, PITCHED=1, CHW=10, NCHW=11, AOS=20, SOA=21
+uint8    format       // constants: FORMAT_BGR8, FORMAT_RGBA8, FORMAT_NV12, FORMAT_YUV420, FORMAT_FP16, FORMAT_FP32, FORMAT_PCL_XYZ, ...
+uint8    layout       // constants: LAYOUT_LINEAR, LAYOUT_PITCHED, LAYOUT_CHW, LAYOUT_NCHW, LAYOUT_AOS, LAYOUT_SOA
 uint32   width
 uint32   height
 uint32   channels
@@ -173,8 +173,8 @@ enum {FREE, IN_USE} + deadline + last_seq_id
 
 ### 8.1 Images
 
-* Formats: `NV12`, `YUV420`, `BGR8`, `RGBA8`（将来: `P010`, `FP16`）
-* Layout: `LINEAR` or `PITCHED`（`pitch_bytes` で通知）
+* Formats: `FORMAT_NV12`, `FORMAT_YUV420`, `FORMAT_BGR8`, `FORMAT_RGBA8`（将来: `FORMAT_P010`, `FORMAT_FP16`）
+* Layout: `LAYOUT_LINEAR` or `LAYOUT_PITCHED`（`pitch_bytes` で通知）
 * 多平面: 平面ごとに `mem_handle` を渡す。イベントはフレーム単位で1つ。
 
 ### 8.2 Point Clouds
@@ -290,8 +290,8 @@ ros2_cuda_ipc:
   lease_timeout_ms: 30
   expected_consumers: 3           # 省略可（未指定ならタイムアウト制）
   image:
-    default_format: NV12
-    layout: pitched
+    default_format: FORMAT_NV12
+    layout: LAYOUT_PITCHED
 ```
 
 ---

--- a/ros2_cuda_ipc_msgs/msg/GpuBuffer.msg
+++ b/ros2_cuda_ipc_msgs/msg/GpuBuffer.msg
@@ -15,7 +15,10 @@ uint8 LAYOUT_NCHW=11
 uint8 LAYOUT_AOS=20
 uint8 LAYOUT_SOA=21
 
-# Update the constants above when introducing new formats or layouts.
+# When introducing new formats or layouts, assign values as follows:
+#   - FORMAT_*: Use values 1-49 for standard formats, 50-99 for future/experimental formats, 100+ for custom/user-defined formats.
+#   - LAYOUT_*: Use values 0-49 for standard layouts, 50-99 for future/experimental layouts, 100+ for custom/user-defined layouts.
+# Update the constants above accordingly and avoid reusing existing values.
 
 uint32 abi_version                # ABI version; increment when incompatible changes are made
 string device_uuid                # Target CUDA device UUID (cudaDeviceProp::uuid); ensures same GPU

--- a/ros2_cuda_ipc_msgs/msg/GpuBuffer.msg
+++ b/ros2_cuda_ipc_msgs/msg/GpuBuffer.msg
@@ -1,3 +1,22 @@
+# Format constants
+uint8 FORMAT_BGR8=1
+uint8 FORMAT_RGBA8=2
+uint8 FORMAT_NV12=10
+uint8 FORMAT_YUV420=11
+uint8 FORMAT_FP16=20
+uint8 FORMAT_FP32=21
+uint8 FORMAT_PCL_XYZ=30
+
+# Layout constants
+uint8 LAYOUT_LINEAR=0
+uint8 LAYOUT_PITCHED=1
+uint8 LAYOUT_CHW=10
+uint8 LAYOUT_NCHW=11
+uint8 LAYOUT_AOS=20
+uint8 LAYOUT_SOA=21
+
+# Update the constants above when introducing new formats or layouts.
+
 uint32 abi_version
 string device_uuid
 uint64 seq_id

--- a/sample_nodes/src/gpu_buffer_publisher.cpp
+++ b/sample_nodes/src/gpu_buffer_publisher.cpp
@@ -111,8 +111,8 @@ class DummyPublisher : public rclcpp::Node {
     }
     msg.seq_id = count_++;
     msg.pool_slot_id = 0;
-    msg.format = 1;   // e.g., BGR8 (tentative)
-    msg.layout = 0;   // LINEAR
+    msg.format = ros2_cuda_ipc_msgs::msg::GpuBuffer::FORMAT_BGR8;
+    msg.layout = ros2_cuda_ipc_msgs::msg::GpuBuffer::LAYOUT_LINEAR;
     msg.width = 640;  // demo values
     msg.height = 480;
     msg.channels = 3;


### PR DESCRIPTION
## Summary
- define `FORMAT_*` and `LAYOUT_*` constants in `GpuBuffer` message
- update design docs and sample publisher to use constants

## Testing
- `colcon test --packages-select ros2_cuda_ipc_msgs sample_nodes` *(failed: command not found)*
- `apt-get update` *(failed: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68c5edb4004883289c71144c4e6aeff4