### PR TITLE
use lambda instead of std::bind

### DIFF
--- a/gpu_image_transport/src/gpu_image_transport_base.cpp
+++ b/gpu_image_transport/src/gpu_image_transport_base.cpp
@@ -3,7 +3,6 @@
 
 #include "gpu_image_transport/gpu_image_transport_base.hpp"
 
-#include <functional>
 #include <stdexcept>
 
 namespace gpu_image_transport {
@@ -29,8 +28,7 @@ GpuImageTransportNodeBase::GpuImageTransportNodeBase(
 
   subscription_ = create_subscription<ros2_cuda_ipc_core::ImageView>(
       input_topic_, rclcpp::QoS(rclcpp::KeepLast(1)).reliable(),
-      std::bind(&GpuImageTransportNodeBase::on_image, this,
-                std::placeholders::_1),
+      [this](const ros2_cuda_ipc_core::ImageView& view) { on_image(view); },
       subscription_options);
 }
 

--- a/julia_set/src/colorize_node.cpp
+++ b/julia_set/src/colorize_node.cpp
@@ -4,7 +4,6 @@
 #include <cuda_runtime_api.h>
 
 #include <chrono>
-#include <functional>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -75,7 +74,7 @@ class ColorizeNode : public rclcpp::Node {
         rclcpp::IntraProcessSetting::Disable;
     subscription_ = create_subscription<ros2_cuda_ipc_core::ImageView>(
         input_topic_, rclcpp::QoS(rclcpp::KeepLast(10)).reliable(),
-        std::bind(&ColorizeNode::on_image, this, std::placeholders::_1),
+        [this](const ros2_cuda_ipc_core::ImageView& view) { on_image(view); },
         subscription_options);
 
     rclcpp::PublisherOptions publisher_options;

--- a/julia_set/src/julia_set_publisher.cpp
+++ b/julia_set/src/julia_set_publisher.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 #include <chrono>
-#include <functional>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -109,7 +108,7 @@ class JuliaSetPublisherNode : public rclcpp::Node {
     const auto period = std::chrono::duration<double>(1.0 / publish_rate_hz_);
     timer_ = create_wall_timer(
         std::chrono::duration_cast<std::chrono::milliseconds>(period),
-        std::bind(&JuliaSetPublisherNode::on_timer, this));
+        [this]() { on_timer(); });
 
     start_time_ = now();
 


### PR DESCRIPTION
## Pull request overview

This PR modernizes callback wiring in ROS 2 nodes by replacing `std::bind`-based callbacks with explicit lambdas, and removes now-unused `<functional>` includes. This aligns the implementation with the documented TypeAdapter subscription pattern for `ros2_cuda_ipc_core::ImageView`.

**Changes:**
- Replaced `std::bind` timer callback with a `[this]` lambda in the Julia set publisher node.
- Replaced `std::bind` subscription callbacks with typed lambdas for `ros2_cuda_ipc_core::ImageView`.
- Removed unused `<functional>` includes from affected translation units.
