### PR TITLE
Add optional tracing for sample helpers

### DIFF
--- a/sample_nodes/CMakeLists.txt
+++ b/sample_nodes/CMakeLists.txt
@@ -5,6 +5,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+option(SAMPLE_NODES_ENABLE_TRACING "Enable LTTng tracepoints for sample_nodes" OFF)
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra)
 endif()
@@ -16,9 +18,18 @@ find_package(ros2_cuda_ipc_core REQUIRED)
 find_package(ros2_cuda_ipc_msgs REQUIRED)
 find_package(CUDAToolkit REQUIRED)
 
+if(SAMPLE_NODES_ENABLE_TRACING)
+  find_package(LTTngUST QUIET)
+  if(NOT LTTngUST_FOUND)
+    message(WARNING "LTTngUST not found; disabling SAMPLE_NODES_ENABLE_TRACING")
+    set(SAMPLE_NODES_ENABLE_TRACING OFF)
+  endif()
+endif()
+
 add_library(sample_nodes_helpers
   src/gpu_image_publisher_helper.cpp
   src/gpu_pointcloud_publisher_helper.cpp
+  $<$<BOOL:${SAMPLE_NODES_ENABLE_TRACING}>:src/tracing.cpp>
 )
 
 target_include_directories(sample_nodes_helpers
@@ -33,6 +44,18 @@ ament_target_dependencies(sample_nodes_helpers
   ros2_cuda_ipc_core
   ros2_cuda_ipc_msgs
 )
+
+if(SAMPLE_NODES_ENABLE_TRACING)
+  if(TARGET LTTng::UST)
+    target_compile_definitions(sample_nodes_helpers PUBLIC SAMPLE_NODES_ENABLE_TRACING)
+    target_link_libraries(sample_nodes_helpers LTTng::UST)
+  elseif(TARGET LTTngUST::lttng-ust)
+    target_compile_definitions(sample_nodes_helpers PUBLIC SAMPLE_NODES_ENABLE_TRACING)
+    target_link_libraries(sample_nodes_helpers LTTngUST::lttng-ust)
+  else()
+    message(WARNING "No LTTng UST target available; disabling tracing support")
+  endif()
+endif()
 
 target_link_libraries(sample_nodes_helpers
   CUDA::cudart

--- a/sample_nodes/include/sample_nodes/tracing.hpp
+++ b/sample_nodes/include/sample_nodes/tracing.hpp
@@ -12,68 +12,115 @@
 
 #include <lttng/tracepoint.h>
 
-TRACEPOINT_EVENT(sample_nodes, slot_selection,
-                 TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t,
-                         byte_size, int32_t, device_id, int32_t, result),
-                 TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id) ctf_integer(
-                     uint64_t, generation, generation)
-                               ctf_integer(uint64_t, byte_size, byte_size)
-                                   ctf_integer(int32_t, device_id, device_id)
-                                       ctf_integer(int32_t, result, result)))
+TRACEPOINT_EVENT(
+    /* Tracepoint provide name */
+    sample_nodes,
+    /* Tracepoint name */
+    slot_selection,
+    /* List of tracepoint arguments (input) */
+    TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t, byte_size,
+            int32_t, device_id, int32_t, result),
+    /* List of fields of eventual event (output) */
+    TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id)         //
+              ctf_integer(uint64_t, generation, generation)  //
+              ctf_integer(uint64_t, byte_size, byte_size)    //
+              ctf_integer(int32_t, device_id, device_id)     //
+              ctf_integer(int32_t, result, result))          //
+)
 
-TRACEPOINT_EVENT(sample_nodes, generation_bump,
-                 TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t,
-                         byte_size, int32_t, device_id, int32_t, result),
-                 TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id) ctf_integer(
-                     uint64_t, generation, generation)
-                               ctf_integer(uint64_t, byte_size, byte_size)
-                                   ctf_integer(int32_t, device_id, device_id)
-                                       ctf_integer(int32_t, result, result)))
+TRACEPOINT_EVENT(
+    /* Tracepoint provide name */
+    sample_nodes,
+    /* Tracepoint name */
+    generation_bump,
+    /* List of tracepoint arguments (input) */
+    TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t, byte_size,
+            int32_t, device_id, int32_t, result),
+    /* List of fields of eventual event (output) */
+    TP_FIELDS(                                         //
+        ctf_integer(int32_t, slot_id, slot_id)         //
+        ctf_integer(uint64_t, generation, generation)  //
+        ctf_integer(uint64_t, byte_size, byte_size)    //
+        ctf_integer(int32_t, device_id, device_id)     //
+        ctf_integer(int32_t, result, result))          //
+)
 
