### PR TITLE
Add handle validation to GPU buffer mapper and subscriber

### DIFF
--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_mapper.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_mapper.hpp
@@ -3,6 +3,8 @@
 
 #include <cstdint>
 #include <mutex>
+#include <string>
+#include <string_view>
 #include <unordered_map>
 
 #include "ros2_cuda_ipc_core/cuda_support.hpp"
@@ -33,6 +35,12 @@ class GpuBufferMapper {
   // event not cached or wait fails.
   bool wait_ready(uint32_t slot_id, cudaStream_t stream) const;
 
+  // Validates ABI version and device UUID for the slot. If a mismatch is
+  // detected compared to cached values, the slot is closed. Returns true when
+  // handles remain valid, false when they were reset due to mismatch.
+  bool validate_handles(uint32_t slot_id, uint32_t abi_version,
+                        std::string_view device_uuid);
+
   // Closes and removes cached resources for a slot.
   void close_slot(uint32_t slot_id);
 
@@ -43,7 +51,12 @@ class GpuBufferMapper {
   struct Entry {
     void* mem{nullptr};
     cudaEvent_t evt{nullptr};
+    uint32_t abi_version{0};
+    std::string device_uuid;
   };
+
+  // Internal helper expecting mutex_ to be locked.
+  void close_slot_locked(uint32_t slot_id);
 
   mutable std::mutex mutex_;
   std::unordered_map<uint32_t, Entry> cache_;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_mapper.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_mapper.hpp
@@ -55,6 +55,10 @@ class GpuBufferMapper {
     std::string device_uuid;
   };
 
+  // Sets ABI version and device UUID on an Entry.
+  static void set_entry_metadata(Entry& e, uint32_t abi_version,
+                                 std::string_view device_uuid);
+
   // Internal helper expecting mutex_ to be locked.
   void close_slot_locked(uint32_t slot_id);
 

--- a/ros2_cuda_ipc_core/src/gpu_buffer_mapper.cpp
+++ b/ros2_cuda_ipc_core/src/gpu_buffer_mapper.cpp
@@ -57,8 +57,38 @@ bool GpuBufferMapper::wait_ready(uint32_t slot_id, cudaStream_t stream) const {
   return cuda_stream_wait_event(stream, evt);
 }
 
+bool GpuBufferMapper::validate_handles(uint32_t slot_id, uint32_t abi_version,
+                                       std::string_view device_uuid) {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = cache_.find(slot_id);
+  if (it == cache_.end()) {
+    Entry e;
+    e.abi_version = abi_version;
+    e.device_uuid = std::string(device_uuid);
+    cache_[slot_id] = std::move(e);
+    return true;
+  }
+  Entry& e = it->second;
+  if (e.abi_version != 0 &&
+      (e.abi_version != abi_version || e.device_uuid != device_uuid)) {
+    close_slot_locked(slot_id);
+    Entry new_e;
+    new_e.abi_version = abi_version;
+    new_e.device_uuid = std::string(device_uuid);
+    cache_[slot_id] = std::move(new_e);
+    return false;
+  }
+  e.abi_version = abi_version;
+  e.device_uuid = std::string(device_uuid);
+  return true;
+}
+
 void GpuBufferMapper::close_slot(uint32_t slot_id) {
   std::lock_guard<std::mutex> lock(mutex_);
+  close_slot_locked(slot_id);
+}
+
+void GpuBufferMapper::close_slot_locked(uint32_t slot_id) {
   auto it = cache_.find(slot_id);
   if (it == cache_.end()) return;
   if (it->second.mem) {

--- a/ros2_cuda_ipc_core/src/gpu_buffer_mapper.cpp
+++ b/ros2_cuda_ipc_core/src/gpu_buffer_mapper.cpp
@@ -57,14 +57,19 @@ bool GpuBufferMapper::wait_ready(uint32_t slot_id, cudaStream_t stream) const {
   return cuda_stream_wait_event(stream, evt);
 }
 
+void GpuBufferMapper::set_entry_metadata(Entry& e, uint32_t abi_version,
+                                         std::string_view device_uuid) {
+  e.abi_version = abi_version;
+  e.device_uuid = std::string(device_uuid);
+}
+
 bool GpuBufferMapper::validate_handles(uint32_t slot_id, uint32_t abi_version,
                                        std::string_view device_uuid) {
   std::lock_guard<std::mutex> lock(mutex_);
   auto it = cache_.find(slot_id);
   if (it == cache_.end()) {
     Entry e;
-    e.abi_version = abi_version;
-    e.device_uuid = std::string(device_uuid);
+    set_entry_metadata(e, abi_version, device_uuid);
     cache_[slot_id] = std::move(e);
     return true;
   }
@@ -73,13 +78,11 @@ bool GpuBufferMapper::validate_handles(uint32_t slot_id, uint32_t abi_version,
       (e.abi_version != abi_version || e.device_uuid != device_uuid)) {
     close_slot_locked(slot_id);
     Entry new_e;
-    new_e.abi_version = abi_version;
-    new_e.device_uuid = std::string(device_uuid);
+    set_entry_metadata(new_e, abi_version, device_uuid);
     cache_[slot_id] = std::move(new_e);
     return false;
   }
-  e.abi_version = abi_version;
-  e.device_uuid = std::string(device_uuid);
+  set_entry_metadata(e, abi_version, device_uuid);
   return true;
 }
 

--- a/sample_nodes/src/gpu_buffer_subscriber.cpp
+++ b/sample_nodes/src/gpu_buffer_subscriber.cpp
@@ -18,22 +18,12 @@ class DummySubscriber : public rclcpp::Node {
     sub_ = this->create_subscription<ros2_cuda_ipc_msgs::msg::GpuBuffer>(
         "gpu_buffer", 10,
         [this](const ros2_cuda_ipc_msgs::msg::GpuBuffer& msg) {
-          // Detect publisher restart or device mismatch and reset mapper
-          if (prev_abi_version_ != 0 && prev_abi_version_ != msg.abi_version) {
-            RCLCPP_WARN(
-                this->get_logger(),
-                "ABI version changed: %u -> %u. Resetting mapper cache.",
-                prev_abi_version_, msg.abi_version);
-            mapper_.reset();
-          }
-          if (!prev_device_id_.empty() && prev_device_id_ != msg.device_uuid) {
+          if (!mapper_.validate_handles(msg.pool_slot_id, msg.abi_version,
+                                        msg.device_uuid)) {
             RCLCPP_WARN(this->get_logger(),
-                        "Device id changed: %s -> %s. Resetting mapper cache.",
-                        prev_device_id_.c_str(), msg.device_uuid.c_str());
-            mapper_.reset();
+                        "Invalidated cached handles for slot %u",
+                        msg.pool_slot_id);
           }
-          prev_abi_version_ = msg.abi_version;
-          prev_device_id_ = msg.device_uuid;
           RCLCPP_INFO(this->get_logger(), "Received seq_id %lu", msg.seq_id);
           auto t0 = std::chrono::steady_clock::now();
           // RAII frame: opens event+mem, waits on stream, decrements SHM on
@@ -66,8 +56,6 @@ class DummySubscriber : public rclcpp::Node {
   rclcpp::Subscription<ros2_cuda_ipc_msgs::msg::GpuBuffer>::SharedPtr sub_;
   cudaStream_t stream_{nullptr};
   ros2_cuda_ipc_core::GpuBufferMapper mapper_;
-  uint32_t prev_abi_version_{0};
-  std::string prev_device_id_;
 };
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary
- validate ABI version and device UUID for each slot in `GpuBufferMapper`
- automatically close and reset slot handles on mismatch
- invoke validation in sample subscriber to safely refresh handles

## Testing
- `pre-commit run --files ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_mapper.hpp ros2_cuda_ipc_core/src/gpu_buffer_mapper.cpp sample_nodes/src/gpu_buffer_subscriber.cpp`
- `colcon build --packages-select ros2_cuda_ipc_core sample_nodes ros2_cuda_ipc_msgs` *(failed: Could not find package configuration file provided by "ament_cmake")*

------
https://chatgpt.com/codex/tasks/task_b_68c79af55db88328809b138d4e924bfd