### PR TITLE
Refactor finalize helper to use GpuBuffer metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ ros2 run sample_nodes gpu_buffer_subscriber
     - 初期化: `helper(pool, &lease, producer_stream)`
     - 借用: `auto f = helper.borrow_frame(width, height, channels)`
     - 書込: `cuda_fill_u8(f.device_ptr, ...)` など
-    - 仕上げ: `helper.finalize_and_fill(f, seq, expected_consumers, owner, w, h, c, layout, format, msg)`
+    - 仕上げ: `helper.finalize_and_fill(f, expected_consumers, owner, msg)`
 
 サンプル Publisher は既に helper を利用する形に差し替え済みです。Subscriber は ScopedMappedFrame を用いて wait と SHM 解放を簡素化しています。
 

--- a/sample_nodes/include/sample_nodes/gpu_buffer_publisher_helper.hpp
+++ b/sample_nodes/include/sample_nodes/gpu_buffer_publisher_helper.hpp
@@ -31,12 +31,11 @@ class GpuBufferPublisherHelper {
   std::optional<Frame> borrow_frame(uint32_t width, uint32_t height,
                                     uint32_t channels);
 
-  // Fills the message fields, exports IPC handles, records the ready event and
-  // optionally starts a lease. Returns true if plane[0] was populated.
-  bool finalize_and_fill(const Frame& f, uint64_t seq_id,
-                         int expected_consumers, std::string_view shm_owner,
-                         uint32_t width, uint32_t height, uint32_t channels,
-                         uint8_t layout, uint8_t format,
+  // Fills remaining message fields, exports IPC handles, records the ready
+  // event and optionally starts a lease. Returns true if plane[0] was
+  // populated.
+  bool finalize_and_fill(const Frame& f, int expected_consumers,
+                         std::string_view shm_owner,
                          ros2_cuda_ipc_msgs::msg::GpuBuffer& out);
 
  private:

--- a/sample_nodes/src/gpu_buffer_publisher.cpp
+++ b/sample_nodes/src/gpu_buffer_publisher.cpp
@@ -105,9 +105,8 @@ class DummyPublisher : public rclcpp::Node {
               ? static_cast<int>(pub_->get_subscription_count())
               : expected_consumers_;
 
-      bool ok = helper_->finalize_and_fill(
-          *frame, msg.seq_id, expected_count, shm_owner_, msg.width, msg.height,
-          msg.channels, msg.layout, msg.format, msg);
+      bool ok =
+          helper_->finalize_and_fill(*frame, expected_count, shm_owner_, msg);
       if (!ok) {
         RCLCPP_WARN_THROTTLE(
             this->get_logger(), *this->get_clock(), 5000,

--- a/sample_nodes/src/gpu_buffer_publisher_helper.cpp
+++ b/sample_nodes/src/gpu_buffer_publisher_helper.cpp
@@ -29,20 +29,12 @@ GpuBufferPublisherHelper::borrow_frame(uint32_t width, uint32_t height,
 }
 
 bool GpuBufferPublisherHelper::finalize_and_fill(
-    const Frame& f, uint64_t seq_id, int expected_consumers,
-    std::string_view shm_owner, uint32_t width, uint32_t height,
-    uint32_t channels, uint8_t layout, uint8_t format,
+    const Frame& f, int expected_consumers, std::string_view shm_owner,
     ros2_cuda_ipc_msgs::msg::GpuBuffer& out) {
   out.abi_version = ros2_cuda_ipc_core::kAbiVersion;
   auto id = ros2_cuda_ipc_core::cuda_get_device_id_string();
   out.device_uuid = id.empty() ? std::string("unknown") : id;
-  out.seq_id = seq_id;
   out.pool_slot_id = f.slot_id;
-  out.layout = layout;
-  out.format = format;
-  out.width = width;
-  out.height = height;
-  out.channels = channels;
   out.shm_name.clear();
 
   ros2_cuda_ipc_core::CudaIpcMemHandle mh{};
@@ -72,7 +64,7 @@ bool GpuBufferPublisherHelper::finalize_and_fill(
   if (expected_consumers > 0 && lease_mgr_) {
     lease_mgr_->set_owner(std::string(shm_owner));
     auto created =
-        lease_mgr_->start_lease(f.slot_id, seq_id, expected_consumers);
+        lease_mgr_->start_lease(f.slot_id, out.seq_id, expected_consumers);
     if (created) {
       out.shm_name = *created;
     }

--- a/sample_nodes/test/test_gpu_buffer_publisher_helper.cpp
+++ b/sample_nodes/test/test_gpu_buffer_publisher_helper.cpp
@@ -20,12 +20,14 @@ TEST(GpuBufferPublisherHelperTest, MetadataOnlyWhenNoCudaMem) {
   ASSERT_TRUE(f.has_value());
 
   ros2_cuda_ipc_msgs::msg::GpuBuffer msg;
-  bool ok = helper.finalize_and_fill(
-      *f, /*seq=*/1, /*expected=*/0,
-      /*owner=*/"test_owner",
-      /*w=*/16, /*h=*/8, /*c=*/3,
-      /*layout=*/ros2_cuda_ipc_msgs::msg::GpuBuffer::LAYOUT_LINEAR,
-      /*format=*/ros2_cuda_ipc_msgs::msg::GpuBuffer::FORMAT_BGR8, msg);
+  msg.seq_id = 1;
+  msg.layout = ros2_cuda_ipc_msgs::msg::GpuBuffer::LAYOUT_LINEAR;
+  msg.format = ros2_cuda_ipc_msgs::msg::GpuBuffer::FORMAT_BGR8;
+  msg.width = 16;
+  msg.height = 8;
+  msg.channels = 3;
+  bool ok = helper.finalize_and_fill(*f, /*expected=*/0,
+                                     /*owner=*/"test_owner", msg);
   EXPECT_FALSE(ok);
   EXPECT_EQ(msg.plane_count, 0u);
 
@@ -44,12 +46,14 @@ TEST(GpuBufferPublisherHelperTest, KeepsSlotOnLeaseStart) {
   ASSERT_TRUE(f.has_value());
 
   ros2_cuda_ipc_msgs::msg::GpuBuffer msg;
-  bool ok = helper.finalize_and_fill(
-      *f, /*seq=*/2, /*expected=*/2,
-      /*owner=*/"owner",
-      /*w=*/10, /*h=*/10, /*c=*/1,
-      ros2_cuda_ipc_msgs::msg::GpuBuffer::LAYOUT_LINEAR,
-      ros2_cuda_ipc_msgs::msg::GpuBuffer::FORMAT_BGR8, msg);
+  msg.seq_id = 2;
+  msg.layout = ros2_cuda_ipc_msgs::msg::GpuBuffer::LAYOUT_LINEAR;
+  msg.format = ros2_cuda_ipc_msgs::msg::GpuBuffer::FORMAT_BGR8;
+  msg.width = 10;
+  msg.height = 10;
+  msg.channels = 1;
+  bool ok = helper.finalize_and_fill(*f, /*expected=*/2,
+                                     /*owner=*/"owner", msg);
   // Without CUDA mem, plane cannot be populated
   EXPECT_FALSE(ok);
   EXPECT_EQ(msg.plane_count, 0u);


### PR DESCRIPTION
## Summary
- Simplify `GpuBufferPublisherHelper::finalize_and_fill` to rely on metadata already stored in `GpuBuffer`
- Update publisher and tests to populate the message once and call helper with remaining parameters
- Document new usage in README

## Testing
- `colcon build --packages-select ros2_cuda_ipc_core ros2_cuda_ipc_msgs sample_nodes` *(fails: ament_cmake not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c74aa20b64832895e47b9c4314c0ba