-TRACEPOINT_EVENT(sample_nodes, cuda_memset_start,
-                 TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t,
-                         byte_size, int32_t, device_id),
-                 TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id)
-                               ctf_integer(uint64_t, generation, generation)
-                                   ctf_integer(uint64_t, byte_size, byte_size)
-                                       ctf_integer(int32_t, device_id,
-                                                   device_id)))
+TRACEPOINT_EVENT(
+    /* Tracepoint provide name */
+    sample_nodes,
+    /* Tracepoint name */
+    cuda_memset_start,
+    /* List of tracepoint arguments (input) */
+    TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t, byte_size,
+            int32_t, device_id),
+    /* List of fields of eventual event (output) */
+    TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id)         //
+              ctf_integer(uint64_t, generation, generation)  //
+              ctf_integer(uint64_t, byte_size, byte_size)    //
+              ctf_integer(int32_t, device_id, device_id))    //
+)
 
-TRACEPOINT_EVENT(sample_nodes, cuda_memset_stop,
-                 TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t,
-                         byte_size, int32_t, device_id, int32_t, result),
-                 TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id) ctf_integer(
-                     uint64_t, generation, generation)
-                               ctf_integer(uint64_t, byte_size, byte_size)
-                                   ctf_integer(int32_t, device_id, device_id)
-                                       ctf_integer(int32_t, result, result)))
+TRACEPOINT_EVENT(
+    /* Tracepoint provide name */
+    sample_nodes,
+    /* Tracepoint name */
+    cuda_memset_stop,
+    /* List of tracepoint arguments (input) */
+    TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t, byte_size,
+            int32_t, device_id, int32_t, result),
+    /* List of fields of eventual event (output) */
+    TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id)         //
+              ctf_integer(uint64_t, generation, generation)  //
+              ctf_integer(uint64_t, byte_size, byte_size)    //
+              ctf_integer(int32_t, device_id, device_id)     //
+              ctf_integer(int32_t, result, result))          //
+)
 
-TRACEPOINT_EVENT(sample_nodes, event_record,
-                 TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t,
-                         byte_size, int32_t, device_id, int32_t, result),
-                 TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id) ctf_integer(
-                     uint64_t, generation, generation)
-                               ctf_integer(uint64_t, byte_size, byte_size)
-                                   ctf_integer(int32_t, device_id, device_id)
-                                       ctf_integer(int32_t, result, result)))
+TRACEPOINT_EVENT(
+    /* Tracepoint provide name */
+    sample_nodes,
+    /* Tracepoint name */
+    event_record,
+    /* List of tracepoint arguments (input) */
+    TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t, byte_size,
+            int32_t, device_id, int32_t, result),
+    /* List of fields of eventual event (output) */
+    TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id)         //
+              ctf_integer(uint64_t, generation, generation)  //
+              ctf_integer(uint64_t, byte_size, byte_size)    //
+              ctf_integer(int32_t, device_id, device_id)     //
+              ctf_integer(int32_t, result, result))          //
+)
 
