### PR TITLE
docs: add helper usage details

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,21 @@ ros2 run sample_nodes gpu_buffer_subscriber
 
 - **LeaseManager**: SHM 参照カウントとタイムアウトに基づくスロット自動解放を管理。
   - 実装: `ros2_cuda_ipc_core/lease_manager.hpp`
-  - 使い方: `LeaseManager lm(pool, lease_timeout_ms); lm.set_owner(owner);` 毎ループ `lm.tick()`
+  - リソース管理: スロットごとに SHM 制御ブロックを生成し、参照カウントまたはタイムアウトで解放。
+  - 注意: 毎ループ `tick()` を呼ばないとスロットが回収されない。`start_lease()` を呼び忘れるとリークする。
+  - 典型シーケンス: `lm.set_owner(owner)` → フレームごとに `lm.start_lease(slot, seq, consumers)` → メインループで `lm.tick()` → 終了時 `lm.cleanup()`
 
 - **ScopedMappedFrame**: Subscriber 側での RAII ヘルパー。イベント open + wait、メモリ open の再利用、破棄時に SHM decrement。
   - 実装: `ros2_cuda_ipc_core/scoped_mapped_frame.hpp`
-  - 使い方: `ScopedMappedFrame frame(mapper, slot, &mem, &evt, stream, shm_name, seq, true);`
+  - リソース管理: IPC イベント/メモリの open とキャッシュ、スコープ終了時に SHM 参照カウントを減算。
+  - 注意: `sync_on_dtor=true` の場合は破棄時にストリーム同期が発生。オブジェクトの寿命は GPU 処理より長く保つ。
+  - 典型シーケンス: メッセージ受信 → `ScopedMappedFrame frame(mapper, slot, &mem, &evt, stream, shm, seq)` → `frame.device_ptr()` で GPU 処理 → スコープ終了で解放
 
 - **GpuBufferPublisherHelper**: Publisher 側の定型処理を集約（借用→GPU書込→イベント→メッセージ→リース）。
   - 実装: `sample_nodes/include/sample_nodes/gpu_buffer_publisher_helper.hpp`
   - ビルドターゲット: `sample_nodes_helpers`（サンプル内の再利用用ライブラリ）
