### PR TITLE
Fix several issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,25 +43,7 @@ jobs:
             --event-handlers console_direct+ \
             --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
-      - name: Detect CUDA availability
-        id: cuda-check
-        run: |
-          set -eo pipefail
-          if command -v nvidia-smi >/dev/null 2>&1; then
-            echo "cuda=true" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          if [ -e /proc/driver/nvidia/version ] || [ -d /dev/nvidia0 ]; then
-            echo "cuda=true" >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
-
-          echo "CUDA devices not detected; tests will be skipped." >&2
-          echo "cuda=false" >> "${GITHUB_OUTPUT}"
-
       - name: Run tests
-        if: steps.cuda-check.outputs.cuda == 'true'
         run: |
           set -eo pipefail
           source "/opt/ros/${ROS_DISTRO}/setup.bash"
@@ -70,16 +52,10 @@ jobs:
             --packages-skip example_type_adapters julia_set_original simple_increment
 
       - name: Check test results
-        if: steps.cuda-check.outputs.cuda == 'true'
         run: |
           set -eo pipefail
           source "/opt/ros/${ROS_DISTRO}/setup.bash"
           colcon test-result --verbose
-
-      - name: Skip tests (no CUDA detected)
-        if: steps.cuda-check.outputs.cuda != 'true'
-        run: |
-          echo "Skipping colcon test because CUDA is unavailable on this runner."
 
       - name: Upload test logs on failure
         if: ${{ failure() }}

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/type_adapters.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/type_adapters.hpp
@@ -385,6 +385,13 @@ struct TypeAdapter<ros2_cuda_ipc_core::BufferView,
     void *dev_ptr = nullptr;
     cudaEvent_t evt = nullptr;
 
+    auto close_opened_event = [&evt]() {
+      if (evt) {
+        cudaEventDestroy(evt);
+        evt = nullptr;
+      }
+    };
+
     {
       std::lock_guard<std::mutex> lock(
           ros2_cuda_ipc_core::detail::ipc_handle_cache_mutex());
@@ -418,14 +425,7 @@ struct TypeAdapter<ros2_cuda_ipc_core::BufferView,
           RCLCPP_WARN(rclcpp::get_logger("ros2_cuda_ipc_core.BufferView"),
                       "cudaIpcOpenMemHandle failed: %s",
                       cudaGetErrorString(err));
-          view = ros2_cuda_ipc_core::BufferView{};
-          return;
-        }
-        if (err != cudaSuccess) {
-          cudaIpcCloseMemHandle(dev_ptr);
-          RCLCPP_WARN(rclcpp::get_logger("ros2_cuda_ipc_core.BufferView"),
-                      "cudaIpcOpenEventHandle failed: %s",
-                      cudaGetErrorString(err));
+          close_opened_event();
           view = ros2_cuda_ipc_core::BufferView{};
           return;
         }
@@ -448,6 +448,7 @@ struct TypeAdapter<ros2_cuda_ipc_core::BufferView,
             msg.mem_handle, msg.device_id,
             static_cast<std::size_t>(msg.byte_size), logger);
         if (!vmm_result.has_value()) {
+          close_opened_event();
           view = ros2_cuda_ipc_core::BufferView{};
           return;
         }

--- a/ros2_cuda_ipc_core/package.xml
+++ b/ros2_cuda_ipc_core/package.xml
@@ -11,6 +11,8 @@
   <depend>rclcpp</depend>
   <depend>rcpputils</depend>
   <depend>ros2_cuda_ipc_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
   <build_depend>libuuid</build_depend>
   <exec_depend>libuuid</exec_depend>
 