-TRACEPOINT_EVENT(sample_nodes, stream_sync,
-                 TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t,
-                         byte_size, int32_t, device_id, int32_t, result),
-                 TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id) ctf_integer(
-                     uint64_t, generation, generation)
-                               ctf_integer(uint64_t, byte_size, byte_size)
-                                   ctf_integer(int32_t, device_id, device_id)
-                                       ctf_integer(int32_t, result, result)))
-
-TRACEPOINT_EVENT(sample_nodes, message_publication,
-                 TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t,
-                         byte_size, int32_t, device_id),
-                 TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id)
-                               ctf_integer(uint64_t, generation, generation)
-                                   ctf_integer(uint64_t, byte_size, byte_size)
-                                       ctf_integer(int32_t, device_id,
-                                                   device_id)))
+TRACEPOINT_EVENT(
+    /* Tracepoint provide name */
+    sample_nodes,
+    /* Tracepoint name */
+    stream_sync,
+    /* List of tracepoint arguments (input) */
+    TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t, byte_size,
+            int32_t, device_id, int32_t, result),
+    /* List of fields of eventual event (output) */
+    TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id)         //
+              ctf_integer(uint64_t, generation, generation)  //
+              ctf_integer(uint64_t, byte_size, byte_size)    //
+              ctf_integer(int32_t, device_id, device_id)     //
+              ctf_integer(int32_t, result, result))          //
+)
+TRACEPOINT_EVENT(
+    /* Tracepoint provide name */
+    sample_nodes,
+    /* Tracepoint name */
+    message_publication,
+    /* List of tracepoint arguments (input) */
+    TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t, byte_size,
+            int32_t, device_id),
+    /* List of fields of eventual event (output) */
+    TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id)         //
+              ctf_integer(uint64_t, generation, generation)  //
+              ctf_integer(uint64_t, byte_size, byte_size)    //
+              ctf_integer(int32_t, device_id, device_id))    //
+)
 
 #endif  // defined(SAMPLE_NODES_ENABLE_TRACING) &&
         // (!defined(_SAMPLE_NODES_TRACEPOINTS_H) ||