+  - リソース管理: GpuBufferPool のスロット借用/返却、CUDA イベント記録、必要に応じて LeaseManager でリースを開始。
+  - 注意: `borrow_frame()` で得たスロットは必ず `finalize_and_fill()` で仕上げる。マルチスレッド利用は未検証。
   - 典型手順:
     - 初期化: `helper(pool, &lease, producer_stream)`
     - 借用: `auto f = helper.borrow_frame(width, height, channels)`

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/lease_manager.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/lease_manager.hpp
@@ -13,8 +13,24 @@
 
 namespace ros2_cuda_ipc_core {
 
-// Manages per-frame SHM release counters and timed auto-release for
-// GpuBufferPool slots. ROS-agnostic; caller triggers tick() periodically.
+/**
+ * @brief Tracks shared-memory leases for slots in a GpuBufferPool.
+ *
+ * A LeaseManager creates per-slot control blocks in shared memory and monitors
+ * their reference counts.  When all consumers release a frame or when the
+ * timeout expires, the slot is returned to the pool.  The class itself is
+ * ROS-agnostic; the owner is expected to call tick() periodically.
+ *
+ * Typical sequence:
+ * 1. Construct with a pool reference and optional timeout.
+ * 2. set_owner() once to establish a SHM name prefix.
+ * 3. For each published frame call start_lease().
+ * 4. Periodically invoke tick() in the main loop to reclaim slots.
+ * 5. Call cleanup() on shutdown to remove lingering SHM objects.
+ *
+ * @note start_lease() must be called exactly once per borrowed slot; otherwise
+ * the pool entry may remain in use indefinitely.
+ */
 class LeaseManager {
  public:
   explicit LeaseManager(GpuBufferPool& pool, int lease_timeout_ms = 3000)
@@ -22,23 +38,40 @@ class LeaseManager {
 
   ~LeaseManager();
 
-  // Set an owner prefix used for SHM names: sanitized to [A-Za-z0-9_].
+  /**
+   * @brief Set an owner prefix used for SHM names.
+   *
+   * The prefix is sanitized to [A-Za-z0-9_].  Should be set before
+   * start_lease() is called to avoid orphaned names.
+   */
   void set_owner(std::string owner) { owner_ = sanitize_shm_owner(owner); }
 
-  // Create-or-open a slot-fixed SHM control block and initialize it for the
-  // given (slot, seq) with expected consumer refcount. Returns the SHM name on
-  // success and starts tracking the lease until release.
+  /**
+   * @brief Create or open a shared-memory control block for a slot.
+   *
+   * Initializes the block for the given sequence and expected consumer count
+   * and begins tracking the lease until release.
+   *
+   * @return SHM name on success; std::nullopt on failure.
+   */
   std::optional<std::string> start_lease(uint32_t slot_id, uint64_t seq,
                                          int expected_consumers);
 
-  // Poll leases: when a lease hits refcnt==0 (via SHM) or times out, release
-  // the slot back to the pool. Returns number of slots released in this tick.
+  /**
+   * @brief Poll leases and release slots that are complete or expired.
+   *
+   * @return Number of slots returned to the pool during this call.
+   */
   int tick();
 
-  // Best-effort cleanup of known SHM objects.
+  /**
+   * @brief Best-effort cleanup of known SHM objects.
+   */
   void cleanup();
 
-  // Update timeout.
+  /**
+   * @brief Update the lease timeout in milliseconds.
+   */
   void set_timeout_ms(int ms) { lease_timeout_ms_ = ms; }
 
  private:

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/scoped_mapped_frame.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/scoped_mapped_frame.hpp
@@ -10,23 +10,54 @@
 
 namespace ros2_cuda_ipc_core {
 
-// RAII helper for a single received frame on the consumer side.
-// - Ensures event is opened (and optionally waited on a stream)
-// - Optionally opens and exposes the device pointer via GpuBufferMapper cache
-// - On destruction, optionally synchronizes the stream, then decrements SHM
-//   refcount if a shm_name was provided.
+/**
+ * @brief RAII helper for a single GPU frame on the subscriber side.
+ *
+ * The constructor opens the IPC event and (optionally) waits on the supplied
+ * CUDA stream. If a memory handle is present it is mapped through
+ * GpuBufferMapper and cached for reuse. When the object goes out of scope the
+ * destructor optionally synchronizes the stream and decrements the shared
+ * memory reference count.
+ *
+ * Typical sequence:
+ * 1. Construct with handles from the received message.
+ * 2. Call device_ptr() and launch kernels on the provided stream.
+ * 3. Let the object destruct at scope exit to release the SHM slot.
+ *
+ * @warning The destructor performs SHM decrement and may block if
+ * sync_on_dtor is true. Do not copy the object or let it outlive the stream
+ * that uses the mapped memory.
+ */
 class ScopedMappedFrame {
  public:
+  /**
+   * @brief Map handles for a frame and optionally wait on a CUDA stream.
+   *
+   * @param mapper       Cache used for mem/event handle mapping.
+   * @param slot_id      Slot identifier within the pool.
+   * @param mem_handle   IPC memory handle (may be nullptr).
+   * @param evt_handle   IPC event handle (may be nullptr).
+   * @param stream       CUDA stream to wait on; may be nullptr.
+   * @param shm_name     SHM control block name for refcount decrement.
+   * @param seq          Sequence number for logging only.
+   * @param sync_on_dtor If true, synchronize the stream before decrementing.
+   */
   ScopedMappedFrame(GpuBufferMapper& mapper, uint32_t slot_id,
                     const CudaIpcMemHandle* mem_handle,
                     const CudaIpcEventHandle* evt_handle, void* stream,
                     std::string shm_name, uint64_t seq,
                     bool sync_on_dtor = true);
 
+  /**
+   * @brief Synchronizes and releases SHM refcount if necessary.
+   */
   ~ScopedMappedFrame();
 
-  // Returns cached device memory pointer (may be nullptr if open failed or
-  // mem_handle was null).
+  /**
+   * @brief Returns cached device memory pointer.
+   *
+   * Pointer may be nullptr if the memory handle was null or mapping failed.
+   */
   void* device_ptr() const { return mem_ptr_; }
 
  private:

--- a/sample_nodes/include/sample_nodes/gpu_buffer_publisher_helper.hpp
+++ b/sample_nodes/include/sample_nodes/gpu_buffer_publisher_helper.hpp
@@ -14,25 +14,56 @@
 
 namespace sample_nodes {
 
+/**
+ * @brief Convenience wrapper for publishing GPU-backed frames.
+ *
+ * The helper hides the ceremony of borrowing a slot from GpuBufferPool,
+ * recording a CUDA event on the producer stream and starting a lease via
+ * LeaseManager.  It is intended for simple samples and single-threaded
+ * publishers.
+ *
+ * Typical sequence:
+ * 1. Call borrow_frame() to reserve a slot and obtain a device pointer.
+ * 2. Write GPU data into the provided pointer.
+ * 3. Call finalize_and_fill() to populate the message and optionally start a
+ *    lease.
+ *
+ * @warning finalize_and_fill() must be called exactly once for each successful
+ * borrow_frame() or the slot will remain reserved and leak.
+ */
 class GpuBufferPublisherHelper {
  public:
+  /** Basic information about a borrowed frame. */
   struct Frame {
-    uint32_t slot_id{0};
-    void* device_ptr{nullptr};
-    uint64_t size_bytes{0};
-    uint64_t pitch_bytes{0};
+    uint32_t slot_id{0};       /**< Slot index in the pool. */
+    void* device_ptr{nullptr}; /**< Writable device pointer. */
+    uint64_t size_bytes{0};    /**< Total byte size of the frame. */
+    uint64_t pitch_bytes{0};   /**< Row pitch in bytes. */
   };
 
+  /**
+   * @brief Create a helper bound to a pool, optional LeaseManager and stream.
+   */
   GpuBufferPublisherHelper(ros2_cuda_ipc_core::GpuBufferPool& pool,
                            ros2_cuda_ipc_core::LeaseManager* lease_mgr,
                            void* producer_stream);
 
-  // Attempts to borrow a slot and returns basic info for filling GPU memory.
+  /**
+   * @brief Borrow a frame slot from the pool.
+   *
+   * @return Frame information including device pointer on success; std::nullopt
+   * on failure.
+   */
   std::optional<Frame> borrow_frame(uint32_t width, uint32_t height,
                                     uint32_t channels);
 
-  // Fills the message fields, exports IPC handles, records the ready event and
-  // optionally starts a lease. Returns true if plane[0] was populated.
+  /**
+   * @brief Finalize a borrowed frame and populate a message.
+   *
+   * Exports IPC handles, records a ready event and optionally starts a lease.
+   *
+   * @return true if plane[0] was populated.
+   */
   bool finalize_and_fill(const Frame& f, uint64_t seq_id,
                          int expected_consumers, std::string_view shm_owner,
                          uint32_t width, uint32_t height, uint32_t channels,
@@ -40,9 +71,10 @@ class GpuBufferPublisherHelper {
                          ros2_cuda_ipc_msgs::msg::GpuBuffer& out);
 
  private:
-  ros2_cuda_ipc_core::GpuBufferPool& pool_;
-  ros2_cuda_ipc_core::LeaseManager* lease_mgr_{nullptr};
-  void* stream_{nullptr};
+  ros2_cuda_ipc_core::GpuBufferPool& pool_; /**< Underlying pool. */
+  ros2_cuda_ipc_core::LeaseManager* lease_mgr_{
+      nullptr};           /**< Optional lease manager. */
+  void* stream_{nullptr}; /**< Producer CUDA stream. */
 };
 
 }  // namespace sample_nodes


### PR DESCRIPTION
## Summary
- document LeaseManager, ScopedMappedFrame and GpuBufferPublisherHelper with Doxygen comments
- elaborate README helper section with resource management, cautions and typical sequences

## Testing
- `doxygen 2>&1 | head -n 20` *(fails: Doxyfile not found)*
- `colcon build --packages-select ros2_cuda_ipc_core sample_nodes` *(fails: Could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_b_68c6f33cfc408328935acc2e50fb7e77