### PR TITLE
Add blocking borrow and GPU buffer pool expansion

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -1,4 +1,4 @@
-# ROS 2 CUDA IPC Zero‑Copy Transport – Design Doc (v1)
+#ROS 2 CUDA IPC Zero‑Copy Transport – Design Doc(v1)
 
 **Author:** dskkato
 **Date:** 2025‑09‑13
@@ -115,11 +115,11 @@ string  shm_name       // 任意：共有制御ブロック方式を使う場合
 
 ```c++
 struct PoolOptions {
-  uint32_t pool_size = 16;               // スロット数
-  size_t   max_bytes_per_plane = 16<<20; // 例: 16 MiB
-  uint32_t max_planes = 2;               // NV12想定
+  uint32_t pool_size = 16;                // スロット数
+  size_t max_bytes_per_plane = 16 << 20;  // 例: 16 MiB
+  uint32_t max_planes = 2;                // NV12想定
   std::chrono::milliseconds lease_timeout{30};
-  cudaStream_t producer_stream = 0;      // 省略可
+  cudaStream_t producer_stream = 0;  // 省略可
 };
 ```
 
@@ -137,7 +137,7 @@ enum {FREE, IN_USE} + deadline + last_seq_id
 
 ### 5.3 Lifecycle
 
-1. `borrow()` で空きスロット取得
+1. `borrow(blocking)` で空きスロット取得
 2. CPU→GPU転送/色変換/前処理（producer stream）
 3. `cudaEventRecord(ready_evt)`
 4. `make_message()` で `GpuBuffer` 生成・Publish
@@ -198,25 +198,26 @@ enum {FREE, IN_USE} + deadline + last_seq_id
 ```c++
 // Publisher side
 class GpuBufferPool {
-public:
-  explicit GpuBufferPool(const PoolOptions&);
+ public:
+  explicit GpuBufferPool(const PoolOptions &);
   BorrowedSlot borrow();
-  GpuBufferMsg make_message(const BorrowedSlot&, const FrameMeta&);
-  void on_release(uint64_t seq_id, uint32_t slot_id, std::string_view consumer_id);
+  GpuBufferMsg make_message(const BorrowedSlot &, const FrameMeta &);
+  void on_release(uint64_t seq_id, uint32_t slot_id,
+                  std::string_view consumer_id);
 };
 
 // Subscriber side
 class GpuBufferMapper {
-public:
-  OpenedBuffer open(const GpuBufferMsg& msg);            // cached
-  void wait_ready(const OpenedBuffer& buf, cudaStream_t user_stream);
-  void release(const GpuBufferMsg& msg, std::string_view consumer_id);
+ public:
+  OpenedBuffer open(const GpuBufferMsg &msg);  // cached
+  void wait_ready(const OpenedBuffer &buf, cudaStream_t user_stream);
+  void release(const GpuBufferMsg &msg, std::string_view consumer_id);
 };
 ```
 
 ### Python (pybind11)
 
-* `pool = GpuBufferPool(opts)` / `slot = pool.borrow()`
+* `pool = GpuBufferPool(opts)` / `slot = pool.borrow(true)`
 * `mapper = GpuBufferMapper()` / `buf = mapper.open(msg)` / `mapper.wait_ready(buf, stream)`
 * DLPack: `to_torch(buf, shape, dtype, layout)` / `to_cupy(...)`
 
@@ -354,7 +355,7 @@ ros2_cuda_ipc:
 ### 22.1 Minimal Pseudocode – Publisher
 
 ```cpp
-auto slot = pool.borrow();
+auto slot = pool.borrow(true);
 // memcpyAsync host_yuv → slot.dev_ptrs[0/1]
 launch_yuv2bgr_kernel(slot, ...);
 cudaEventRecord(slot.ready_evt, producer_stream);
@@ -362,15 +363,14 @@ auto msg = pool.make_message(slot, meta);
 pub->publish(msg);
 ```
 
-### 22.2 Minimal Pseudocode – Subscriber
+    ## #22.2 Minimal Pseudocode – Subscriber
 