--- a/sample_nodes/include/sample_nodes/tracing.hpp
+++ b/sample_nodes/include/sample_nodes/tracing.hpp
@@ -1,0 +1,156 @@
+#pragma once
+
+#include <cstdint>
+
+#define TRACEPOINT_PROVIDER sample_nodes
+#define TRACEPOINT_INCLUDE "sample_nodes/tracing.hpp"
+
+#if defined(SAMPLE_NODES_ENABLE_TRACING) &&   \
+    (!defined(_SAMPLE_NODES_TRACEPOINTS_H) || \
+     defined(TRACEPOINT_HEADER_MULTI_READ))
+#define _SAMPLE_NODES_TRACEPOINTS_H
+
+#include <lttng/tracepoint.h>
+
+TRACEPOINT_EVENT(sample_nodes, slot_selection,
+                 TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t,
+                         byte_size, int32_t, device_id, int32_t, result),
+                 TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id) ctf_integer(
+                     uint64_t, generation, generation)
+                               ctf_integer(uint64_t, byte_size, byte_size)
+                                   ctf_integer(int32_t, device_id, device_id)
+                                       ctf_integer(int32_t, result, result)))
+
+TRACEPOINT_EVENT(sample_nodes, generation_bump,
+                 TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t,
+                         byte_size, int32_t, device_id, int32_t, result),
+                 TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id) ctf_integer(
+                     uint64_t, generation, generation)
+                               ctf_integer(uint64_t, byte_size, byte_size)
+                                   ctf_integer(int32_t, device_id, device_id)
+                                       ctf_integer(int32_t, result, result)))
+
+TRACEPOINT_EVENT(sample_nodes, cuda_memset_start,
+                 TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t,
+                         byte_size, int32_t, device_id),
+                 TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id)
+                               ctf_integer(uint64_t, generation, generation)
+                                   ctf_integer(uint64_t, byte_size, byte_size)
+                                       ctf_integer(int32_t, device_id,
+                                                   device_id)))
+
+TRACEPOINT_EVENT(sample_nodes, cuda_memset_stop,
+                 TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t,
+                         byte_size, int32_t, device_id, int32_t, result),
+                 TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id) ctf_integer(
+                     uint64_t, generation, generation)
+                               ctf_integer(uint64_t, byte_size, byte_size)
+                                   ctf_integer(int32_t, device_id, device_id)
+                                       ctf_integer(int32_t, result, result)))
+
+TRACEPOINT_EVENT(sample_nodes, event_record,
+                 TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t,
+                         byte_size, int32_t, device_id, int32_t, result),
+                 TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id) ctf_integer(
+                     uint64_t, generation, generation)
+                               ctf_integer(uint64_t, byte_size, byte_size)
+                                   ctf_integer(int32_t, device_id, device_id)
+                                       ctf_integer(int32_t, result, result)))
+
+TRACEPOINT_EVENT(sample_nodes, stream_sync,
+                 TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t,
+                         byte_size, int32_t, device_id, int32_t, result),
+                 TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id) ctf_integer(
+                     uint64_t, generation, generation)
+                               ctf_integer(uint64_t, byte_size, byte_size)
+                                   ctf_integer(int32_t, device_id, device_id)
+                                       ctf_integer(int32_t, result, result)))
+
+TRACEPOINT_EVENT(sample_nodes, message_publication,
+                 TP_ARGS(int32_t, slot_id, uint64_t, generation, uint64_t,
+                         byte_size, int32_t, device_id),
+                 TP_FIELDS(ctf_integer(int32_t, slot_id, slot_id)
+                               ctf_integer(uint64_t, generation, generation)
+                                   ctf_integer(uint64_t, byte_size, byte_size)
+                                       ctf_integer(int32_t, device_id,
+                                                   device_id)))
+
+#endif  // defined(SAMPLE_NODES_ENABLE_TRACING) &&
+        // (!defined(_SAMPLE_NODES_TRACEPOINTS_H) ||
+        // defined(TRACEPOINT_HEADER_MULTI_READ))
+
+#if defined(SAMPLE_NODES_ENABLE_TRACING)
+#include <lttng/tracepoint-event.h>
+#endif
+
+#if defined(SAMPLE_NODES_ENABLE_TRACING)
+#define SAMPLE_NODES_TRACE_SLOT_SELECTION(slot_id, generation, byte_size,  \
+                                          device_id, result)               \
+  tracepoint(sample_nodes, slot_selection, slot_id, generation, byte_size, \
+             device_id, result)
+
+#define SAMPLE_NODES_TRACE_GENERATION_BUMP(slot_id, generation, byte_size,  \
+                                           device_id, result)               \
+  tracepoint(sample_nodes, generation_bump, slot_id, generation, byte_size, \
+             device_id, result)
+
+#define SAMPLE_NODES_TRACE_CUDA_MEMSET_START(slot_id, generation, byte_size,  \
+                                             device_id)                       \
+  tracepoint(sample_nodes, cuda_memset_start, slot_id, generation, byte_size, \
+             device_id)
+
+#define SAMPLE_NODES_TRACE_CUDA_MEMSET_STOP(slot_id, generation, byte_size,  \
+                                            device_id, result)               \
+  tracepoint(sample_nodes, cuda_memset_stop, slot_id, generation, byte_size, \
+             device_id, result)
+
+#define SAMPLE_NODES_TRACE_EVENT_RECORD(slot_id, generation, byte_size,  \
+                                        device_id, result)               \
+  tracepoint(sample_nodes, event_record, slot_id, generation, byte_size, \
+             device_id, result)
+
+#define SAMPLE_NODES_TRACE_STREAM_SYNC(slot_id, generation, byte_size,  \
+                                       device_id, result)               \
+  tracepoint(sample_nodes, stream_sync, slot_id, generation, byte_size, \
+             device_id, result)
+
+#define SAMPLE_NODES_TRACE_MESSAGE_PUBLICATION(slot_id, generation, byte_size, \
+                                               device_id)                      \
+  tracepoint(sample_nodes, message_publication, slot_id, generation,           \
+             byte_size, device_id)
+#else
+#define SAMPLE_NODES_TRACE_SLOT_SELECTION(slot_id, generation, byte_size, \
+                                          device_id, result)              \
+  do {                                                                    \
+  } while (false)
+
+#define SAMPLE_NODES_TRACE_GENERATION_BUMP(slot_id, generation, byte_size, \
+                                           device_id, result)              \
+  do {                                                                     \
+  } while (false)
+
+#define SAMPLE_NODES_TRACE_CUDA_MEMSET_START(slot_id, generation, byte_size, \
+                                             device_id)                      \
+  do {                                                                       \
+  } while (false)
+
+#define SAMPLE_NODES_TRACE_CUDA_MEMSET_STOP(slot_id, generation, byte_size, \
+                                            device_id, result)              \
+  do {                                                                      \
+  } while (false)
+
+#define SAMPLE_NODES_TRACE_EVENT_RECORD(slot_id, generation, byte_size, \
+                                        device_id, result)              \
+  do {                                                                  \
+  } while (false)
+
+#define SAMPLE_NODES_TRACE_STREAM_SYNC(slot_id, generation, byte_size, \
+                                       device_id, result)              \
+  do {                                                                 \
+  } while (false)
+
+#define SAMPLE_NODES_TRACE_MESSAGE_PUBLICATION(slot_id, generation, byte_size, \
+                                               device_id)                      \
+  do {                                                                         \
+  } while (false)
+#endif

