### PR TITLE
Include CUDA error string in exceptions

### DIFF
--- a/ros2_cuda_ipc_core/src/cuda_support.cu
+++ b/ros2_cuda_ipc_core/src/cuda_support.cu
@@ -12,10 +12,11 @@ inline void check_cuda_error(
     cudaError_t err, const std::experimental::source_location& location =
                          std::experimental::source_location::current()) {
   if (err != cudaSuccess) {
+    const char* err_str = cudaGetErrorString(err);
     std::fprintf(stderr, "CUDA error at %s:%u in %s(): %s\n",
                  location.file_name(), location.line(),
-                 location.function_name(), cudaGetErrorString(err));
-    throw std::runtime_error("CUDA error");
+                 location.function_name(), err_str);
+    throw std::runtime_error(std::string("CUDA error: ") + err_str);
   }
 }
 

--- a/ros2_cuda_ipc_core/test/test_cuda_support.cpp
+++ b/ros2_cuda_ipc_core/test/test_cuda_support.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include <stdexcept>
+#include <string>
 
 #include "ros2_cuda_ipc_core/cuda_support.hpp"
 
@@ -41,6 +42,24 @@ TEST(CudaSupport, NullArgumentValidation) {
   // Handle struct sizes are ABI-stable wrappers (64 bytes)
   EXPECT_EQ(sizeof(CudaIpcMemHandle), static_cast<size_t>(64));
   EXPECT_EQ(sizeof(CudaIpcEventHandle), static_cast<size_t>(64));
+}
+
+TEST(CudaSupport, ErrorMessageIncludesCudaString) {
+  if (!cuda_is_available()) {
+    GTEST_SKIP() << "CUDA device not available";
+  }
+
+  const cudaEvent_t bad_evt = reinterpret_cast<cudaEvent_t>(1);
+  auto err = cudaEventDestroy(bad_evt);
+  const char* err_str = cudaGetErrorString(err);
+  EXPECT_NE(err, cudaSuccess);
+
+  try {
+    cuda_event_destroy(bad_evt);
+    FAIL() << "Expected std::runtime_error";
+  } catch (const std::runtime_error& e) {
+    EXPECT_NE(std::string::npos, std::string(e.what()).find(err_str));
+  }
 }
 
 TEST(CudaSupport, AllocateAndFree) {

--- a/ros2_cuda_ipc_core/test/test_cuda_support.cpp
+++ b/ros2_cuda_ipc_core/test/test_cuda_support.cpp
@@ -58,7 +58,7 @@ TEST(CudaSupport, ErrorMessageIncludesCudaString) {
     cuda_event_destroy(bad_evt);
     FAIL() << "Expected std::runtime_error";
   } catch (const std::runtime_error& e) {
-    EXPECT_NE(std::string::npos, std::string(e.what()).find(err_str));
+    EXPECT_NE(std::string(e.what()).find(err_str), std::string::npos);
   }
 }
 


### PR DESCRIPTION
## Summary
- propagate CUDA error strings in check_cuda_error exceptions
- add unit test ensuring exception message reports CUDA runtime error text

## Testing
- `pre-commit run --files ros2_cuda_ipc_core/src/cuda_support.cu ros2_cuda_ipc_core/test/test_cuda_support.cpp`
- `colcon test --packages-select ros2_cuda_ipc_core` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c79af316e083289d4e7f711be08e34