### PR TITLE
Create gpu_image_transport package

### DIFF
--- a/gpu_image_transport/CMakeLists.txt
+++ b/gpu_image_transport/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.16)
+project(gpu_image_transport)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(ros2_cuda_ipc_core REQUIRED)
+find_package(ros2_cuda_ipc_msgs REQUIRED)
+find_package(CUDAToolkit REQUIRED)
+
+add_executable(gpu_image_transport
+  src/gpu_image_transport.cpp
+)
+
+target_link_libraries(gpu_image_transport
+  CUDA::cudart
+)
+
+ament_target_dependencies(gpu_image_transport
+  rclcpp
+  sensor_msgs
+  ros2_cuda_ipc_core
+  ros2_cuda_ipc_msgs
+)
+
+install(TARGETS
+  gpu_image_transport
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+ament_package()

--- a/gpu_image_transport/CMakeLists.txt
+++ b/gpu_image_transport/CMakeLists.txt
@@ -19,6 +19,11 @@ add_executable(gpu_image_transport
   src/gpu_image_transport.cpp
 )
 
+target_include_directories(gpu_image_transport
+  PRIVATE
+    ${CUDAToolkit_INCLUDE_DIRS}
+)
+
 target_link_libraries(gpu_image_transport
   CUDA::cudart
 )

--- a/gpu_image_transport/package.xml
+++ b/gpu_image_transport/package.xml
@@ -14,5 +14,6 @@
   <depend>ros2_cuda_ipc_msgs</depend>
 
   <export>
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/gpu_image_transport/package.xml
+++ b/gpu_image_transport/package.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <package format="3">
-  <name>julia_set</name>
-  <version>0.1.0</version>
-  <description>Julia set fractal demo leveraging ROS 2 CUDA IPC for zero-copy GPU sharing.</description>
+  <name>gpu_image_transport</name>
+  <version>0.0.0</version>
+  <description>GPU to CPU image transport node for ros2_cuda_ipc samples.</description>
   <maintainer email="dskkato@example.com">dskkato</maintainer>
   <license>MIT</license>
 
@@ -13,11 +13,6 @@
   <depend>ros2_cuda_ipc_core</depend>
   <depend>ros2_cuda_ipc_msgs</depend>
 
-  <exec_depend>rclcpp_components</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>gpu_image_transport</exec_depend>
-
   <export>
-    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/gpu_image_transport/src/gpu_image_transport.cpp
+++ b/gpu_image_transport/src/gpu_image_transport.cpp
@@ -1,6 +1,8 @@
 #include <cuda_runtime_api.h>
 
 #include <algorithm>
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <functional>
 #include <limits>
@@ -9,14 +11,26 @@
 #include <stdexcept>
 #include <string>
 
-#include "julia_set/cuda/cuda_util.hpp"
-#include "julia_set/cuda/nvtx_scoped_range.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_cuda_ipc_core/image_view.hpp"
 #include "ros2_cuda_ipc_core/type_adapters.hpp"
 #include "sensor_msgs/msg/image.hpp"
 
-namespace julia_set {
+namespace gpu_image_transport {
+
+namespace {
+
+class NvtxScopedRange {
+ public:
+  explicit NvtxScopedRange(const char *) {}
+};
+
+std::string cuda_error_to_string(cudaError_t err) {
+  const char *error_string = cudaGetErrorString(err);
+  return error_string ? std::string(error_string) : std::string{};
+}
+
+}  // namespace
 
 class GpuImageTransportNode : public rclcpp::Node {
  public:
@@ -190,8 +204,8 @@ class GpuImageTransportNode : public rclcpp::Node {
     publisher_->publish(std::move(msg));
   }
 
-  std::string describe_sample(const uint8_t *buffer,
-                              std::size_t bytes_to_copy) const {
+  [[maybe_unused]] std::string describe_sample(
+      const uint8_t *buffer, std::size_t bytes_to_copy) const {
     constexpr std::size_t kMaxElements = 16;
     std::ostringstream oss;
     if (bytes_to_copy == 0) {
@@ -280,17 +294,17 @@ class GpuImageTransportNode : public rclcpp::Node {
   cudaStream_t stream_ = nullptr;
   std::string input_topic_;
   std::string output_topic_;
-  std::size_t sample_bytes_ = 64;
+  [[maybe_unused]] std::size_t sample_bytes_ = 64;
   uint8_t *pinned_host_buffer_ = nullptr;
   std::size_t pinned_host_capacity_ = 0;
 };
 
-}  // namespace julia_set
+}  // namespace gpu_image_transport
 
 int main(int argc, char **argv) {
   rclcpp::init(argc, argv);
   try {
-    auto node = std::make_shared<julia_set::GpuImageTransportNode>();
+    auto node = std::make_shared<gpu_image_transport::GpuImageTransportNode>();
     rclcpp::spin(node);
   } catch (const std::exception &ex) {
     RCLCPP_FATAL(rclcpp::get_logger("gpu_image_transport"), "Exception: %s",

--- a/gpu_image_transport/src/gpu_image_transport.cpp
+++ b/gpu_image_transport/src/gpu_image_transport.cpp
@@ -1,13 +1,11 @@
 #include <cuda_runtime_api.h>
 
-#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <functional>
 #include <limits>
 #include <memory>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 
@@ -35,16 +33,10 @@ class GpuImageTransportNode : public rclcpp::Node {
   GpuImageTransportNode()
       : rclcpp::Node("gpu_image_transport",
                      rclcpp::NodeOptions().use_intra_process_comms(false)),
-        input_topic_(declare_parameter<std::string>("input_topic_name",
-                                                    "julia_set/colorized")),
-        output_topic_(declare_parameter<std::string>("cpu_topic_name",
-                                                     "julia_set/image_cpu")),
-        sample_bytes_(static_cast<std::size_t>(
-            declare_parameter<int>("sample_bytes", 64))) {
-    if (sample_bytes_ == 0) {
-      sample_bytes_ = 1;
-    }
-
+        input_topic_(
+            declare_parameter<std::string>("input_topic_name", "image_gpu")),
+        output_topic_(
+            declare_parameter<std::string>("cpu_topic_name", "image")) {
     const cudaError_t err =
         cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking);
     if (err != cudaSuccess) {
@@ -202,26 +194,6 @@ class GpuImageTransportNode : public rclcpp::Node {
     publisher_->publish(std::move(msg));
   }
 
-  [[maybe_unused]] std::string describe_sample(
-      const uint8_t *buffer, std::size_t bytes_to_copy) const {
-    constexpr std::size_t kMaxElements = 16;
-    std::ostringstream oss;
-    if (bytes_to_copy == 0) {
-      return "";
-    }
-    const std::size_t count = std::min(bytes_to_copy, kMaxElements);
-    for (std::size_t i = 0; i < count; ++i) {
-      if (i != 0) {
-        oss << ",";
-      }
-      oss << static_cast<unsigned>(buffer[i]);
-    }
-    if (bytes_to_copy > count) {
-      oss << ",...";
-    }
-    return oss.str();
-  }
-
   std::string infer_encoding(const ros2_cuda_ipc_core::ImageView &view) const {
     const auto channels = view.channels();
     const auto suffix = std::to_string(channels);
@@ -292,7 +264,6 @@ class GpuImageTransportNode : public rclcpp::Node {
   cudaStream_t stream_ = nullptr;
   std::string input_topic_;
   std::string output_topic_;
-  [[maybe_unused]] std::size_t sample_bytes_ = 64;
   uint8_t *pinned_host_buffer_ = nullptr;
   std::size_t pinned_host_capacity_ = 0;
 };

--- a/gpu_image_transport/src/gpu_image_transport.cpp
+++ b/gpu_image_transport/src/gpu_image_transport.cpp
@@ -13,17 +13,15 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_cuda_ipc_core/image_view.hpp"
+#include "ros2_cuda_ipc_core/nvtx_scoped_range.hpp"
 #include "ros2_cuda_ipc_core/type_adapters.hpp"
 #include "sensor_msgs/msg/image.hpp"
 
 namespace gpu_image_transport {
 
-namespace {
+using ros2_cuda_ipc_core::NvtxScopedRange;
 
-class NvtxScopedRange {
- public:
-  explicit NvtxScopedRange(const char *) {}
-};
+namespace {
 
 std::string cuda_error_to_string(cudaError_t err) {
   const char *error_string = cudaGetErrorString(err);

--- a/gpu_image_transport/src/gpu_image_transport.cpp
+++ b/gpu_image_transport/src/gpu_image_transport.cpp
@@ -31,8 +31,7 @@ std::string cuda_error_to_string(cudaError_t err) {
 class GpuImageTransportNode : public rclcpp::Node {
  public:
   GpuImageTransportNode()
-      : rclcpp::Node("gpu_image_transport",
-                     rclcpp::NodeOptions().use_intra_process_comms(false)),
+      : rclcpp::Node("gpu_image_transport"),
         input_topic_(
             declare_parameter<std::string>("input_topic_name", "image_gpu")),
         output_topic_(
@@ -100,8 +99,7 @@ class GpuImageTransportNode : public rclcpp::Node {
       return;
     }
 
-    const std::size_t bytes_to_copy =
-        static_cast<std::size_t>(view.core.byte_size);
+    const std::uint64_t bytes_to_copy = view.core.byte_size;
     if (bytes_to_copy == 0) {
       return;
     }
@@ -142,13 +140,9 @@ class GpuImageTransportNode : public rclcpp::Node {
   }
 
   void publish_cpu_image(const ros2_cuda_ipc_core::ImageView &view,
-                         std::size_t available_bytes) {
-    if (!publisher_) {
-      return;
-    }
-
-    const std::size_t height = static_cast<std::size_t>(view.rows());
-    const std::size_t step_bytes = static_cast<std::size_t>(view.strideH());
+                         std::uint64_t available_bytes) {
+    const std::uint32_t height = view.rows();
+    const std::uint64_t step_bytes = view.strideH();
     if (height == 0 || step_bytes == 0) {
       RCLCPP_WARN(
           get_logger(),
@@ -167,12 +161,12 @@ class GpuImageTransportNode : public rclcpp::Node {
     if (height > 0 &&
         step_bytes > std::numeric_limits<std::size_t>::max() / height) {
       RCLCPP_WARN(get_logger(),
-                  "Skipping publish: size overflow height=%zu step=%zu", height,
+                  "Skipping publish: size overflow height=%u step=%zu", height,
                   step_bytes);
       return;
     }
 
-    const std::size_t required_bytes = step_bytes * height;
+    const std::uint64_t required_bytes = step_bytes * height;
     if (available_bytes < required_bytes) {
       RCLCPP_WARN(
           get_logger(),

--- a/julia_set/CMakeLists.txt
+++ b/julia_set/CMakeLists.txt
@@ -65,12 +65,6 @@ target_link_libraries(colorize_node
   julia_set_helpers
 )
 
-## GPU Image Transport
-add_executable(gpu_image_transport src/gpu_image_transport.cpp)
-target_link_libraries(gpu_image_transport
-  julia_set_helpers
-)
-
 ament_target_dependencies(julia_set_publisher
   rclcpp
   sensor_msgs
@@ -84,18 +78,10 @@ ament_target_dependencies(colorize_node
   ros2_cuda_ipc_msgs
 )
 
-ament_target_dependencies(gpu_image_transport
-  rclcpp
-  sensor_msgs
-  ros2_cuda_ipc_core
-  ros2_cuda_ipc_msgs
-)
-
 install(TARGETS
   julia_set_helpers
   julia_set_publisher
   colorize_node
-  gpu_image_transport
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/julia_set/CMakeLists.txt
+++ b/julia_set/CMakeLists.txt
@@ -16,7 +16,6 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(sensor_msgs REQUIRED)
 find_package(ros2_cuda_ipc_core REQUIRED)
 find_package(ros2_cuda_ipc_msgs REQUIRED)
 find_package(CUDAToolkit REQUIRED)
@@ -67,7 +66,6 @@ target_link_libraries(colorize_node
 
 ament_target_dependencies(julia_set_publisher
   rclcpp
-  sensor_msgs
   ros2_cuda_ipc_core
   ros2_cuda_ipc_msgs
 )
@@ -111,6 +109,6 @@ if(BUILD_TESTING)
   endif()
 endif()
 
-ament_export_dependencies(rclcpp sensor_msgs ros2_cuda_ipc_core ros2_cuda_ipc_msgs)
+ament_export_dependencies(rclcpp ros2_cuda_ipc_core ros2_cuda_ipc_msgs)
 
 ament_package()

--- a/julia_set/launch/julia_set_demo.launch.py
+++ b/julia_set/launch/julia_set_demo.launch.py
@@ -180,7 +180,7 @@ def launch_setup(context) -> List[Node]:
     }
 
     transport_kwargs = dict(
-        package="julia_set",
+        package="gpu_image_transport",
         executable="gpu_image_transport",
         name="gpu_image_transport",
         parameters=[transport_params],

--- a/julia_set/package.xml
+++ b/julia_set/package.xml
@@ -9,7 +9,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
-  <depend>sensor_msgs</depend>
   <depend>ros2_cuda_ipc_core</depend>
   <depend>ros2_cuda_ipc_msgs</depend>
 

--- a/julia_set/src/colorize_node.cpp
+++ b/julia_set/src/colorize_node.cpp
@@ -9,12 +9,14 @@
 #include "julia_set/cuda/cuda_util.hpp"
 #include "julia_set/cuda/gpu_lease_pool.hpp"
 #include "julia_set/cuda/julia_kernel.hpp"
-#include "julia_set/cuda/nvtx_scoped_range.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_cuda_ipc_core/image_view.hpp"
+#include "ros2_cuda_ipc_core/nvtx_scoped_range.hpp"
 #include "ros2_cuda_ipc_core/type_adapters.hpp"
 
 namespace julia_set {
+
+using ros2_cuda_ipc_core::NvtxScopedRange;
 
 class ColorizeNode : public rclcpp::Node {
  public:

--- a/julia_set/src/julia_publisher_helper.cpp
+++ b/julia_set/src/julia_publisher_helper.cpp
@@ -21,10 +21,12 @@
 
 #include "julia_set/cuda/cuda_util.hpp"
 #include "julia_set/cuda/julia_kernel.hpp"
-#include "julia_set/cuda/nvtx_scoped_range.hpp"
 #include "rclcpp/logging.hpp"
+#include "ros2_cuda_ipc_core/nvtx_scoped_range.hpp"
 
 namespace julia_set {
+
+using ros2_cuda_ipc_core::NvtxScopedRange;
 namespace {
 
 uint32_t dtype_bytes(ros2_cuda_ipc_core::DType dtype) {

--- a/julia_set/src/julia_set_publisher.cpp
+++ b/julia_set/src/julia_set_publisher.cpp
@@ -4,12 +4,14 @@
 #include <stdexcept>
 #include <string>
 
-#include "julia_set/cuda/nvtx_scoped_range.hpp"
 #include "julia_set/julia_publisher_helper.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "ros2_cuda_ipc_core/nvtx_scoped_range.hpp"
 #include "ros2_cuda_ipc_core/type_adapters.hpp"
 
 namespace julia_set {
+
+using ros2_cuda_ipc_core::NvtxScopedRange;
 namespace {
 
 ros2_cuda_ipc_core::DType parse_dtype(const std::string &name) {

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/nvtx_scoped_range.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/nvtx_scoped_range.hpp
@@ -2,7 +2,7 @@
 
 #include <nvtx3/nvToolsExt.h>
 
-namespace julia_set {
+namespace ros2_cuda_ipc_core {
 
 class NvtxScopedRange {
  public:
@@ -19,4 +19,4 @@ class NvtxScopedRange {
   nvtxRangeId_t id_{};
 };
 
-}  // namespace julia_set
+}  // namespace ros2_cuda_ipc_core


### PR DESCRIPTION
## Summary
- add a dedicated gpu_image_transport package that builds the image transport node with the required ROS 2 and CUDA dependencies
- adjust the node implementation to live under the new package namespace and continue publishing CPU images from GPU views
- update the julia_set build, launch file, and runtime dependencies to rely on the new package

## Testing
- not run (colcon is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_b_68da649645f48328abeb165e7bd5be1a