--- a/ros2_cuda_ipc_core/src/lease_handle.cpp
+++ b/ros2_cuda_ipc_core/src/lease_handle.cpp
@@ -356,6 +356,7 @@ LeaseHandle LeaseHandle::acquire(const std::string &shm_name, uint32_t slot_id,
 
   const uint32_t prev = ref.fetch_add(1, std::memory_order_acq_rel);
   if (prev == UINT32_MAX) {
+    ref.fetch_sub(1, std::memory_order_acq_rel);
     RCLCPP_ERROR(lease_logger(), "lease:ref_overflow slot=%u", slot_id);
     return LeaseHandle{};
   }

--- a/ros2_cuda_ipc_core/src/lease_handle.cpp
+++ b/ros2_cuda_ipc_core/src/lease_handle.cpp
@@ -354,11 +354,17 @@ LeaseHandle LeaseHandle::acquire(const std::string &shm_name, uint32_t slot_id,
     return LeaseHandle{};
   }
 
-  const uint32_t prev = ref.fetch_add(1, std::memory_order_acq_rel);
-  if (prev == UINT32_MAX) {
-    ref.fetch_sub(1, std::memory_order_acq_rel);
-    RCLCPP_ERROR(lease_logger(), "lease:ref_overflow slot=%u", slot_id);
-    return LeaseHandle{};
+  uint32_t observed_ref = ref.load(std::memory_order_acquire);
+  while (true) {
+    if (observed_ref == UINT32_MAX) {
+      RCLCPP_ERROR(lease_logger(), "lease:ref_overflow slot=%u", slot_id);
+      return LeaseHandle{};
+    }
+    if (ref.compare_exchange_weak(observed_ref, observed_ref + 1,
+                                  std::memory_order_acq_rel,
+                                  std::memory_order_acquire)) {
+      break;
+    }
   }
 
   const uint32_t recheck_gen = gen.load(std::memory_order_acquire);

--- a/ros2_cuda_ipc_core/test/test_gpu_lease_pool.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_lease_pool.cpp
@@ -1,3 +1,4 @@
+#include <cuda_runtime_api.h>
 #include <gtest/gtest.h>
 #include <sys/mman.h>
 #include <unistd.h>
@@ -25,7 +26,24 @@ std::string make_unique_shm_name(const std::string &prefix) {
 
 using ros2_cuda_ipc_core::cuda::GpuLeasePool;
 
-TEST(GpuLeasePoolTest, InitialiseAndAcquireSetsPendingWhenSubscribersPresent) {
+class GpuLeasePoolTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    int device_count = 0;
+    auto err = cudaGetDeviceCount(&device_count);
+    if (err != cudaSuccess || device_count == 0) {
+      GTEST_SKIP() << "CUDA device not available for tests";
+    }
+
+    err = cudaSetDevice(0);
+    if (err != cudaSuccess) {
+      GTEST_SKIP() << "Failed to select CUDA device 0";
+    }
+  }
+};
+
+TEST_F(GpuLeasePoolTest,
+       InitialiseAndAcquireSetsPendingWhenSubscribersPresent) {
   const std::string shm_name = make_unique_shm_name("gpu_pool_basic");
   auto logger = rclcpp::get_logger("GpuLeasePoolTest");
   GpuLeasePool pool({shm_name, 2, std::chrono::milliseconds(100)}, logger);
@@ -53,7 +71,7 @@ TEST(GpuLeasePoolTest, InitialiseAndAcquireSetsPendingWhenSubscribersPresent) {
   ::shm_unlink(shm_name.c_str());
 }
 
-TEST(GpuLeasePoolTest, AcquireWithoutSubscribersDoesNotSetPendingDeadline) {
+TEST_F(GpuLeasePoolTest, AcquireWithoutSubscribersDoesNotSetPendingDeadline) {
   const std::string shm_name = make_unique_shm_name("gpu_pool_nosub");
   auto logger = rclcpp::get_logger("GpuLeasePoolTest");
   GpuLeasePool pool({shm_name, 1, std::chrono::milliseconds(100)}, logger);
@@ -75,7 +93,7 @@ TEST(GpuLeasePoolTest, AcquireWithoutSubscribersDoesNotSetPendingDeadline) {
   ::shm_unlink(shm_name.c_str());
 }
 
-TEST(GpuLeasePoolTest, ReclaimStalePendingClearsLease) {
+TEST_F(GpuLeasePoolTest, ReclaimStalePendingClearsLease) {
   const std::string shm_name = make_unique_shm_name("gpu_pool_reclaim");
   auto logger = rclcpp::get_logger("GpuLeasePoolTest");
   GpuLeasePool pool({shm_name, 1, std::chrono::milliseconds(1)}, logger);


### PR DESCRIPTION
## Pull request overview

This PR addresses several CUDA/ROS2 integration and reliability issues across the core library, tests, and CI, primarily improving cleanup paths and making GPU-dependent tests gracefully skip when CUDA devices are unavailable.

**Changes:**
- Updated GPU-related tests to use fixtures that skip when no CUDA device is available.
- Fixed a resource-cleanup path in `TypeAdapter<BufferView>` when opening IPC handles fails.
- Adjusted CI to always run `colcon test` (rather than skipping the entire test phase based on CUDA detection), and added missing ROS message dependencies.
