### PR TITLE
Use CUDA stream/event alias types

### DIFF
--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/cuda_support.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/cuda_support.hpp
@@ -18,10 +18,6 @@ struct CudaIpcEventHandle {
   unsigned char reserved[64];
 };
 
-// Aliases for CUDA stream and event handle types.
-using cudaStream_t = ::cudaStream_t;
-using cudaEvent_t = ::cudaEvent_t;
-
 // Returns true if CUDA runtime is available (device count > 0)
 bool cuda_is_available();
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/cuda_support.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/cuda_support.hpp
@@ -1,6 +1,8 @@
 #ifndef ROS2_CUDA_IPC_CORE_CUDA_SUPPORT_HPP_
 #define ROS2_CUDA_IPC_CORE_CUDA_SUPPORT_HPP_
 
+#include <cuda_runtime_api.h>
+
 #include <cstddef>
 #include <string>
 
@@ -16,9 +18,9 @@ struct CudaIpcEventHandle {
   unsigned char reserved[64];
 };
 
-// Opaque CUDA stream and event handle types (avoid including CUDA headers).
-using cudaStream_t = void*;
-using cudaEvent_t = void*;
+// Aliases for CUDA stream and event handle types.
+using cudaStream_t = ::cudaStream_t;
+using cudaEvent_t = ::cudaEvent_t;
 
 // Returns true if CUDA runtime is available (device count > 0)
 bool cuda_is_available();
@@ -64,7 +66,7 @@ bool cuda_event_query(cudaEvent_t evt);
 // Records the event on the specified stream. Returns true on success.
 bool cuda_event_record_on_stream(cudaEvent_t evt, cudaStream_t stream);
 
-// CUDA stream helpers (opaque void* to avoid leaking CUDA headers)
+// CUDA stream helpers
 cudaStream_t cuda_stream_create();
 bool cuda_stream_destroy(cudaStream_t stream);
 // Waits for evt on the given stream. Returns true on success.

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/cuda_support.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/cuda_support.hpp
@@ -16,6 +16,10 @@ struct CudaIpcEventHandle {
   unsigned char reserved[64];
 };
 
+// Opaque CUDA stream and event handle types (avoid including CUDA headers).
+using cudaStream_t = void*;
+using cudaEvent_t = void*;
+
 // Returns true if CUDA runtime is available (device count > 0)
 bool cuda_is_available();
 
@@ -39,35 +43,35 @@ bool cuda_ipc_close_mem_handle(void* device_ptr);
 
 // Creates a CUDA interprocess-capable event. Returns opaque handle or nullptr
 // on failure.
-void* cuda_event_create();
+cudaEvent_t cuda_event_create();
 
 // Destroys a CUDA event previously created or opened. Returns true on success.
-bool cuda_event_destroy(void* evt);
+bool cuda_event_destroy(cudaEvent_t evt);
 
 // Records the event on the default stream (0). Returns true on success.
-bool cuda_event_record(void* evt);
+bool cuda_event_record(cudaEvent_t evt);
 
 // Exports an IPC event handle for a given event. Returns true on success.
-bool cuda_event_get_ipc_handle(void* evt, CudaIpcEventHandle* out_handle);
+bool cuda_event_get_ipc_handle(cudaEvent_t evt, CudaIpcEventHandle* out_handle);
 
 // Opens an IPC event handle in the current process. Returns event or nullptr on
 // failure.
-void* cuda_ipc_open_event_handle(const CudaIpcEventHandle& handle);
+cudaEvent_t cuda_ipc_open_event_handle(const CudaIpcEventHandle& handle);
 
 // Queries event status. Returns true if event has completed (or if
 // unsupported), false if not ready.
-bool cuda_event_query(void* evt);
+bool cuda_event_query(cudaEvent_t evt);
 // Records the event on the specified stream. Returns true on success.
-bool cuda_event_record_on_stream(void* evt, void* stream);
+bool cuda_event_record_on_stream(cudaEvent_t evt, cudaStream_t stream);
 
 // CUDA stream helpers (opaque void* to avoid leaking CUDA headers)
-void* cuda_stream_create();
-bool cuda_stream_destroy(void* stream);
+cudaStream_t cuda_stream_create();
+bool cuda_stream_destroy(cudaStream_t stream);
 // Waits for evt on the given stream. Returns true on success.
-bool cuda_stream_wait_event(void* stream, void* evt);
+bool cuda_stream_wait_event(cudaStream_t stream, cudaEvent_t evt);
 // Optional: synchronize stream (blocks until complete). Returns true on
 // success.