--- a/sample_nodes/include/sample_nodes/tracing.hpp
+++ b/sample_nodes/include/sample_nodes/tracing.hpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include <cstdint>
 
 #define TRACEPOINT_PROVIDER sample_nodes

--- a/sample_nodes/src/gpu_image_publisher.cpp
+++ b/sample_nodes/src/gpu_image_publisher.cpp
@@ -5,6 +5,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_cuda_ipc_core/type_adapters.hpp"
 #include "sample_nodes/gpu_image_publisher_helper.hpp"
+#include "sample_nodes/tracing.hpp"
 
 namespace sample_nodes {
 namespace {
@@ -100,6 +101,9 @@ class GpuImagePublisherNode : public rclcpp::Node {
     view->header.stamp = now();
     view->header.frame_id = frame_id_;
     publisher_->publish(*view);
+    SAMPLE_NODES_TRACE_MESSAGE_PUBLICATION(
+        static_cast<int32_t>(view->core.slot_id), view->core.generation,
+        view->core.byte_size, view->core.device_id);
     ++frame_counter_;
   }
 

--- a/sample_nodes/src/gpu_image_publisher_helper.cpp
+++ b/sample_nodes/src/gpu_image_publisher_helper.cpp
@@ -5,6 +5,7 @@
 
 #include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/cuda/cuda_util.hpp"
+#include "sample_nodes/tracing.hpp"
 
 namespace sample_nodes {
 namespace {
@@ -127,12 +128,19 @@ std::optional<ros2_cuda_ipc_core::ImageView> GpuImagePublisherHelper::produce(
 
   auto free_slot =
       ros2_cuda_ipc_core::LeaseHandle::choose_empty_slot(config_.shm_name);
+  SAMPLE_NODES_TRACE_SLOT_SELECTION(
+      free_slot.has_value() ? static_cast<int32_t>(free_slot.value()) : -1,
+      free_slot.has_value() ? slots_[free_slot.value()].generation : 0,
+      frame_size_bytes_, config_.device_index, free_slot.has_value() ? 1 : 0);
   if (!free_slot.has_value()) {
     RCLCPP_WARN(rclcpp::get_logger("GpuImagePublisherHelper"),
                 "No available GPU slots (all leases in use)");
     return std::nullopt;
   }
   if (free_slot.value() >= slots_.size()) {
+    SAMPLE_NODES_TRACE_SLOT_SELECTION(static_cast<int32_t>(free_slot.value()),
+                                      0, frame_size_bytes_,
+                                      config_.device_index, 0);
     RCLCPP_ERROR(rclcpp::get_logger("GpuImagePublisherHelper"),
                  "LeaseHandle returned invalid slot index %u",
                  free_slot.value());
@@ -144,11 +152,17 @@ std::optional<ros2_cuda_ipc_core::ImageView> GpuImagePublisherHelper::produce(
   auto gen = ros2_cuda_ipc_core::LeaseHandle::bump_generation(
       config_.shm_name, slot.index, subscriber_count);
   if (!gen.has_value()) {
+    SAMPLE_NODES_TRACE_GENERATION_BUMP(static_cast<int32_t>(slot.index),
+                                       slot.generation, frame_size_bytes_,
+                                       config_.device_index, 0);
     RCLCPP_WARN(rclcpp::get_logger("GpuImagePublisherHelper"),
                 "Failed to bump generation for slot %u", slot.index);
     return std::nullopt;
   }
   slot.generation = gen.value();
+  SAMPLE_NODES_TRACE_GENERATION_BUMP(static_cast<int32_t>(slot.index),
+                                     slot.generation, frame_size_bytes_,
+                                     config_.device_index, 1);
 
   const auto now = std::chrono::steady_clock::now();
   if (subscriber_count > 0 && config_.pending_ttl.count() > 0) {
@@ -157,31 +171,52 @@ std::optional<ros2_cuda_ipc_core::ImageView> GpuImagePublisherHelper::produce(
     slot.pending_deadline = {};
   }
 
+  SAMPLE_NODES_TRACE_CUDA_MEMSET_START(static_cast<int32_t>(slot.index),
+                                       slot.generation, frame_size_bytes_,
+                                       config_.device_index);
   cudaError_t err =
       cudaMemsetAsync(slot.device_ptr, fill_value, frame_size_bytes_, stream_);
   if (err != cudaSuccess) {
+    SAMPLE_NODES_TRACE_CUDA_MEMSET_STOP(static_cast<int32_t>(slot.index),
+                                        slot.generation, frame_size_bytes_,
+                                        config_.device_index, 0);
     RCLCPP_ERROR(rclcpp::get_logger("GpuImagePublisherHelper"),
                  "cudaMemsetAsync failed: %s",
                  cuda_error_to_string(err).c_str());
     return std::nullopt;
   }
+  SAMPLE_NODES_TRACE_CUDA_MEMSET_STOP(static_cast<int32_t>(slot.index),
+                                      slot.generation, frame_size_bytes_,
+                                      config_.device_index, 1);
 
   err = cudaEventRecord(slot.event, stream_);
   if (err != cudaSuccess) {
+    SAMPLE_NODES_TRACE_EVENT_RECORD(static_cast<int32_t>(slot.index),
+                                    slot.generation, frame_size_bytes_,
+                                    config_.device_index, 0);
     RCLCPP_ERROR(rclcpp::get_logger("GpuImagePublisherHelper"),
                  "cudaEventRecord failed: %s",
                  cuda_error_to_string(err).c_str());
     return std::nullopt;
   }
+  SAMPLE_NODES_TRACE_EVENT_RECORD(static_cast<int32_t>(slot.index),
+                                  slot.generation, frame_size_bytes_,
+                                  config_.device_index, 1);
 
   // optional wait to ensure data ready for demo (event ensures consumer waits)
   err = cudaStreamSynchronize(stream_);
   if (err != cudaSuccess) {
+    SAMPLE_NODES_TRACE_STREAM_SYNC(static_cast<int32_t>(slot.index),
+                                   slot.generation, frame_size_bytes_,
+                                   config_.device_index, 0);
     RCLCPP_ERROR(rclcpp::get_logger("GpuImagePublisherHelper"),
                  "cudaStreamSynchronize failed: %s",
                  cuda_error_to_string(err).c_str());
     return std::nullopt;
   }
+  SAMPLE_NODES_TRACE_STREAM_SYNC(static_cast<int32_t>(slot.index),
+                                 slot.generation, frame_size_bytes_,
+                                 config_.device_index, 1);
 
   ros2_cuda_ipc_core::ImageView view;
   view.core.dev_ptr = slot.device_ptr;

--- a/sample_nodes/src/gpu_pointcloud_publisher.cpp
+++ b/sample_nodes/src/gpu_pointcloud_publisher.cpp
@@ -5,6 +5,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_cuda_ipc_core/type_adapters.hpp"
 #include "sample_nodes/gpu_pointcloud_publisher_helper.hpp"
+#include "sample_nodes/tracing.hpp"
 
 namespace sample_nodes {
 class GpuPointCloudPublisherNode : public rclcpp::Node {
@@ -65,6 +66,9 @@ class GpuPointCloudPublisherNode : public rclcpp::Node {
     view->header.stamp = now();
     view->header.frame_id = frame_id_;
     publisher_->publish(*view);
+    SAMPLE_NODES_TRACE_MESSAGE_PUBLICATION(
+        static_cast<int32_t>(view->core.slot_id), view->core.generation,
+        view->core.byte_size, view->core.device_id);
     ++frame_counter_;
   }
 

--- a/sample_nodes/src/gpu_pointcloud_publisher_helper.cpp
+++ b/sample_nodes/src/gpu_pointcloud_publisher_helper.cpp
@@ -6,6 +6,7 @@
 
 #include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/cuda/cuda_util.hpp"
+#include "sample_nodes/tracing.hpp"
 #include "sensor_msgs/msg/point_field.hpp"
 
 namespace sample_nodes {
@@ -123,12 +124,19 @@ GpuPointCloudPublisherHelper::produce(size_t subscriber_count, float value) {
 
   auto free_slot =
       ros2_cuda_ipc_core::LeaseHandle::choose_empty_slot(config_.shm_name);
+  SAMPLE_NODES_TRACE_SLOT_SELECTION(
+      free_slot.has_value() ? static_cast<int32_t>(free_slot.value()) : -1,
+      free_slot.has_value() ? slots_[free_slot.value()].generation : 0,
+      cloud_size_bytes_, config_.device_index, free_slot.has_value() ? 1 : 0);
   if (!free_slot.has_value()) {
     RCLCPP_WARN(rclcpp::get_logger("GpuPointCloudPublisherHelper"),
                 "No available GPU slots (all leases in use)");
     return std::nullopt;
   }
   if (free_slot.value() >= slots_.size()) {
+    SAMPLE_NODES_TRACE_SLOT_SELECTION(static_cast<int32_t>(free_slot.value()),
+                                      0, cloud_size_bytes_,
+                                      config_.device_index, 0);
     RCLCPP_ERROR(rclcpp::get_logger("GpuPointCloudPublisherHelper"),
                  "LeaseHandle returned invalid slot index %u",
                  free_slot.value());
@@ -140,11 +148,17 @@ GpuPointCloudPublisherHelper::produce(size_t subscriber_count, float value) {
   auto gen = ros2_cuda_ipc_core::LeaseHandle::bump_generation(
       config_.shm_name, slot.index, subscriber_count);
   if (!gen.has_value()) {
+    SAMPLE_NODES_TRACE_GENERATION_BUMP(static_cast<int32_t>(slot.index),
+                                       slot.generation, cloud_size_bytes_,
+                                       config_.device_index, 0);
     RCLCPP_WARN(rclcpp::get_logger("GpuPointCloudPublisherHelper"),
                 "Failed to bump generation for slot %u", slot.index);
     return std::nullopt;
   }
   slot.generation = gen.value();
+  SAMPLE_NODES_TRACE_GENERATION_BUMP(static_cast<int32_t>(slot.index),
+                                     slot.generation, cloud_size_bytes_,
+                                     config_.device_index, 1);
 
   const auto now = std::chrono::steady_clock::now();
   if (subscriber_count > 0 && config_.pending_ttl.count() > 0) {
@@ -163,11 +177,17 @@ GpuPointCloudPublisherHelper::produce(size_t subscriber_count, float value) {
 
   err = cudaEventRecord(slot.event, stream_);
   if (err != cudaSuccess) {
+    SAMPLE_NODES_TRACE_EVENT_RECORD(static_cast<int32_t>(slot.index),
+                                    slot.generation, cloud_size_bytes_,
+                                    config_.device_index, 0);
     RCLCPP_ERROR(rclcpp::get_logger("GpuPointCloudPublisherHelper"),
                  "cudaEventRecord failed: %s",
                  cuda_error_to_string(err).c_str());
     return std::nullopt;
   }
+  SAMPLE_NODES_TRACE_EVENT_RECORD(static_cast<int32_t>(slot.index),
+                                  slot.generation, cloud_size_bytes_,
+                                  config_.device_index, 1);
 
   ros2_cuda_ipc_core::PointCloud2View view;
   view.core.dev_ptr = slot.device_ptr;

--- a/sample_nodes/src/tracing.cpp
+++ b/sample_nodes/src/tracing.cpp
@@ -1,0 +1,7 @@
+#include "sample_nodes/tracing.hpp"
+
+#if defined(SAMPLE_NODES_ENABLE_TRACING)
+#define TRACEPOINT_CREATE_PROBES
+#define TRACEPOINT_DEFINE
+#include "sample_nodes/tracing.hpp"
+#endif

--- a/sample_nodes/src/tracing.cpp
+++ b/sample_nodes/src/tracing.cpp
@@ -1,7 +1,5 @@
-#include "sample_nodes/tracing.hpp"
-
 #if defined(SAMPLE_NODES_ENABLE_TRACING)
 #define TRACEPOINT_CREATE_PROBES
 #define TRACEPOINT_DEFINE
-#include "sample_nodes/tracing.hpp"
 #endif
+#include "sample_nodes/tracing.hpp"


### PR DESCRIPTION
## Summary
- add an optional tracing provider with LTTng tracepoints and build toggles for sample_nodes
- instrument GPU image and point cloud helpers/publishers with trace events around slot selection, generation bumps, CUDA operations, and message publication
- expose reusable tracing macros and provider probe registration for correlated tracing data

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6923ca63bb948328830a22776e5dcade)