### PR TITLE
Refactor finalize_and_fill parameters into PublishParams struct

### DIFF
--- a/sample_nodes/include/sample_nodes/gpu_buffer_publisher_helper.hpp
+++ b/sample_nodes/include/sample_nodes/gpu_buffer_publisher_helper.hpp
@@ -6,7 +6,6 @@
 #include <cstdint>
 #include <optional>
 #include <string>
-#include <string_view>
 
 #include "ros2_cuda_ipc_core/gpu_buffer_pool.hpp"
 #include "ros2_cuda_ipc_core/lease_manager.hpp"
@@ -23,6 +22,17 @@ class GpuBufferPublisherHelper {
     uint64_t pitch_bytes{0};
   };
 
+  struct PublishParams {
+    uint64_t seq_id{0};
+    int expected_consumers{0};
+    std::string shm_owner{};
+    uint32_t width{0};
+    uint32_t height{0};
+    uint32_t channels{0};
+    uint8_t layout{0};
+    uint8_t format{0};
+  };
+
   GpuBufferPublisherHelper(ros2_cuda_ipc_core::GpuBufferPool& pool,
                            ros2_cuda_ipc_core::LeaseManager* lease_mgr,
                            void* producer_stream);
@@ -33,10 +43,7 @@ class GpuBufferPublisherHelper {
 
   // Fills the message fields, exports IPC handles, records the ready event and
   // optionally starts a lease. Returns true if plane[0] was populated.
-  bool finalize_and_fill(const Frame& f, uint64_t seq_id,
-                         int expected_consumers, std::string_view shm_owner,
-                         uint32_t width, uint32_t height, uint32_t channels,
-                         uint8_t layout, uint8_t format,
+  bool finalize_and_fill(const Frame& f, const PublishParams& params,
                          ros2_cuda_ipc_msgs::msg::GpuBuffer& out);
 
  private:

--- a/sample_nodes/src/gpu_buffer_publisher.cpp
+++ b/sample_nodes/src/gpu_buffer_publisher.cpp
@@ -105,9 +105,17 @@ class DummyPublisher : public rclcpp::Node {
               ? static_cast<int>(pub_->get_subscription_count())
               : expected_consumers_;
 
-      bool ok = helper_->finalize_and_fill(
-          *frame, msg.seq_id, expected_count, shm_owner_, msg.width, msg.height,
-          msg.channels, msg.layout, msg.format, msg);
+      sample_nodes::GpuBufferPublisherHelper::PublishParams params;
+      params.seq_id = msg.seq_id;
+      params.expected_consumers = expected_count;
+      params.shm_owner = shm_owner_;
+      params.width = msg.width;
+      params.height = msg.height;
+      params.channels = msg.channels;
+      params.layout = msg.layout;
+      params.format = msg.format;
+
+      bool ok = helper_->finalize_and_fill(*frame, params, msg);
       if (!ok) {
         RCLCPP_WARN_THROTTLE(
             this->get_logger(), *this->get_clock(), 5000,

--- a/sample_nodes/src/gpu_buffer_publisher_helper.cpp
+++ b/sample_nodes/src/gpu_buffer_publisher_helper.cpp
@@ -29,20 +29,18 @@ GpuBufferPublisherHelper::borrow_frame(uint32_t width, uint32_t height,
 }
 
 bool GpuBufferPublisherHelper::finalize_and_fill(
-    const Frame& f, uint64_t seq_id, int expected_consumers,
-    std::string_view shm_owner, uint32_t width, uint32_t height,
-    uint32_t channels, uint8_t layout, uint8_t format,
+    const Frame& f, const PublishParams& params,
     ros2_cuda_ipc_msgs::msg::GpuBuffer& out) {
   out.abi_version = ros2_cuda_ipc_core::kAbiVersion;
   auto id = ros2_cuda_ipc_core::cuda_get_device_id_string();
   out.device_uuid = id.empty() ? std::string("unknown") : id;
-  out.seq_id = seq_id;
+  out.seq_id = params.seq_id;
   out.pool_slot_id = f.slot_id;
-  out.layout = layout;
-  out.format = format;
-  out.width = width;
-  out.height = height;
-  out.channels = channels;
+  out.layout = params.layout;
+  out.format = params.format;
+  out.width = params.width;
+  out.height = params.height;
+  out.channels = params.channels;
   out.shm_name.clear();
 
   ros2_cuda_ipc_core::CudaIpcMemHandle mh{};
@@ -69,10 +67,10 @@ bool GpuBufferPublisherHelper::finalize_and_fill(
     }
   }
 
-  if (expected_consumers > 0 && lease_mgr_) {
-    lease_mgr_->set_owner(std::string(shm_owner));
-    auto created =
-        lease_mgr_->start_lease(f.slot_id, seq_id, expected_consumers);
+  if (params.expected_consumers > 0 && lease_mgr_) {
+    lease_mgr_->set_owner(params.shm_owner);
+    auto created = lease_mgr_->start_lease(f.slot_id, params.seq_id,
+                                           params.expected_consumers);
     if (created) {
       out.shm_name = *created;
     }

--- a/sample_nodes/test/test_gpu_buffer_publisher_helper.cpp
+++ b/sample_nodes/test/test_gpu_buffer_publisher_helper.cpp
@@ -20,12 +20,16 @@ TEST(GpuBufferPublisherHelperTest, MetadataOnlyWhenNoCudaMem) {
   ASSERT_TRUE(f.has_value());
 
   ros2_cuda_ipc_msgs::msg::GpuBuffer msg;
-  bool ok = helper.finalize_and_fill(
-      *f, /*seq=*/1, /*expected=*/0,
-      /*owner=*/"test_owner",
-      /*w=*/16, /*h=*/8, /*c=*/3,
-      /*layout=*/ros2_cuda_ipc_msgs::msg::GpuBuffer::LAYOUT_LINEAR,
-      /*format=*/ros2_cuda_ipc_msgs::msg::GpuBuffer::FORMAT_BGR8, msg);
+  sample_nodes::GpuBufferPublisherHelper::PublishParams params;
+  params.seq_id = 1;
+  params.expected_consumers = 0;
+  params.shm_owner = "test_owner";
+  params.width = 16;
+  params.height = 8;
+  params.channels = 3;
+  params.layout = ros2_cuda_ipc_msgs::msg::GpuBuffer::LAYOUT_LINEAR;
+  params.format = ros2_cuda_ipc_msgs::msg::GpuBuffer::FORMAT_BGR8;
+  bool ok = helper.finalize_and_fill(*f, params, msg);
   EXPECT_FALSE(ok);
   EXPECT_EQ(msg.plane_count, 0u);
 
@@ -44,12 +48,16 @@ TEST(GpuBufferPublisherHelperTest, KeepsSlotOnLeaseStart) {
   ASSERT_TRUE(f.has_value());
 
   ros2_cuda_ipc_msgs::msg::GpuBuffer msg;
-  bool ok = helper.finalize_and_fill(
-      *f, /*seq=*/2, /*expected=*/2,
-      /*owner=*/"owner",
-      /*w=*/10, /*h=*/10, /*c=*/1,
-      ros2_cuda_ipc_msgs::msg::GpuBuffer::LAYOUT_LINEAR,
-      ros2_cuda_ipc_msgs::msg::GpuBuffer::FORMAT_BGR8, msg);
+  sample_nodes::GpuBufferPublisherHelper::PublishParams params;
+  params.seq_id = 2;
+  params.expected_consumers = 2;
+  params.shm_owner = "owner";
+  params.width = 10;
+  params.height = 10;
+  params.channels = 1;
+  params.layout = ros2_cuda_ipc_msgs::msg::GpuBuffer::LAYOUT_LINEAR;
+  params.format = ros2_cuda_ipc_msgs::msg::GpuBuffer::FORMAT_BGR8;
+  bool ok = helper.finalize_and_fill(*f, params, msg);
   // Without CUDA mem, plane cannot be populated
   EXPECT_FALSE(ok);
   EXPECT_EQ(msg.plane_count, 0u);


### PR DESCRIPTION
## Summary
- consolidate finalize_and_fill arguments into PublishParams struct
- adjust publisher and tests to use new PublishParams

## Testing
- `colcon build --packages-select ros2_cuda_ipc_core sample_nodes --cmake-args -DBUILD_TESTING=ON` *(fails: command not found)*
- `colcon test --packages-select ros2_cuda_ipc_core sample_nodes` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c6f32e86f48328bcfeeaa95fa237e2