-bool cuda_stream_synchronize(void* stream);
+bool cuda_stream_synchronize(cudaStream_t stream);
 
 // Returns a stable device identifier string for the current device.
 // Prefer UUID when available; otherwise falls back to PCI bus id.

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_mapper.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_mapper.hpp
@@ -22,15 +22,16 @@ class GpuBufferMapper {
 
   // Opens and caches an event for a given slot. Returns event pointer, or
   // nullptr on failure.
-  void* open_event(uint32_t slot_id, const CudaIpcEventHandle& evt_handle);
+  cudaEvent_t open_event(uint32_t slot_id,
+                         const CudaIpcEventHandle& evt_handle);
 
   // Returns cached pointers (nullptr if none).
   void* get_memory(uint32_t slot_id) const;
-  void* get_event(uint32_t slot_id) const;
+  cudaEvent_t get_event(uint32_t slot_id) const;
 
   // Waits on cached event for slot on the provided stream. Returns false if
   // event not cached or wait fails.
-  bool wait_ready(uint32_t slot_id, void* stream) const;
+  bool wait_ready(uint32_t slot_id, cudaStream_t stream) const;
 
   // Closes and removes cached resources for a slot.
   void close_slot(uint32_t slot_id);
@@ -41,7 +42,7 @@ class GpuBufferMapper {
  private:
   struct Entry {
     void* mem{nullptr};
-    void* evt{nullptr};
+    cudaEvent_t evt{nullptr};
   };
 
   mutable std::mutex mutex_;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_pool.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_pool.hpp
@@ -14,7 +14,8 @@ struct PoolOptions {
   std::size_t pool_size = 16;
   std::size_t bytes_per_slot = 0;  // 0 means no device allocation
   bool events_enabled = true;  // create interprocess-capable events per slot
-  void* producer_stream = nullptr;  // optional: record events on this stream
+  cudaStream_t producer_stream =
+      nullptr;  // optional: record events on this stream
 };
 
 struct Slot {
@@ -41,7 +42,7 @@ class GpuBufferPool {
   // Records the slot's ready event (default stream). Returns true on success.
   bool record_ready(std::size_t id);
   // Records the slot's ready event on the provided stream.
-  bool record_ready_on_stream(std::size_t id, void* stream);
+  bool record_ready_on_stream(std::size_t id, cudaStream_t stream);
 
   // Exports CUDA IPC handle for a slot's ready event.
   bool ipc_event_handle(std::size_t id, CudaIpcEventHandle& out_handle) const;
@@ -49,10 +50,10 @@ class GpuBufferPool {
  private:
   std::vector<Slot> slots_;
   std::vector<void*> device_ptrs_;
-  std::vector<void*> events_;
+  std::vector<cudaEvent_t> events_;
   std::size_t bytes_per_slot_{0};
   bool events_enabled_{false};
-  void* producer_stream_{nullptr};
+  cudaStream_t producer_stream_{nullptr};
   std::mutex mutex_;
 };
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/scoped_mapped_frame.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/scoped_mapped_frame.hpp
@@ -19,7 +19,7 @@ class ScopedMappedFrame {
  public:
   ScopedMappedFrame(GpuBufferMapper& mapper, uint32_t slot_id,
                     const CudaIpcMemHandle* mem_handle,
-                    const CudaIpcEventHandle* evt_handle, void* stream,
+                    const CudaIpcEventHandle* evt_handle, cudaStream_t stream,
                     std::string shm_name, uint64_t seq,
                     bool sync_on_dtor = true);
 
@@ -32,12 +32,12 @@ class ScopedMappedFrame {
  private:
   GpuBufferMapper& mapper_;
   uint32_t slot_;
-  void* stream_;
+  cudaStream_t stream_;
   std::string shm_name_;
   uint64_t seq_;
   bool sync_on_dtor_;
   void* mem_ptr_{nullptr};
-  void* evt_ptr_{nullptr};
+  cudaEvent_t evt_ptr_{nullptr};
 };
 
 }  // namespace ros2_cuda_ipc_core

--- a/ros2_cuda_ipc_core/src/cuda_support.cu
+++ b/ros2_cuda_ipc_core/src/cuda_support.cu
@@ -68,86 +68,88 @@ bool cuda_ipc_close_mem_handle(void* device_ptr) {
   return true;
 }
 
-void* cuda_event_create() {
-  cudaEvent_t evt = nullptr;
+cudaEvent_t cuda_event_create() {
+  ::cudaEvent_t evt = nullptr;
   check_cuda_error(cudaEventCreateWithFlags(
       &evt, cudaEventDisableTiming | cudaEventInterprocess));
-  return reinterpret_cast<void*>(evt);
+  return reinterpret_cast<cudaEvent_t>(evt);
 }
 
-bool cuda_event_destroy(void* evt) {
+bool cuda_event_destroy(cudaEvent_t evt) {
   if (!evt) return false;
-  check_cuda_error(cudaEventDestroy(reinterpret_cast<cudaEvent_t>(evt)));
+  check_cuda_error(cudaEventDestroy(reinterpret_cast<::cudaEvent_t>(evt)));
   return true;
 }
 
-bool cuda_event_record(void* evt) {
+bool cuda_event_record(cudaEvent_t evt) {
   if (!evt) return false;
   check_cuda_error(
-      cudaEventRecord(reinterpret_cast<cudaEvent_t>(evt), /*stream=*/0));
+      cudaEventRecord(reinterpret_cast<::cudaEvent_t>(evt), /*stream=*/0));
   return true;
 }
 
-bool cuda_event_get_ipc_handle(void* evt, CudaIpcEventHandle* out_handle) {
+bool cuda_event_get_ipc_handle(cudaEvent_t evt,
+                               CudaIpcEventHandle* out_handle) {
   if (!evt || !out_handle) return false;
   cudaIpcEventHandle_t h{};
   check_cuda_error(
-      cudaIpcGetEventHandle(&h, reinterpret_cast<cudaEvent_t>(evt)));
+      cudaIpcGetEventHandle(&h, reinterpret_cast<::cudaEvent_t>(evt)));
   static_assert(sizeof(CudaIpcEventHandle) == sizeof(cudaIpcEventHandle_t),
                 "IPC event handle size mismatch");
   std::memcpy(out_handle, &h, sizeof(h));
   return true;
 }
 
-void* cuda_ipc_open_event_handle(const CudaIpcEventHandle& handle) {
+cudaEvent_t cuda_ipc_open_event_handle(const CudaIpcEventHandle& handle) {
   cudaIpcEventHandle_t h{};
   static_assert(sizeof(CudaIpcEventHandle) == sizeof(cudaIpcEventHandle_t),
                 "IPC event handle size mismatch");
   std::memcpy(&h, &handle, sizeof(h));
-  cudaEvent_t evt = nullptr;
+  ::cudaEvent_t evt = nullptr;
   check_cuda_error(cudaIpcOpenEventHandle(&evt, h));
-  return reinterpret_cast<void*>(evt);
+  return reinterpret_cast<cudaEvent_t>(evt);
 }
 
-bool cuda_event_query(void* evt) {
+bool cuda_event_query(cudaEvent_t evt) {
   if (!evt) return false;
-  auto err = cudaEventQuery(reinterpret_cast<cudaEvent_t>(evt));
+  auto err = cudaEventQuery(reinterpret_cast<::cudaEvent_t>(evt));
   if (err == cudaSuccess) return true;
   if (err == cudaErrorNotReady) return false;
   return false;
 }
 
-bool cuda_event_record_on_stream(void* evt, void* stream) {
+bool cuda_event_record_on_stream(cudaEvent_t evt, cudaStream_t stream) {
   if (!evt) return false;
-  auto s = stream ? reinterpret_cast<cudaStream_t>(stream)
-                  : static_cast<cudaStream_t>(0);
-  check_cuda_error(cudaEventRecord(reinterpret_cast<cudaEvent_t>(evt), s));
+  auto s = stream ? reinterpret_cast<::cudaStream_t>(stream)
+                  : static_cast<::cudaStream_t>(0);
+  check_cuda_error(cudaEventRecord(reinterpret_cast<::cudaEvent_t>(evt), s));
   return true;
 }
 
-void* cuda_stream_create() {
-  cudaStream_t s = nullptr;
+cudaStream_t cuda_stream_create() {
+  ::cudaStream_t s = nullptr;
   check_cuda_error(cudaStreamCreateWithFlags(&s, cudaStreamNonBlocking));
-  return reinterpret_cast<void*>(s);
+  return reinterpret_cast<cudaStream_t>(s);
 }
 
-bool cuda_stream_destroy(void* stream) {
+bool cuda_stream_destroy(cudaStream_t stream) {
   if (!stream) return false;
-  check_cuda_error(cudaStreamDestroy(reinterpret_cast<cudaStream_t>(stream)));
+  check_cuda_error(cudaStreamDestroy(reinterpret_cast<::cudaStream_t>(stream)));
   return true;
 }
 
-bool cuda_stream_wait_event(void* stream, void* evt) {
+bool cuda_stream_wait_event(cudaStream_t stream, cudaEvent_t evt) {
   if (!stream || !evt) return false;
-  check_cuda_error(cudaStreamWaitEvent(reinterpret_cast<cudaStream_t>(stream),
-                                       reinterpret_cast<cudaEvent_t>(evt), 0));
+  check_cuda_error(cudaStreamWaitEvent(reinterpret_cast<::cudaStream_t>(stream),
+                                       reinterpret_cast<::cudaEvent_t>(evt),
+                                       0));
   return true;
 }
 
-bool cuda_stream_synchronize(void* stream) {
+bool cuda_stream_synchronize(cudaStream_t stream) {
   if (!stream) return false;
   check_cuda_error(
-      cudaStreamSynchronize(reinterpret_cast<cudaStream_t>(stream)));
+      cudaStreamSynchronize(reinterpret_cast<::cudaStream_t>(stream)));
   return true;
 }
 

--- a/ros2_cuda_ipc_core/src/cuda_support.cu
+++ b/ros2_cuda_ipc_core/src/cuda_support.cu
@@ -1,4 +1,4 @@
-#include <cuda_runtime.h>
+#include <cuda_runtime_api.h>
 
 #include <cstdio>
 #include <cstring>
@@ -69,22 +69,21 @@ bool cuda_ipc_close_mem_handle(void* device_ptr) {
 }
 
 cudaEvent_t cuda_event_create() {
-  ::cudaEvent_t evt = nullptr;
+  cudaEvent_t evt = nullptr;
   check_cuda_error(cudaEventCreateWithFlags(
       &evt, cudaEventDisableTiming | cudaEventInterprocess));
-  return reinterpret_cast<cudaEvent_t>(evt);
+  return evt;
 }
 
 bool cuda_event_destroy(cudaEvent_t evt) {
   if (!evt) return false;
-  check_cuda_error(cudaEventDestroy(reinterpret_cast<::cudaEvent_t>(evt)));
+  check_cuda_error(cudaEventDestroy(evt));
   return true;
 }
 
 bool cuda_event_record(cudaEvent_t evt) {
   if (!evt) return false;
-  check_cuda_error(
-      cudaEventRecord(reinterpret_cast<::cudaEvent_t>(evt), /*stream=*/0));
+  check_cuda_error(cudaEventRecord(evt, /*stream=*/0));
   return true;
 }
 
@@ -92,8 +91,7 @@ bool cuda_event_get_ipc_handle(cudaEvent_t evt,
                                CudaIpcEventHandle* out_handle) {
   if (!evt || !out_handle) return false;
   cudaIpcEventHandle_t h{};
-  check_cuda_error(
-      cudaIpcGetEventHandle(&h, reinterpret_cast<::cudaEvent_t>(evt)));
+  check_cuda_error(cudaIpcGetEventHandle(&h, evt));
   static_assert(sizeof(CudaIpcEventHandle) == sizeof(cudaIpcEventHandle_t),
                 "IPC event handle size mismatch");
   std::memcpy(out_handle, &h, sizeof(h));
@@ -105,14 +103,14 @@ cudaEvent_t cuda_ipc_open_event_handle(const CudaIpcEventHandle& handle) {
   static_assert(sizeof(CudaIpcEventHandle) == sizeof(cudaIpcEventHandle_t),
                 "IPC event handle size mismatch");
   std::memcpy(&h, &handle, sizeof(h));
-  ::cudaEvent_t evt = nullptr;
+  cudaEvent_t evt = nullptr;
   check_cuda_error(cudaIpcOpenEventHandle(&evt, h));
-  return reinterpret_cast<cudaEvent_t>(evt);
+  return evt;
 }
 
 bool cuda_event_query(cudaEvent_t evt) {
   if (!evt) return false;
-  auto err = cudaEventQuery(reinterpret_cast<::cudaEvent_t>(evt));
+  auto err = cudaEventQuery(evt);
   if (err == cudaSuccess) return true;
   if (err == cudaErrorNotReady) return false;
   return false;
@@ -120,36 +118,31 @@ bool cuda_event_query(cudaEvent_t evt) {
 
 bool cuda_event_record_on_stream(cudaEvent_t evt, cudaStream_t stream) {
   if (!evt) return false;
-  auto s = stream ? reinterpret_cast<::cudaStream_t>(stream)
-                  : static_cast<::cudaStream_t>(0);
-  check_cuda_error(cudaEventRecord(reinterpret_cast<::cudaEvent_t>(evt), s));
+  check_cuda_error(cudaEventRecord(evt, stream ? stream : 0));
   return true;
 }
 
 cudaStream_t cuda_stream_create() {
-  ::cudaStream_t s = nullptr;
+  cudaStream_t s = nullptr;
   check_cuda_error(cudaStreamCreateWithFlags(&s, cudaStreamNonBlocking));
-  return reinterpret_cast<cudaStream_t>(s);
+  return s;
 }
 
 bool cuda_stream_destroy(cudaStream_t stream) {
   if (!stream) return false;
-  check_cuda_error(cudaStreamDestroy(reinterpret_cast<::cudaStream_t>(stream)));
+  check_cuda_error(cudaStreamDestroy(stream));
   return true;
 }
 
 bool cuda_stream_wait_event(cudaStream_t stream, cudaEvent_t evt) {
   if (!stream || !evt) return false;
-  check_cuda_error(cudaStreamWaitEvent(reinterpret_cast<::cudaStream_t>(stream),
-                                       reinterpret_cast<::cudaEvent_t>(evt),
-                                       0));
+  check_cuda_error(cudaStreamWaitEvent(stream, evt, 0));
   return true;
 }
 
 bool cuda_stream_synchronize(cudaStream_t stream) {
   if (!stream) return false;
-  check_cuda_error(
-      cudaStreamSynchronize(reinterpret_cast<::cudaStream_t>(stream)));
+  check_cuda_error(cudaStreamSynchronize(stream));
   return true;
 }
 

--- a/ros2_cuda_ipc_core/src/gpu_buffer_mapper.cpp
+++ b/ros2_cuda_ipc_core/src/gpu_buffer_mapper.cpp
@@ -20,8 +20,8 @@ void* GpuBufferMapper::open_memory(uint32_t slot_id,
   return e.mem;
 }
 
-void* GpuBufferMapper::open_event(uint32_t slot_id,
-                                  const CudaIpcEventHandle& evt_handle) {
+cudaEvent_t GpuBufferMapper::open_event(uint32_t slot_id,
+                                        const CudaIpcEventHandle& evt_handle) {
   std::lock_guard<std::mutex> lock(mutex_);
   auto& e = cache_[slot_id];
   if (!e.evt) {
@@ -41,18 +41,18 @@ void* GpuBufferMapper::get_memory(uint32_t slot_id) const {
   return it->second.mem;
 }
 
-void* GpuBufferMapper::get_event(uint32_t slot_id) const {
+cudaEvent_t GpuBufferMapper::get_event(uint32_t slot_id) const {
   std::lock_guard<std::mutex> lock(mutex_);
   auto it = cache_.find(slot_id);
   if (it == cache_.end()) return nullptr;
   return it->second.evt;
 }
 
-bool GpuBufferMapper::wait_ready(uint32_t slot_id, void* stream) const {
+bool GpuBufferMapper::wait_ready(uint32_t slot_id, cudaStream_t stream) const {
   std::lock_guard<std::mutex> lock(mutex_);
   auto it = cache_.find(slot_id);
   if (it == cache_.end()) return false;
-  void* evt = it->second.evt;
+  cudaEvent_t evt = it->second.evt;
   if (!evt) return false;
   return cuda_stream_wait_event(stream, evt);
 }

--- a/ros2_cuda_ipc_core/src/gpu_buffer_pool.cpp
+++ b/ros2_cuda_ipc_core/src/gpu_buffer_pool.cpp
@@ -32,7 +32,7 @@ GpuBufferPool::GpuBufferPool(const PoolOptions& opts)
 
   if (ok && opts.events_enabled) {
     for (std::size_t i = 0; i < opts.pool_size; ++i) {
-      void* e = cuda_event_create();
+      cudaEvent_t e = cuda_event_create();
       if (!e) {
         ok = false;
         break;
@@ -42,7 +42,7 @@ GpuBufferPool::GpuBufferPool(const PoolOptions& opts)
   }
 
   if (!ok) {
-    for (void* e : events_) {
+    for (cudaEvent_t e : events_) {
       if (e) cuda_event_destroy(e);
     }
     for (void* p : device_ptrs_) {
@@ -57,7 +57,7 @@ GpuBufferPool::GpuBufferPool(const PoolOptions& opts)
 }
 
 GpuBufferPool::~GpuBufferPool() {
-  for (void* e : events_) {
+  for (cudaEvent_t e : events_) {
     if (e) cuda_event_destroy(e);
   }
   for (void* p : device_ptrs_) {
@@ -101,7 +101,7 @@ bool GpuBufferPool::ipc_handle(std::size_t id,
 bool GpuBufferPool::record_ready(std::size_t id) {
   if (!events_enabled_) return false;
   if (id >= events_.size()) return false;
-  void* evt = events_[id];
+  cudaEvent_t evt = events_[id];
   if (!evt) return false;
   if (producer_stream_) {
     return cuda_event_record_on_stream(evt, producer_stream_);
@@ -113,15 +113,16 @@ bool GpuBufferPool::ipc_event_handle(std::size_t id,
                                      CudaIpcEventHandle& out_handle) const {
   if (!events_enabled_) return false;
   if (id >= events_.size()) return false;
-  void* evt = events_[id];
+  cudaEvent_t evt = events_[id];
   if (!evt) return false;
   return cuda_event_get_ipc_handle(evt, &out_handle);
 }
 
-bool GpuBufferPool::record_ready_on_stream(std::size_t id, void* stream) {
+bool GpuBufferPool::record_ready_on_stream(std::size_t id,
+                                           cudaStream_t stream) {
   if (!events_enabled_) return false;
   if (id >= events_.size()) return false;
-  void* evt = events_[id];
+  cudaEvent_t evt = events_[id];
   if (!evt) return false;
   return cuda_event_record_on_stream(evt, stream);
 }

--- a/ros2_cuda_ipc_core/src/scoped_mapped_frame.cpp
+++ b/ros2_cuda_ipc_core/src/scoped_mapped_frame.cpp
@@ -5,7 +5,7 @@ namespace ros2_cuda_ipc_core {
 ScopedMappedFrame::ScopedMappedFrame(GpuBufferMapper& mapper, uint32_t slot_id,
                                      const CudaIpcMemHandle* mem_handle,
                                      const CudaIpcEventHandle* evt_handle,
-                                     void* stream, std::string shm_name,
+                                     cudaStream_t stream, std::string shm_name,
                                      uint64_t seq, bool sync_on_dtor)
     : mapper_(mapper),
       slot_(slot_id),

--- a/ros2_cuda_ipc_core/test/test_cuda_support.cpp
+++ b/ros2_cuda_ipc_core/test/test_cuda_support.cpp
@@ -30,8 +30,7 @@ TEST(CudaSupport, NullArgumentValidation) {
 
   CudaIpcEventHandle evt{};
   EXPECT_FALSE(cuda_event_get_ipc_handle(nullptr, &evt));
-  EXPECT_FALSE(
-      cuda_event_get_ipc_handle(reinterpret_cast<void*>(0x1), nullptr));
+  EXPECT_FALSE(cuda_event_get_ipc_handle(cudaEvent_t{}, nullptr));
   EXPECT_FALSE(cuda_event_query(nullptr));
   EXPECT_FALSE(cuda_event_record_on_stream(nullptr, nullptr));
 

--- a/ros2_cuda_ipc_core/test/test_cuda_support.cpp
+++ b/ros2_cuda_ipc_core/test/test_cuda_support.cpp
@@ -59,11 +59,11 @@ TEST(CudaSupport, EventAndStreamBasic) {
     GTEST_SKIP() << "CUDA device not available";
   }
 
-  void* evt = nullptr;
+  cudaEvent_t evt = nullptr;
   ASSERT_NO_THROW({ evt = cuda_event_create(); });
   ASSERT_NE(evt, nullptr);
 
-  void* stream = nullptr;
+  cudaStream_t stream = nullptr;
   ASSERT_NO_THROW({ stream = cuda_stream_create(); });
   ASSERT_NE(stream, nullptr);
 

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_mapper.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_mapper.cpp
@@ -11,7 +11,7 @@ TEST(GpuBufferMapperTest, EventOpenCacheAndWait) {
   }
 
   // Create an interprocess-capable event in this process (exporter side)
-  void* exporter_evt = cuda_event_create();
+  cudaEvent_t exporter_evt = cuda_event_create();
   ASSERT_NE(exporter_evt, nullptr);
 
   CudaIpcEventHandle evt_handle{};
@@ -21,19 +21,19 @@ TEST(GpuBufferMapperTest, EventOpenCacheAndWait) {
   const uint32_t slot_id = 3;
 
   // Open the event via IPC (consumer side) and check caching behavior
-  void* opened_evt_1 = mapper.open_event(slot_id, evt_handle);
+  cudaEvent_t opened_evt_1 = mapper.open_event(slot_id, evt_handle);
   if (opened_evt_1 == nullptr) {
     // Some driver/runtime combinations may not permit opening our own IPC
     // event handle within the same process. Treat as an environment skip.
     GTEST_SKIP() << "cudaIpcOpenEventHandle returned nullptr in-process";
   }
 
-  void* opened_evt_2 = mapper.open_event(slot_id, evt_handle);
+  cudaEvent_t opened_evt_2 = mapper.open_event(slot_id, evt_handle);
   EXPECT_EQ(opened_evt_1, opened_evt_2) << "Mapper should cache event per slot";
 
   // Create a stream and wait on the opened event. First record the exporter
   // event so the wait can complete successfully.
-  void* stream = cuda_stream_create();
+  cudaStream_t stream = cuda_stream_create();
   ASSERT_NE(stream, nullptr);
 
   ASSERT_TRUE(cuda_event_record(exporter_evt));

--- a/sample_nodes/CMakeLists.txt
+++ b/sample_nodes/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(sample_nodes_helpers STATIC src/gpu_buffer_publisher_helper.cpp)
 target_include_directories(sample_nodes_helpers PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 ament_target_dependencies(sample_nodes_helpers ros2_cuda_ipc_core ros2_cuda_ipc_msgs)
 
-# 
+# Setup CUDA library for GPU utilities
 set(SAMPLE_CUDA_LIB sample_cuda_utils)
 enable_language(CUDA)
 set(CMAKE_CUDA_STANDARD 14)

--- a/sample_nodes/CMakeLists.txt
+++ b/sample_nodes/CMakeLists.txt
@@ -12,21 +12,16 @@ add_library(sample_nodes_helpers STATIC src/gpu_buffer_publisher_helper.cpp)
 target_include_directories(sample_nodes_helpers PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 ament_target_dependencies(sample_nodes_helpers ros2_cuda_ipc_core ros2_cuda_ipc_msgs)
 
-# Optional CUDA support for demo GPU work in samples
+# 
 set(SAMPLE_CUDA_LIB sample_cuda_utils)
 enable_language(CUDA)
 set(CMAKE_CUDA_STANDARD 14)
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 add_library(${SAMPLE_CUDA_LIB} STATIC src/sample_cuda_utils.cu)
-find_package(CUDAToolkit QUIET)
-if(CUDAToolkit_FOUND AND TARGET CUDA::cudart)
-  target_link_libraries(${SAMPLE_CUDA_LIB} CUDA::cudart)
-endif()
+ament_target_dependencies(${SAMPLE_CUDA_LIB} ros2_cuda_ipc_core)
 
-if(TARGET gpu_buffer_publisher)
-  target_link_libraries(gpu_buffer_publisher ${SAMPLE_CUDA_LIB} sample_nodes_helpers)
-  target_include_directories(gpu_buffer_publisher PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
-endif()
+target_link_libraries(gpu_buffer_publisher ${SAMPLE_CUDA_LIB} sample_nodes_helpers)
+target_include_directories(gpu_buffer_publisher PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 ament_auto_package()
 

--- a/sample_nodes/CMakeLists.txt
+++ b/sample_nodes/CMakeLists.txt
@@ -20,8 +20,10 @@ set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 add_library(${SAMPLE_CUDA_LIB} STATIC src/sample_cuda_utils.cu)
 ament_target_dependencies(${SAMPLE_CUDA_LIB} ros2_cuda_ipc_core)
 
-target_link_libraries(gpu_buffer_publisher ${SAMPLE_CUDA_LIB} sample_nodes_helpers)
-target_include_directories(gpu_buffer_publisher PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+if(TARGET gpu_buffer_publisher)
+  target_link_libraries(gpu_buffer_publisher ${SAMPLE_CUDA_LIB} sample_nodes_helpers)
+  target_include_directories(gpu_buffer_publisher PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+endif()
 
 ament_auto_package()
 

--- a/sample_nodes/include/sample_nodes/gpu_buffer_publisher_helper.hpp
+++ b/sample_nodes/include/sample_nodes/gpu_buffer_publisher_helper.hpp
@@ -25,7 +25,7 @@ class GpuBufferPublisherHelper {
 
   GpuBufferPublisherHelper(ros2_cuda_ipc_core::GpuBufferPool& pool,
                            ros2_cuda_ipc_core::LeaseManager* lease_mgr,
-                           void* producer_stream);
+                           ros2_cuda_ipc_core::cudaStream_t producer_stream);
 
   // Attempts to borrow a slot and returns basic info for filling GPU memory.
   std::optional<Frame> borrow_frame(uint32_t width, uint32_t height,
@@ -42,7 +42,7 @@ class GpuBufferPublisherHelper {
  private:
   ros2_cuda_ipc_core::GpuBufferPool& pool_;
   ros2_cuda_ipc_core::LeaseManager* lease_mgr_{nullptr};
-  void* stream_{nullptr};
+  ros2_cuda_ipc_core::cudaStream_t stream_{nullptr};
 };
 
 }  // namespace sample_nodes

--- a/sample_nodes/include/sample_nodes/gpu_buffer_publisher_helper.hpp
+++ b/sample_nodes/include/sample_nodes/gpu_buffer_publisher_helper.hpp
@@ -25,7 +25,7 @@ class GpuBufferPublisherHelper {
 
   GpuBufferPublisherHelper(ros2_cuda_ipc_core::GpuBufferPool& pool,
                            ros2_cuda_ipc_core::LeaseManager* lease_mgr,
-                           ros2_cuda_ipc_core::cudaStream_t producer_stream);
+                           cudaStream_t producer_stream);
 
   // Attempts to borrow a slot and returns basic info for filling GPU memory.
   std::optional<Frame> borrow_frame(uint32_t width, uint32_t height,
@@ -42,7 +42,7 @@ class GpuBufferPublisherHelper {
  private:
   ros2_cuda_ipc_core::GpuBufferPool& pool_;
   ros2_cuda_ipc_core::LeaseManager* lease_mgr_{nullptr};
-  ros2_cuda_ipc_core::cudaStream_t stream_{nullptr};
+  cudaStream_t stream_{nullptr};
 };
 
 }  // namespace sample_nodes

--- a/sample_nodes/include/sample_nodes/sample_cuda_utils.hpp
+++ b/sample_nodes/include/sample_nodes/sample_cuda_utils.hpp
@@ -4,6 +4,8 @@
 
 #include <cstddef>
 
+#include "ros2_cuda_ipc_core/cuda_support.hpp"
+
 namespace sample_nodes {
 
 // Fill a device buffer with a byte pattern asynchronously on a stream.
@@ -13,7 +15,7 @@ namespace sample_nodes {
 // - stream: CUDA stream handle (nullptr for default stream)
 // Returns true on success.
 bool cuda_fill_u8(void* device_ptr, unsigned char value, std::size_t size_bytes,
-                  void* stream);
+                  ros2_cuda_ipc_core::cudaStream_t stream);
 
 }  // namespace sample_nodes
 

--- a/sample_nodes/include/sample_nodes/sample_cuda_utils.hpp
+++ b/sample_nodes/include/sample_nodes/sample_cuda_utils.hpp
@@ -15,7 +15,7 @@ namespace sample_nodes {
 // - stream: CUDA stream handle (nullptr for default stream)
 // Returns true on success.
 bool cuda_fill_u8(void* device_ptr, unsigned char value, std::size_t size_bytes,
-                  ros2_cuda_ipc_core::cudaStream_t stream);
+                  cudaStream_t stream);
 
 }  // namespace sample_nodes
 

--- a/sample_nodes/src/gpu_buffer_publisher.cpp
+++ b/sample_nodes/src/gpu_buffer_publisher.cpp
@@ -134,7 +134,7 @@ class DummyPublisher : public rclcpp::Node {
   int lease_timeout_ms_{3000};
   int expected_consumers_{-1};
   uint64_t count_{0};
-  ros2_cuda_ipc_core::cudaStream_t producer_stream_{nullptr};
+  cudaStream_t producer_stream_{nullptr};
   std::string shm_owner_;
 };
 

--- a/sample_nodes/src/gpu_buffer_publisher.cpp
+++ b/sample_nodes/src/gpu_buffer_publisher.cpp
@@ -134,7 +134,7 @@ class DummyPublisher : public rclcpp::Node {
   int lease_timeout_ms_{3000};
   int expected_consumers_{-1};
   uint64_t count_{0};
-  void* producer_stream_{nullptr};
+  ros2_cuda_ipc_core::cudaStream_t producer_stream_{nullptr};
   std::string shm_owner_;
 };
 

--- a/sample_nodes/src/gpu_buffer_publisher_helper.cpp
+++ b/sample_nodes/src/gpu_buffer_publisher_helper.cpp
@@ -12,8 +12,7 @@ namespace sample_nodes {
 
 GpuBufferPublisherHelper::GpuBufferPublisherHelper(
     ros2_cuda_ipc_core::GpuBufferPool& pool,
-    ros2_cuda_ipc_core::LeaseManager* lease_mgr,
-    ros2_cuda_ipc_core::cudaStream_t producer_stream)
+    ros2_cuda_ipc_core::LeaseManager* lease_mgr, cudaStream_t producer_stream)
     : pool_(pool), lease_mgr_(lease_mgr), stream_(producer_stream) {}
 
 std::optional<GpuBufferPublisherHelper::Frame>

--- a/sample_nodes/src/gpu_buffer_publisher_helper.cpp
+++ b/sample_nodes/src/gpu_buffer_publisher_helper.cpp
@@ -12,7 +12,8 @@ namespace sample_nodes {
 
 GpuBufferPublisherHelper::GpuBufferPublisherHelper(
     ros2_cuda_ipc_core::GpuBufferPool& pool,
-    ros2_cuda_ipc_core::LeaseManager* lease_mgr, void* producer_stream)
+    ros2_cuda_ipc_core::LeaseManager* lease_mgr,
+    ros2_cuda_ipc_core::cudaStream_t producer_stream)
     : pool_(pool), lease_mgr_(lease_mgr), stream_(producer_stream) {}
 
 std::optional<GpuBufferPublisherHelper::Frame>

--- a/sample_nodes/src/gpu_buffer_subscriber.cpp
+++ b/sample_nodes/src/gpu_buffer_subscriber.cpp
@@ -65,7 +65,7 @@ class DummySubscriber : public rclcpp::Node {
 
  private:
   rclcpp::Subscription<ros2_cuda_ipc_msgs::msg::GpuBuffer>::SharedPtr sub_;
-  void* stream_{nullptr};
+  ros2_cuda_ipc_core::cudaStream_t stream_{nullptr};
   ros2_cuda_ipc_core::GpuBufferMapper mapper_;
   uint32_t prev_abi_version_{0};
   std::string prev_device_id_;

--- a/sample_nodes/src/gpu_buffer_subscriber.cpp
+++ b/sample_nodes/src/gpu_buffer_subscriber.cpp
@@ -65,7 +65,7 @@ class DummySubscriber : public rclcpp::Node {
 
  private:
   rclcpp::Subscription<ros2_cuda_ipc_msgs::msg::GpuBuffer>::SharedPtr sub_;
-  ros2_cuda_ipc_core::cudaStream_t stream_{nullptr};
+  cudaStream_t stream_{nullptr};
   ros2_cuda_ipc_core::GpuBufferMapper mapper_;
   uint32_t prev_abi_version_{0};
   std::string prev_device_id_;

--- a/sample_nodes/src/sample_cuda_utils.cu
+++ b/sample_nodes/src/sample_cuda_utils.cu
@@ -5,7 +5,7 @@
 namespace sample_nodes {
 
 bool cuda_fill_u8(void* device_ptr, unsigned char value, std::size_t size_bytes,
-                  ros2_cuda_ipc_core::cudaStream_t stream) {
+                  cudaStream_t stream) {
   if (!device_ptr || size_bytes == 0) return false;
   auto err =
       cudaMemsetAsync(device_ptr, static_cast<int>(value), size_bytes, stream);

--- a/sample_nodes/src/sample_cuda_utils.cu
+++ b/sample_nodes/src/sample_cuda_utils.cu
@@ -1,4 +1,4 @@
-#include <cuda_runtime.h>
+#include <cuda_runtime_api.h>
 
 #include "ros2_cuda_ipc_core/cuda_support.hpp"
 
@@ -7,10 +7,8 @@ namespace sample_nodes {
 bool cuda_fill_u8(void* device_ptr, unsigned char value, std::size_t size_bytes,
                   ros2_cuda_ipc_core::cudaStream_t stream) {
   if (!device_ptr || size_bytes == 0) return false;
-  ::cudaStream_t s = stream ? reinterpret_cast<::cudaStream_t>(stream)
-                            : static_cast<::cudaStream_t>(0);
   auto err =
-      cudaMemsetAsync(device_ptr, static_cast<int>(value), size_bytes, s);
+      cudaMemsetAsync(device_ptr, static_cast<int>(value), size_bytes, stream);
   if (err != cudaSuccess) return false;
   return true;
 }

--- a/sample_nodes/src/sample_cuda_utils.cu
+++ b/sample_nodes/src/sample_cuda_utils.cu
@@ -1,12 +1,14 @@
 #include <cuda_runtime.h>
 
+#include "ros2_cuda_ipc_core/cuda_support.hpp"
+
 namespace sample_nodes {
 
 bool cuda_fill_u8(void* device_ptr, unsigned char value, std::size_t size_bytes,
-                  void* stream) {
+                  ros2_cuda_ipc_core::cudaStream_t stream) {
   if (!device_ptr || size_bytes == 0) return false;
-  cudaStream_t s = stream ? reinterpret_cast<cudaStream_t>(stream)
-                          : static_cast<cudaStream_t>(0);
+  ::cudaStream_t s = stream ? reinterpret_cast<::cudaStream_t>(stream)
+                            : static_cast<::cudaStream_t>(0);
   auto err =
       cudaMemsetAsync(device_ptr, static_cast<int>(value), size_bytes, s);
   if (err != cudaSuccess) return false;


### PR DESCRIPTION
## Summary
- replace raw `void*` stream and event handles with `cudaStream_t`/`cudaEvent_t` aliases
- update GPU buffer utilities and sample nodes to use typed CUDA handles

## Testing
- `pre-commit run --files ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/cuda_support.hpp ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_mapper.hpp ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_pool.hpp ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/scoped_mapped_frame.hpp ros2_cuda_ipc_core/src/cuda_support.cu ros2_cuda_ipc_core/src/gpu_buffer_mapper.cpp ros2_cuda_ipc_core/src/gpu_buffer_pool.cpp ros2_cuda_ipc_core/src/scoped_mapped_frame.cpp ros2_cuda_ipc_core/test/test_cuda_support.cpp ros2_cuda_ipc_core/test/test_gpu_buffer_mapper.cpp sample_nodes/include/sample_nodes/gpu_buffer_publisher_helper.hpp sample_nodes/include/sample_nodes/sample_cuda_utils.hpp sample_nodes/src/gpu_buffer_publisher.cpp sample_nodes/src/gpu_buffer_publisher_helper.cpp sample_nodes/src/gpu_buffer_subscriber.cpp sample_nodes/src/sample_cuda_utils.cu`
- `colcon build --packages-select ros2_cuda_ipc_core sample_nodes ros2_cuda_ipc_msgs --cmake-args -DBUILD_TESTING=ON` *(fails: Could not find a package configuration file provided by "rosidl_default_generators")*
- `colcon build --packages-select ros2_cuda_ipc_core --cmake-args -DBUILD_TESTING=ON` *(fails: Could not find a package configuration file provided by "ament_cmake")*


------
https://chatgpt.com/codex/tasks/task_b_68c6f33adb24832891824b2c62724baf