-```cpp
-auto buf = mapper.open(msg);
+```cpp auto buf = mapper.open(msg);
 mapper.wait_ready(buf, my_stream);
 // use buf.dev_ptrs[...] as input (zero-copy)
 mapper.release(msg, consumer_id);
 ```
 
----
+    -- -
 
-**End of Document**
+    **End of Document **

--- a/doc/design.md
+++ b/doc/design.md
@@ -363,14 +363,15 @@ auto msg = pool.make_message(slot, meta);
 pub->publish(msg);
 ```
 
-    ## #22.2 Minimal Pseudocode – Subscriber
+### 22.2 Minimal Pseudocode – Subscriber
 
-```cpp auto buf = mapper.open(msg);
+```cpp
+auto buf = mapper.open(msg);
 mapper.wait_ready(buf, my_stream);
 // use buf.dev_ptrs[...] as input (zero-copy)
 mapper.release(msg, consumer_id);
 ```
 
-    -- -
+---
 
-    **End of Document **
+**End of Document**

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_pool.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/gpu_buffer_pool.hpp
@@ -1,6 +1,7 @@
 #ifndef ROS2_CUDA_IPC_CORE_GPU_BUFFER_POOL_HPP_
 #define ROS2_CUDA_IPC_CORE_GPU_BUFFER_POOL_HPP_
 
+#include <condition_variable>
 #include <cstddef>
 #include <mutex>
 #include <optional>
@@ -30,7 +31,12 @@ class GpuBufferPool {
   // Options-based constructor for future extensibility.
   explicit GpuBufferPool(const PoolOptions& opts);
   ~GpuBufferPool();
-  std::optional<std::size_t> borrow();
+  // Borrows a free slot. If blocking is true, waits until a slot becomes
+  // available. When blocking is false, returns std::nullopt immediately if the
+  // pool is exhausted.
+  std::optional<std::size_t> borrow(bool blocking = false);
+  // Expands the pool by the given number of slots. Returns true on success.
+  bool expand_pool(std::size_t new_slots);
   bool release(std::size_t id);
   std::size_t capacity() const { return slots_.size(); }
   // Returns device pointer for a slot (nullptr if not CUDA or invalid).
@@ -55,6 +61,7 @@ class GpuBufferPool {
   bool events_enabled_{false};
   cudaStream_t producer_stream_{nullptr};
   std::mutex mutex_;
+  std::condition_variable cv_;
 };
 
 }  // namespace ros2_cuda_ipc_core

--- a/ros2_cuda_ipc_core/src/gpu_buffer_pool.cpp
+++ b/ros2_cuda_ipc_core/src/gpu_buffer_pool.cpp
@@ -128,11 +128,13 @@ bool GpuBufferPool::expand_pool(std::size_t new_slots) {
         for (std::size_t j = old_size; j < slots_.size(); ++j) {
           if (events_[j]) cuda_event_destroy(events_[j]);
         }
-        for (std::size_t j = old_size; j < slots_.size(); ++j) {
-          if (device_ptrs_[j]) cuda_free(device_ptrs_[j]);
+        if (bytes_per_slot_ > 0) {
+          for (std::size_t j = old_size; j < slots_.size(); ++j) {
+            if (device_ptrs_[j]) cuda_free(device_ptrs_[j]);
+          }
+          device_ptrs_.resize(old_size);
         }
         slots_.resize(old_size);
-        device_ptrs_.resize(old_size);
         events_.resize(old_size);
         return false;
       }

--- a/ros2_cuda_ipc_core/src/gpu_buffer_pool.cpp
+++ b/ros2_cuda_ipc_core/src/gpu_buffer_pool.cpp
@@ -125,11 +125,11 @@ bool GpuBufferPool::expand_pool(std::size_t new_slots) {
     for (std::size_t i = old_size; i < slots_.size(); ++i) {
       cudaEvent_t e = cuda_event_create();
       if (!e) {
-        for (std::size_t j = old_size; j < slots_.size(); ++j) {
+        for (std::size_t j = old_size; j < i; ++j) {
           if (events_[j]) cuda_event_destroy(events_[j]);
         }
         if (bytes_per_slot_ > 0) {
-          for (std::size_t j = old_size; j < slots_.size(); ++j) {
+          for (std::size_t j = old_size; j < i; ++j) {
             if (device_ptrs_[j]) cuda_free(device_ptrs_[j]);
           }
           device_ptrs_.resize(old_size);

--- a/ros2_cuda_ipc_core/src/gpu_buffer_pool.cpp
+++ b/ros2_cuda_ipc_core/src/gpu_buffer_pool.cpp
@@ -65,21 +65,90 @@ GpuBufferPool::~GpuBufferPool() {
   }
 }
 
-std::optional<std::size_t> GpuBufferPool::borrow() {
+std::optional<std::size_t> GpuBufferPool::borrow(bool blocking) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  auto find_slot = [&]() -> std::optional<std::size_t> {
+    for (std::size_t i = 0; i < slots_.size(); ++i) {
+      if (!slots_[i].in_use) {
+        slots_[i].in_use = true;
+        return i;
+      }
+    }
+    return std::nullopt;
+  };
+
+  while (true) {
+    auto slot = find_slot();
+    if (slot.has_value() || !blocking) {
+      return slot;
+    }
+    cv_.wait(lock);
+  }
+}
+
+bool GpuBufferPool::expand_pool(std::size_t new_slots) {
+  if (new_slots == 0) return true;
+  const bool needs_cuda = (bytes_per_slot_ > 0) || events_enabled_;
+  if (needs_cuda && !cuda_is_available()) return false;
+
   std::lock_guard<std::mutex> lock(mutex_);
-  for (std::size_t i = 0; i < slots_.size(); ++i) {
-    if (!slots_[i].in_use) {
-      slots_[i].in_use = true;
-      return i;
+  const std::size_t old_size = slots_.size();
+  slots_.resize(old_size + new_slots);
+
+  // Resize vectors for CUDA resources if needed
+  if (bytes_per_slot_ > 0) {
+    device_ptrs_.resize(old_size + new_slots, nullptr);
+  }
+  if (events_enabled_) {
+    events_.resize(old_size + new_slots, nullptr);
+  }
+
+  // Allocate CUDA resources for new slots
+  if (bytes_per_slot_ > 0) {
+    for (std::size_t i = old_size; i < slots_.size(); ++i) {
+      void* p = cuda_allocate(bytes_per_slot_);
+      if (!p) {
+        // rollback
+        for (std::size_t j = old_size; j < i; ++j) {
+          if (device_ptrs_[j]) cuda_free(device_ptrs_[j]);
+          if (events_enabled_ && events_[j]) cuda_event_destroy(events_[j]);
+        }
+        slots_.resize(old_size);
+        device_ptrs_.resize(old_size);
+        if (events_enabled_) events_.resize(old_size);
+        return false;
+      }
+      device_ptrs_[i] = p;
     }
   }
-  return std::nullopt;
+  if (events_enabled_) {
+    for (std::size_t i = old_size; i < slots_.size(); ++i) {
+      cudaEvent_t e = cuda_event_create();
+      if (!e) {
+        for (std::size_t j = old_size; j < slots_.size(); ++j) {
+          if (events_[j]) cuda_event_destroy(events_[j]);
+        }
+        for (std::size_t j = old_size; j < slots_.size(); ++j) {
+          if (device_ptrs_[j]) cuda_free(device_ptrs_[j]);
+        }
+        slots_.resize(old_size);
+        device_ptrs_.resize(old_size);
+        events_.resize(old_size);
+        return false;
+      }
+      events_[i] = e;
+    }
+  }
+
+  cv_.notify_all();
+  return true;
 }
 
 bool GpuBufferPool::release(std::size_t id) {
   std::lock_guard<std::mutex> lock(mutex_);
   if (id < slots_.size() && slots_[id].in_use) {
     slots_[id].in_use = false;
+    cv_.notify_one();
     return true;
   }
   return false;

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_pool.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_pool.cpp
@@ -1,5 +1,9 @@
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
+#include <thread>
+
 #include "ros2_cuda_ipc_core/gpu_buffer_pool.hpp"
 
 using ros2_cuda_ipc_core::GpuBufferPool;
@@ -16,6 +20,34 @@ TEST(GpuBufferPool, BorrowRelease) {
   EXPECT_FALSE(pool.release(pool.capacity()));
   auto s3 = pool.borrow();
   EXPECT_TRUE(s3.has_value());
+}
+
+TEST(GpuBufferPool, BlockingBorrowWaits) {
+  GpuBufferPool pool(1);
+  auto s0 = pool.borrow(true);
+  ASSERT_TRUE(s0.has_value());
+
+  std::atomic<bool> got_slot{false};
+  std::thread t([&]() {
+    auto s1 = pool.borrow(true);
+    if (s1.has_value()) {
+      got_slot = true;
+      pool.release(*s1);
+    }
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  EXPECT_FALSE(got_slot.load());
+  EXPECT_TRUE(pool.release(*s0));
+  t.join();
+  EXPECT_TRUE(got_slot.load());
+}
+
+TEST(GpuBufferPool, ExpandPool) {
+  GpuBufferPool pool(1);
+  EXPECT_EQ(pool.capacity(), 1u);
+  EXPECT_TRUE(pool.expand_pool(2));
+  EXPECT_EQ(pool.capacity(), 3u);
 }
 
 int main(int argc, char **argv) {

--- a/sample_nodes/include/sample_nodes/gpu_buffer_publisher_helper.hpp
+++ b/sample_nodes/include/sample_nodes/gpu_buffer_publisher_helper.hpp
@@ -28,8 +28,9 @@ class GpuBufferPublisherHelper {
                            cudaStream_t producer_stream);
 
   // Attempts to borrow a slot and returns basic info for filling GPU memory.
+  // When blocking is true, waits until a slot is available.
   std::optional<Frame> borrow_frame(uint32_t width, uint32_t height,
-                                    uint32_t channels);
+                                    uint32_t channels, bool blocking = false);
 
   // Fills remaining message fields, exports IPC handles, records the ready
   // event and optionally starts a lease. Returns true if plane[0] was

--- a/sample_nodes/src/gpu_buffer_publisher.cpp
+++ b/sample_nodes/src/gpu_buffer_publisher.cpp
@@ -89,7 +89,8 @@ class DummyPublisher : public rclcpp::Node {
     msg.stamp = this->now();
     msg.frame_id = "frame";
 
-    auto frame = helper_->borrow_frame(msg.width, msg.height, msg.channels);
+    auto frame = helper_->borrow_frame(msg.width, msg.height, msg.channels,
+                                       /*blocking=*/true);
     if (frame.has_value()) {
       // Fill device buffer with a changing pattern
       const uint64_t size_bytes = frame->size_bytes;

--- a/sample_nodes/src/gpu_buffer_publisher_helper.cpp
+++ b/sample_nodes/src/gpu_buffer_publisher_helper.cpp
@@ -17,8 +17,8 @@ GpuBufferPublisherHelper::GpuBufferPublisherHelper(
 
 std::optional<GpuBufferPublisherHelper::Frame>
 GpuBufferPublisherHelper::borrow_frame(uint32_t width, uint32_t height,
-                                       uint32_t channels) {
-  auto slot = pool_.borrow();
+                                       uint32_t channels, bool blocking) {
+  auto slot = pool_.borrow(blocking);
   if (!slot.has_value()) return std::nullopt;
   Frame f;
   f.slot_id = static_cast<uint32_t>(*slot);


### PR DESCRIPTION
## Summary
- add condition_variable-based waiting to GPU buffer pool with `borrow(blocking)`
- allow dynamic pool growth via `expand_pool`
- demonstrate blocking borrow in sample publisher and document usage

## Testing
- `cmake .. && make && ctest` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_b_68c79af8c1988328bfc0c6d0473869c5