### PR TITLE
mv nvtx file under cuda dir

### DIFF
--- a/gpu_image_transport/include/gpu_image_transport/gpu_image_transport_base.hpp
+++ b/gpu_image_transport/include/gpu_image_transport/gpu_image_transport_base.hpp
@@ -11,8 +11,8 @@
 #include <string>
 
 #include "rclcpp/rclcpp.hpp"
+#include "ros2_cuda_ipc_core/cuda/nvtx_scoped_range.hpp"
 #include "ros2_cuda_ipc_core/image_view.hpp"
-#include "ros2_cuda_ipc_core/nvtx_scoped_range.hpp"
 #include "ros2_cuda_ipc_core/type_adapters.hpp"
 
 namespace gpu_image_transport {

--- a/gpu_image_transport/src/gpu_image_transport_base.cpp
+++ b/gpu_image_transport/src/gpu_image_transport_base.cpp
@@ -8,7 +8,7 @@
 
 namespace gpu_image_transport {
 
-using ros2_cuda_ipc_core::NvtxScopedRange;
+using ros2_cuda_ipc_core::cuda::NvtxScopedRange;
 
 GpuImageTransportNodeBase::GpuImageTransportNodeBase(
     const std::string& node_name, const rclcpp::NodeOptions& options)

--- a/julia_set/src/colorize_node.cpp
+++ b/julia_set/src/colorize_node.cpp
@@ -13,16 +13,16 @@
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_cuda_ipc_core/cuda/cuda_util.hpp"
 #include "ros2_cuda_ipc_core/cuda/gpu_lease_pool.hpp"
+#include "ros2_cuda_ipc_core/cuda/nvtx_scoped_range.hpp"
 #include "ros2_cuda_ipc_core/image_view.hpp"
 #include "ros2_cuda_ipc_core/memory_backend_utils.hpp"
-#include "ros2_cuda_ipc_core/nvtx_scoped_range.hpp"
 #include "ros2_cuda_ipc_core/type_adapters.hpp"
 
 namespace julia_set {
 
-using ros2_cuda_ipc_core::NvtxScopedRange;
 using ros2_cuda_ipc_core::cuda::cuda_error_to_string;
 using ros2_cuda_ipc_core::cuda::GpuLeasePool;
+using ros2_cuda_ipc_core::cuda::NvtxScopedRange;
 
 class ColorizeNode : public rclcpp::Node {
  public:

--- a/julia_set/src/julia_publisher_helper.cpp
+++ b/julia_set/src/julia_publisher_helper.cpp
@@ -25,12 +25,12 @@
 #include "julia_set/cuda/julia_kernel.hpp"
 #include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/cuda/cuda_util.hpp"
-#include "ros2_cuda_ipc_core/nvtx_scoped_range.hpp"
+#include "ros2_cuda_ipc_core/cuda/nvtx_scoped_range.hpp"
 
 namespace julia_set {
 
-using ros2_cuda_ipc_core::NvtxScopedRange;
 using ros2_cuda_ipc_core::cuda::cuda_error_to_string;
+using ros2_cuda_ipc_core::cuda::NvtxScopedRange;
 namespace {
 
 uint32_t dtype_bytes(ros2_cuda_ipc_core::DType dtype) {

--- a/julia_set/src/julia_set_publisher.cpp
+++ b/julia_set/src/julia_set_publisher.cpp
@@ -9,13 +9,13 @@
 
 #include "julia_set/julia_publisher_helper.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "ros2_cuda_ipc_core/cuda/nvtx_scoped_range.hpp"
 #include "ros2_cuda_ipc_core/memory_backend_utils.hpp"
-#include "ros2_cuda_ipc_core/nvtx_scoped_range.hpp"
 #include "ros2_cuda_ipc_core/type_adapters.hpp"
 
 namespace julia_set {
 
-using ros2_cuda_ipc_core::NvtxScopedRange;
+using ros2_cuda_ipc_core::cuda::NvtxScopedRange;
 namespace {
 
 ros2_cuda_ipc_core::DType parse_dtype(const std::string& name) {

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/cuda/nvtx_scoped_range.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/cuda/nvtx_scoped_range.hpp
@@ -5,7 +5,7 @@
 
 #include <nvtx3/nvToolsExt.h>
 
-namespace ros2_cuda_ipc_core {
+namespace ros2_cuda_ipc_core::cuda {
 
 class NvtxScopedRange {
  public:
@@ -22,4 +22,4 @@ class NvtxScopedRange {
   nvtxRangeId_t id_{};
 };
 
-}  // namespace ros2_cuda_ipc_core
+}  // namespace ros2_cuda_ipc_core::cuda


### PR DESCRIPTION
## Pull request overview

This PR updates the NVTX scoped range utility to live under the CUDA-specific namespace (`ros2_cuda_ipc_core::cuda`) and updates downstream packages to include and reference it from the new location. This aligns the NVTX helper with the rest of the CUDA utilities and avoids polluting the root `ros2_cuda_ipc_core` namespace.

**Changes:**
- Move `NvtxScopedRange` into the `ros2_cuda_ipc_core::cuda` namespace.
- Update includes to use `ros2_cuda_ipc_core/cuda/nvtx_scoped_range.hpp`.
- Update `using` declarations to reference `ros2_cuda_ipc_core::cuda::NvtxScopedRange`.