### PR TITLE
Add Python GPU buffer publisher and subscriber examples

### DIFF
--- a/ros2_cuda_ipc_py/ros2_cuda_ipc_py/publisher.py
+++ b/ros2_cuda_ipc_py/ros2_cuda_ipc_py/publisher.py
@@ -39,9 +39,9 @@ class GpuBufferPublisher(Node):
             if request.pool_slot_id != self._held_slot or request.seq_id != self._held_seq:
                 response.ok = False
                 self.get_logger().warn(
-                    'Release mismatch: req(slot=%u, seq=%u) vs held(slot=%s, seq=%u)',
+                    'Release mismatch: req(slot=%u, seq=%u) vs held(slot=%u, seq=%u)',
                     request.pool_slot_id, request.seq_id,
-                    str(self._held_slot), self._held_seq)
+                    self._held_slot, self._held_seq)
                 return response
             ok = self._pool.release(self._held_slot)
             response.ok = bool(ok)

--- a/ros2_cuda_ipc_py/ros2_cuda_ipc_py/publisher.py
+++ b/ros2_cuda_ipc_py/ros2_cuda_ipc_py/publisher.py
@@ -1,0 +1,128 @@
+import time
+from typing import Optional
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile
+
+from ros2_cuda_ipc_msgs.msg import GpuBuffer, GpuPlane
+from ros2_cuda_ipc_msgs.srv import GpuBufferRelease
+from ros2_cuda_ipc_py import GpuBufferPool
+
+
+class GpuBufferPublisher(Node):
+    """Simple GPU buffer publisher using a tiny buffer pool."""
+
+    def __init__(self) -> None:
+        super().__init__('gpu_buffer_publisher')
+        qos = QoSProfile(depth=10)
+        self._pub = self.create_publisher(GpuBuffer, 'gpu_buffer', qos)
+        # Prepare pool: one slot, 4 MiB, try enabling CUDA
+        self._pool = GpuBufferPool(1, 4 * 1024 * 1024, True)
+        self._timer = self.create_timer(1.0, self._publish_once)
+        self._release_srv = self.create_service(
+            GpuBufferRelease, 'gpu_buffer_release', self._on_release)
+        self._held_slot: Optional[int] = None
+        self._held_seq: int = 0
+        self._held_since: float = 0.0
+        self._lease_timeout_ms = (
+            self.declare_parameter('lease_timeout_ms', 3000).value
+        )
+
+    def _on_release(self, request: GpuBufferRelease.Request,
+                    response: GpuBufferRelease.Response) -> GpuBufferRelease.Response:
+        try:
+            if self._held_slot is None:
+                response.ok = False
+                self.get_logger().warn('Release requested but no slot held')
+                return response
+            if request.pool_slot_id != self._held_slot or request.seq_id != self._held_seq:
+                response.ok = False
+                self.get_logger().warn(
+                    'Release mismatch: req(slot=%u, seq=%u) vs held(slot=%s, seq=%u)',
+                    request.pool_slot_id, request.seq_id,
+                    str(self._held_slot), self._held_seq)
+                return response
+            ok = self._pool.release(self._held_slot)
+            response.ok = bool(ok)
+            if ok:
+                self.get_logger().info(
+                    'Released slot %u for seq %u from %s',
+                    request.pool_slot_id, request.seq_id, request.consumer_id)
+                self._held_slot = None
+                self._held_since = 0.0
+            else:
+                self.get_logger().warn('Release failed for slot %u', request.pool_slot_id)
+        except Exception as exc:  # pragma: no cover - defensive
+            response.ok = False
+            self.get_logger().error(f'Release service error: {exc}')
+        return response
+
+    def _publish_once(self) -> None:
+        try:
+            # Enforce lease timeout
+            if self._held_slot is not None:
+                elapsed = (time.time() - self._held_since) * 1000.0
+                if elapsed > self._lease_timeout_ms:
+                    self.get_logger().warn(
+                        'Lease timeout exceeded for slot %u (seq %u). Forcing release.',
+                        self._held_slot, self._held_seq)
+                    self._pool.release(self._held_slot)
+                    self._held_slot = None
+                    self._held_since = 0.0
+                return
+
+            slot = self._pool.borrow()
+            msg = GpuBuffer()
+            msg.abi_version = 1
+            msg.device_uuid = 'unknown'
+            msg.seq_id = self._held_seq + 1
+            msg.pool_slot_id = slot or 0
+            msg.format = GpuBuffer.FORMAT_BGR8
+            msg.layout = GpuBuffer.LAYOUT_LINEAR
+            msg.width = 0
+            msg.height = 0
+            msg.channels = 0
+            msg.plane_count = 0
+            msg.stamp = self.get_clock().now().to_msg()
+            msg.frame_id = ''
+            msg.shm_name = ''
+
+            if slot is not None:
+                # For demo purposes we do not export actual handles; use zeros
+                plane = GpuPlane()
+                plane.size_bytes = 0
+                plane.pitch_bytes = 0
+                plane.ipc_mem_handle = [0] * 64
+                msg.planes.append(plane)
+                msg.plane_count = 1
+                msg.pool_slot_id = slot
+                msg.ipc_event_handle = [0] * 64
+                self._held_slot = slot
+                self._held_seq = msg.seq_id
+                self._held_since = time.time()
+                self.get_logger().info(
+                    'Publishing seq=%u with dummy CUDA IPC handles (slot %u)',
+                    msg.seq_id, slot)
+            else:
+                self.get_logger().warn('Pool exhausted; publishing metadata only')
+
+            self._pub.publish(msg)
+        except Exception as exc:  # pragma: no cover - defensive
+            self.get_logger().error(f'Publish error: {exc}')
+
+
+def main(args=None) -> None:
+    rclpy.init(args=args)
+    node = GpuBufferPublisher()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/ros2_cuda_ipc_py/ros2_cuda_ipc_py/subscriber.py
+++ b/ros2_cuda_ipc_py/ros2_cuda_ipc_py/subscriber.py
@@ -1,0 +1,98 @@
+from typing import Optional
+
+import rclpy
+from rclpy.node import Node
+from rclpy.qos import QoSProfile
+
+from ros2_cuda_ipc_msgs.msg import GpuBuffer
+from ros2_cuda_ipc_msgs.srv import GpuBufferRelease
+from ros2_cuda_ipc_py import GpuBufferMapper, to_dlpack
+
+
+class GpuBufferSubscriber(Node):
+    """Subscriber that maps GPU buffers and converts them to DLPack."""
+
+    def __init__(self) -> None:
+        super().__init__('gpu_buffer_subscriber')
+        qos = QoSProfile(depth=10)
+        self._sub = self.create_subscription(
+            GpuBuffer, 'gpu_buffer', self._on_msg, qos)
+        self._release_client = self.create_client(
+            GpuBufferRelease, 'gpu_buffer_release')
+        self._mapper = GpuBufferMapper()
+        self._stream = self._create_stream()
+
+    def _create_stream(self) -> Optional[int]:
+        try:
+            import cupy as cp  # type: ignore
+            return int(cp.cuda.Stream(non_blocking=True).ptr)
+        except Exception as exc:  # pragma: no cover - defensive
+            self.get_logger().warn(f'Failed to create CUDA stream: {exc}')
+            return None
+
+    def _on_msg(self, msg: GpuBuffer) -> None:
+        try:
+            self.get_logger().info(f'Received seq_id {msg.seq_id}')
+            if msg.plane_count > 0 and len(msg.planes) >= 1:
+                # Map memory using IPC handle
+                try:
+                    mem_handle = bytes(msg.planes[0].ipc_mem_handle)
+                    self._mapper.open_memory(msg.pool_slot_id, mem_handle)
+                except Exception as exc:
+                    self.get_logger().error(f'open_memory failed: {exc}')
+                    return
+            # Open event and wait on our stream
+            try:
+                evt_handle = bytes(msg.ipc_event_handle)
+                self._mapper.open_event(msg.pool_slot_id, evt_handle)
+                if self._stream is not None:
+                    self._mapper.wait_ready(msg.pool_slot_id, self._stream)
+            except Exception as exc:
+                self.get_logger().error(f'wait_ready failed: {exc}')
+                return
+            # Convert to DLPack capsule
+            if msg.plane_count > 0 and len(msg.planes) >= 1:
+                ptr = self._mapper.get_memory(msg.pool_slot_id)
+                if ptr:
+                    size = int(msg.planes[0].size_bytes)
+                    try:
+                        cap = to_dlpack(int(ptr), size)
+                        try:
+                            import cupy as cp  # type: ignore
+                            arr = cp.fromDlpack(cap)
+                            self.get_logger().info(
+                                f'Converted to CuPy array with shape {arr.shape}')
+                        except Exception:
+                            self.get_logger().info('Produced DLPack capsule')
+                    except Exception as exc:
+                        self.get_logger().error(f'DLPack conversion failed: {exc}')
+            # Notify release
+            if not self._release_client.service_is_ready():
+                self._release_client.wait_for_service(timeout_sec=0.5)
+            req = GpuBufferRelease.Request()
+            req.seq_id = msg.seq_id
+            req.pool_slot_id = msg.pool_slot_id
+            req.consumer_id = self.get_fully_qualified_name()
+            try:
+                future = self._release_client.call_async(req)
+                future.result(timeout=1.0)
+            except Exception as exc:
+                self.get_logger().warn(f'Release service call failed: {exc}')
+        except Exception as exc:  # pragma: no cover - defensive
+            self.get_logger().error(f'Callback error: {exc}')
+
+
+def main(args=None) -> None:
+    rclpy.init(args=args)
+    node = GpuBufferSubscriber()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add Python publisher using `GpuBufferPool` with release service handling
- implement subscriber that waits on CUDA events and converts buffers using DLPack

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68c63fcbbc588328ba623518789a14f4