### PR TITLE
move view related files to view/

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,17 +117,17 @@ ros2 launch julia_set julia_set_demo.launch.py
 
 ## コアコンポーネントとヘルパー
 
-- `ros2_cuda_ipc_core::BufferView`: 任意バッファ向けの基盤ビューです。受信側では import 済み GPU resource と lease を保持します。
-- `ros2_cuda_ipc_core::ImageView` / `PointCloud2View`: `BufferView` に画像・点群メタデータを重ねた custom type です。
-- `ros2_cuda_ipc_core::BufferViewMapper` / `ImageViewMapper` / `PointCloud2ViewMapper`: `BufferCore` / `GpuImage` / `GpuPointCloud2` から View を構築する明示制御 API です。
-- `ros2_cuda_ipc_core/type_adapters.hpp`: `Publisher<ImageView>` / `Subscription<ImageView>` のように View を直接扱うための薄い TypeAdapter です。内部では mapper API を呼びます。
+- `ros2_cuda_ipc_core::view::BufferView`: 任意バッファ向けの基盤ビューです。受信側では import 済み GPU resource と lease を保持します。
+- `ros2_cuda_ipc_core::view::ImageView` / `ros2_cuda_ipc_core::view::PointCloud2View`: `BufferView` に画像・点群メタデータを重ねた custom type です。
+- `ros2_cuda_ipc_core::mapper::BufferViewMapper` / `ImageViewMapper` / `PointCloud2ViewMapper`: `BufferCore` / `GpuImage` / `GpuPointCloud2` から View を構築する明示制御 API です。
+- `ros2_cuda_ipc_core/type_adapters.hpp`: `Publisher<ros2_cuda_ipc_core::view::ImageView>` / `Subscription<ros2_cuda_ipc_core::view::ImageView>` のように View を直接扱うための薄い TypeAdapter です。内部では mapper API を呼びます。
 - `ros2_cuda_ipc_core::LeaseHandle`: Publisher 側でスロットの貸出状態を管理し、`pending_ttl` の経過で強制解放します。
 - `ros2_cuda_ipc_core::cuda::GpuLeasePool`: Publisher 側の GPU メモリスロット、backend 切り替え、lease 更新をまとめる共通プールです。
 
 受信側 API は 2 系統あります。
 
-- TypeAdapter API: `Subscription<ImageView>` / `Subscription<PointCloud2View>` をそのまま使う高レベル API
-- Mapper API: `Subscription<ros2_cuda_ipc_msgs::msg::GpuImage>` などで raw message を受け、`ImageViewMapper::map()` で明示的に resource import する API
+- TypeAdapter API: `Subscription<ros2_cuda_ipc_core::view::ImageView>` / `Subscription<ros2_cuda_ipc_core::view::PointCloud2View>` をそのまま使う高レベル API
+- Mapper API: `Subscription<ros2_cuda_ipc_msgs::msg::GpuImage>` などで raw message を受け、`ros2_cuda_ipc_core::mapper::ImageViewMapper::map()` で明示的に resource import する API
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ ros2 launch julia_set julia_set_demo.launch.py
 
 - `ros2_cuda_ipc_core::view::BufferView`: 任意バッファ向けの基盤ビューです。受信側では import 済み GPU resource と lease を保持します。
 - `ros2_cuda_ipc_core::view::ImageView` / `ros2_cuda_ipc_core::view::PointCloud2View`: `BufferView` に画像・点群メタデータを重ねた custom type です。
-- `ros2_cuda_ipc_core::mapper::BufferViewMapper` / `ImageViewMapper` / `PointCloud2ViewMapper`: `BufferCore` / `GpuImage` / `GpuPointCloud2` から View を構築する明示制御 API です。
+- `ros2_cuda_ipc_core::mapper::BufferViewMapper` / `ros2_cuda_ipc_core::mapper::ImageViewMapper` / `ros2_cuda_ipc_core::mapper::PointCloud2ViewMapper`: `BufferCore` / `GpuImage` / `GpuPointCloud2` から View を構築する明示制御 API です。
 - `ros2_cuda_ipc_core/type_adapters.hpp`: `Publisher<ros2_cuda_ipc_core::view::ImageView>` / `Subscription<ros2_cuda_ipc_core::view::ImageView>` のように View を直接扱うための薄い TypeAdapter です。内部では mapper API を呼びます。
 - `ros2_cuda_ipc_core::LeaseHandle`: Publisher 側でスロットの貸出状態を管理し、`pending_ttl` の経過で強制解放します。
 - `ros2_cuda_ipc_core::cuda::GpuLeasePool`: Publisher 側の GPU メモリスロット、backend 切り替え、lease 更新をまとめる共通プールです。

--- a/doc/design.md
+++ b/doc/design.md
@@ -227,11 +227,13 @@ Mapper API を併設する。
 #### ImageView（BufferView + 最小限の画像メタデータ）
 
 ```cpp
-// image_view.hpp
+// view/image_view.hpp
 #pragma once
 #include <cstdint>
 #include <string>
-#include <ros2_cuda_ipc_core/buffer_view.hpp>
+#include <ros2_cuda_ipc_core/view/buffer_view.hpp>
+
+namespace ros2_cuda_ipc_core::view {
 
 // 画素型（必要十分な最小セット。用途に応じて拡張可）
 enum class DType : uint8_t {
@@ -318,6 +320,8 @@ struct ImageView {
     return core.byte_size >= needed;
   }
 };
+
+}  // namespace ros2_cuda_ipc_core::view
 ```
 
 **ポイント**
@@ -330,6 +334,8 @@ struct ImageView {
 #### 点群：PointCloud2View（BufferView + レイアウト情報）
 
 ```cpp
+namespace ros2_cuda_ipc_core::view {
+
 // PointCloud2View: sensor_msgs/PointCloud2 のレイアウトをGPU向けにそのまま保持
 struct PointCloud2View {
   BufferView core;
@@ -383,6 +389,8 @@ struct PointCloud2View {
     return core.enqueue_ready_event(s);
   }
 };
+
+}  // namespace ros2_cuda_ipc_core::view
 ```
 
 **ポイント**

--- a/gpu_image_transport/include/gpu_image_transport/gpu_image_transport_base.hpp
+++ b/gpu_image_transport/include/gpu_image_transport/gpu_image_transport_base.hpp
@@ -12,8 +12,8 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_cuda_ipc_core/cuda/nvtx_scoped_range.hpp"
-#include "ros2_cuda_ipc_core/image_view.hpp"
 #include "ros2_cuda_ipc_core/type_adapters.hpp"
+#include "ros2_cuda_ipc_core/view/image_view.hpp"
 
 namespace gpu_image_transport {
 
@@ -25,7 +25,7 @@ class GpuImageTransportNodeBase : public rclcpp::Node {
   ~GpuImageTransportNodeBase() override;
 
  protected:
-  virtual void publish_frame(const ros2_cuda_ipc_core::ImageView& view,
+  virtual void publish_frame(const ros2_cuda_ipc_core::view::ImageView& view,
                              std::uint64_t available_bytes) = 0;
 
   const std::string& input_topic() const { return input_topic_; }
@@ -36,11 +36,12 @@ class GpuImageTransportNodeBase : public rclcpp::Node {
   static std::string cuda_error_to_string(cudaError_t err);
 
  private:
-  void on_image(const ros2_cuda_ipc_core::ImageView& view);
+  void on_image(const ros2_cuda_ipc_core::view::ImageView& view);
   cudaError_t ensure_pinned_capacity(std::size_t bytes);
   void release_pinned_host();
 
-  rclcpp::Subscription<ros2_cuda_ipc_core::ImageView>::SharedPtr subscription_;
+  rclcpp::Subscription<ros2_cuda_ipc_core::view::ImageView>::SharedPtr
+      subscription_;
   cudaStream_t stream_ = nullptr;
   std::string input_topic_;
   std::string output_topic_;

--- a/gpu_image_transport/src/gpu_image_transport.cpp
+++ b/gpu_image_transport/src/gpu_image_transport.cpp
@@ -26,7 +26,7 @@ class GpuImageTransportNode : public GpuImageTransportNodeBase {
   }
 
  private:
-  void publish_frame(const ros2_cuda_ipc_core::ImageView& view,
+  void publish_frame(const ros2_cuda_ipc_core::view::ImageView& view,
                      std::uint64_t available_bytes) override {
     const std::uint32_t height = view.rows();
     const std::uint64_t step_bytes = view.strideH();
@@ -75,10 +75,11 @@ class GpuImageTransportNode : public GpuImageTransportNodeBase {
     publisher_->publish(std::move(msg));
   }
 
-  std::string infer_encoding(const ros2_cuda_ipc_core::ImageView& view) const {
+  std::string infer_encoding(
+      const ros2_cuda_ipc_core::view::ImageView& view) const {
     const auto channels = view.channels();
     const auto suffix = std::to_string(channels);
-    using ros2_cuda_ipc_core::DType;
+    using ros2_cuda_ipc_core::view::DType;
     switch (view.dtype) {
       case DType::U8:
         if (channels == 1) {

--- a/gpu_image_transport/src/gpu_image_transport_base.cpp
+++ b/gpu_image_transport/src/gpu_image_transport_base.cpp
@@ -26,9 +26,11 @@ GpuImageTransportNodeBase::GpuImageTransportNodeBase(
   subscription_options.use_intra_process_comm =
       rclcpp::IntraProcessSetting::Disable;
 
-  subscription_ = create_subscription<ros2_cuda_ipc_core::ImageView>(
+  subscription_ = create_subscription<ros2_cuda_ipc_core::view::ImageView>(
       input_topic_, rclcpp::QoS(rclcpp::KeepLast(1)).reliable(),
-      [this](const ros2_cuda_ipc_core::ImageView& view) { on_image(view); },
+      [this](const ros2_cuda_ipc_core::view::ImageView& view) {
+        on_image(view);
+      },
       subscription_options);
 }
 
@@ -45,7 +47,7 @@ GpuImageTransportNodeBase::~GpuImageTransportNodeBase() {
 }
 
 void GpuImageTransportNodeBase::on_image(
-    const ros2_cuda_ipc_core::ImageView& view) {
+    const ros2_cuda_ipc_core::view::ImageView& view) {
   NvtxScopedRange callback_range("GpuImageTransportNodeBase::on_image");
   if (!view.core.valid()) {
     RCLCPP_WARN(get_logger(), "Received invalid GPU image view");

--- a/gpu_image_transport/src/gpu_image_transport_compressed.cpp
+++ b/gpu_image_transport/src/gpu_image_transport_compressed.cpp
@@ -47,7 +47,7 @@ class GpuImageTransportCompressedNode : public GpuImageTransportNodeBase {
   }
 
  private:
-  void publish_frame(const ros2_cuda_ipc_core::ImageView& view,
+  void publish_frame(const ros2_cuda_ipc_core::view::ImageView& view,
                      std::uint64_t available_bytes) override {
     const std::uint32_t height = view.rows();
     const std::uint64_t step_bytes = view.strideH();
@@ -85,7 +85,7 @@ class GpuImageTransportCompressedNode : public GpuImageTransportNodeBase {
       return;
     }
 
-    using ros2_cuda_ipc_core::DType;
+    using ros2_cuda_ipc_core::view::DType;
     if (view.dtype != DType::U8) {
       RCLCPP_WARN(
           get_logger(),

--- a/julia_set/README.md
+++ b/julia_set/README.md
@@ -22,7 +22,7 @@ source install/setup.bash
 
 ### `julia_set_publisher`
 
-Publishes `ros2_cuda_ipc_core::ImageView` messages containing the Julia set
+Publishes `ros2_cuda_ipc_core::view::ImageView` messages containing the Julia set
 fractal. Key parameters:
 
 - `publish_rate_hz` (double, default `30.0`): Output frame rate.
@@ -57,7 +57,7 @@ Copies the GPU image to host memory and republishes it as a
 `sensor_msgs::msg::Image`. Parameters:
 
 - `input_topic_name` (string, default `image_gpu`): Topic carrying
-  `ros2_cuda_ipc_core::ImageView` messages.
+  `ros2_cuda_ipc_core::view::ImageView` messages.
 - `cpu_topic_name` (string, default `image`): Output topic name.
 
 ### `gpu_image_transport_compressed`
@@ -66,7 +66,7 @@ Publishes the CUDA image as a `sensor_msgs::msg::CompressedImage` using
 OpenCV for encoding. Parameters:
 
 - `input_topic_name` (string, default `image_gpu`): Topic carrying
-  `ros2_cuda_ipc_core::ImageView` messages.
+  `ros2_cuda_ipc_core::view::ImageView` messages.
 - `cpu_topic_name` (string, default `image`): Output topic name.
 - `compressed_format` (string, default `jpeg`): Encoding passed to
   `cv::imencode` (e.g. `jpeg`, `png`, `bmp`).

--- a/julia_set/include/julia_set/julia_publisher_helper.hpp
+++ b/julia_set/include/julia_set/julia_publisher_helper.hpp
@@ -12,8 +12,8 @@
 
 #include "rclcpp/logger.hpp"
 #include "ros2_cuda_ipc_core/cuda/gpu_lease_pool.hpp"
-#include "ros2_cuda_ipc_core/image_view.hpp"
 #include "ros2_cuda_ipc_core/memory_types.hpp"
+#include "ros2_cuda_ipc_core/view/image_view.hpp"
 
 namespace julia_set {
 
@@ -24,7 +24,7 @@ class JuliaPublisherHelper {
     uint32_t width = 1280;
     uint32_t height = 720;
     uint32_t channels = 1;
-    ros2_cuda_ipc_core::DType dtype = ros2_cuda_ipc_core::DType::U8;
+    ros2_cuda_ipc_core::view::DType dtype = ros2_cuda_ipc_core::view::DType::U8;
     std::string encoding = "mono8";
     std::size_t slot_count = 4;
     int device_index = 0;
@@ -47,7 +47,7 @@ class JuliaPublisherHelper {
   JuliaPublisherHelper(JuliaPublisherHelper&&) = delete;
   JuliaPublisherHelper& operator=(JuliaPublisherHelper&&) = delete;
 
-  std::optional<ros2_cuda_ipc_core::ImageView> produce(
+  std::optional<ros2_cuda_ipc_core::view::ImageView> produce(
       std::size_t subscriber_count, float time_phase = 0.0f);
 
   uint64_t frame_size_bytes() const noexcept { return frame_size_bytes_; }

--- a/julia_set/src/colorize_node.cpp
+++ b/julia_set/src/colorize_node.cpp
@@ -13,9 +13,9 @@
 #include "ros2_cuda_ipc_core/cuda/cuda_util.hpp"
 #include "ros2_cuda_ipc_core/cuda/gpu_lease_pool.hpp"
 #include "ros2_cuda_ipc_core/cuda/nvtx_scoped_range.hpp"
-#include "ros2_cuda_ipc_core/image_view.hpp"
 #include "ros2_cuda_ipc_core/memory_backend_utils.hpp"
 #include "ros2_cuda_ipc_core/type_adapters.hpp"
+#include "ros2_cuda_ipc_core/view/image_view.hpp"
 
 namespace julia_set {
 
@@ -72,15 +72,17 @@ class ColorizeNode : public rclcpp::Node {
     rclcpp::SubscriptionOptions subscription_options;
     subscription_options.use_intra_process_comm =
         rclcpp::IntraProcessSetting::Disable;
-    subscription_ = create_subscription<ros2_cuda_ipc_core::ImageView>(
+    subscription_ = create_subscription<ros2_cuda_ipc_core::view::ImageView>(
         input_topic_, rclcpp::QoS(rclcpp::KeepLast(10)).reliable(),
-        [this](const ros2_cuda_ipc_core::ImageView& view) { on_image(view); },
+        [this](const ros2_cuda_ipc_core::view::ImageView& view) {
+          on_image(view);
+        },
         subscription_options);
 
     rclcpp::PublisherOptions publisher_options;
     publisher_options.use_intra_process_comm =
         rclcpp::IntraProcessSetting::Disable;
-    publisher_ = create_publisher<ros2_cuda_ipc_core::ImageView>(
+    publisher_ = create_publisher<ros2_cuda_ipc_core::view::ImageView>(
         output_topic_, rclcpp::QoS(rclcpp::KeepLast(10)).reliable(),
         publisher_options);
 
@@ -107,7 +109,7 @@ class ColorizeNode : public rclcpp::Node {
   }
 
  private:
-  void on_image(const ros2_cuda_ipc_core::ImageView& view) {
+  void on_image(const ros2_cuda_ipc_core::view::ImageView& view) {
     NvtxScopedRange callback_range("ColorizeNode::on_image");
     auto logger = get_logger();
     if (!view.core.valid()) {
@@ -192,11 +194,11 @@ class ColorizeNode : public rclcpp::Node {
       return;
     }
 
-    ros2_cuda_ipc_core::ImageView output = make_output_view(slot, view);
+    ros2_cuda_ipc_core::view::ImageView output = make_output_view(slot, view);
     publisher_->publish(output);
   }
 
-  bool ensure_pool(const ros2_cuda_ipc_core::ImageView& view) {
+  bool ensure_pool(const ros2_cuda_ipc_core::view::ImageView& view) {
     const uint32_t width = view.cols();
     const uint32_t height = view.rows();
     const int device_id = view.core.device_id;
@@ -241,10 +243,10 @@ class ColorizeNode : public rclcpp::Node {
     return true;
   }
 
-  ros2_cuda_ipc_core::ImageView make_output_view(
+  ros2_cuda_ipc_core::view::ImageView make_output_view(
       const GpuLeasePool::Slot& slot,
-      const ros2_cuda_ipc_core::ImageView& input) const {
-    ros2_cuda_ipc_core::ImageView view;
+      const ros2_cuda_ipc_core::view::ImageView& input) const {
+    ros2_cuda_ipc_core::view::ImageView view;
     view.header = input.header;
     view.core.dev_ptr = slot.device_ptr;
     view.core.ready_evt = slot.event;
@@ -255,7 +257,7 @@ class ColorizeNode : public rclcpp::Node {
     view.core.shm_name = output_shm_name_;
     view.core.set_ipc_handles(slot.backend, slot.mem_handle.data(),
                               slot.mem_handle.size(), slot.event_handle);
-    view.dtype = ros2_cuda_ipc_core::DType::U8;
+    view.dtype = ros2_cuda_ipc_core::view::DType::U8;
     view.shape = {height_, width_, output_channels_};
     view.strides = {static_cast<uint64_t>(width_) * output_channels_,
                     static_cast<uint64_t>(output_channels_), 1};
@@ -263,8 +265,9 @@ class ColorizeNode : public rclcpp::Node {
     return view;
   }
 
-  rclcpp::Subscription<ros2_cuda_ipc_core::ImageView>::SharedPtr subscription_;
-  rclcpp::Publisher<ros2_cuda_ipc_core::ImageView>::SharedPtr publisher_;
+  rclcpp::Subscription<ros2_cuda_ipc_core::view::ImageView>::SharedPtr
+      subscription_;
+  rclcpp::Publisher<ros2_cuda_ipc_core::view::ImageView>::SharedPtr publisher_;
   cudaStream_t stream_ = nullptr;
   uint64_t frame_size_bytes_ = 0;
   uint32_t width_ = 0;

--- a/julia_set/src/julia_publisher_helper.cpp
+++ b/julia_set/src/julia_publisher_helper.cpp
@@ -33,19 +33,19 @@ using ros2_cuda_ipc_core::cuda::cuda_error_to_string;
 using ros2_cuda_ipc_core::cuda::NvtxScopedRange;
 namespace {
 
-uint32_t dtype_bytes(ros2_cuda_ipc_core::DType dtype) {
+uint32_t dtype_bytes(ros2_cuda_ipc_core::view::DType dtype) {
   switch (dtype) {
-    case ros2_cuda_ipc_core::DType::U8:
+    case ros2_cuda_ipc_core::view::DType::U8:
       return 1;
-    case ros2_cuda_ipc_core::DType::U16:
-    case ros2_cuda_ipc_core::DType::F16:
-    case ros2_cuda_ipc_core::DType::S16:
+    case ros2_cuda_ipc_core::view::DType::U16:
+    case ros2_cuda_ipc_core::view::DType::F16:
+    case ros2_cuda_ipc_core::view::DType::S16:
       return 2;
-    case ros2_cuda_ipc_core::DType::F32:
-    case ros2_cuda_ipc_core::DType::S32:
-    case ros2_cuda_ipc_core::DType::U32:
+    case ros2_cuda_ipc_core::view::DType::F32:
+    case ros2_cuda_ipc_core::view::DType::S32:
+    case ros2_cuda_ipc_core::view::DType::U32:
       return 4;
-    case ros2_cuda_ipc_core::DType::F64:
+    case ros2_cuda_ipc_core::view::DType::F64:
       return 8;
   }
   return 1;
@@ -95,14 +95,14 @@ JuliaPublisherHelper::~JuliaPublisherHelper() {
   }
 }
 
-std::optional<ros2_cuda_ipc_core::ImageView> JuliaPublisherHelper::produce(
-    std::size_t subscriber_count, float time_phase) {
+std::optional<ros2_cuda_ipc_core::view::ImageView>
+JuliaPublisherHelper::produce(std::size_t subscriber_count, float time_phase) {
   NvtxScopedRange produce_range("JuliaPublisherHelper::produce");
   if (!pool_.is_initialised()) {
     return std::nullopt;
   }
 
-  if (config_.dtype != ros2_cuda_ipc_core::DType::U8) {
+  if (config_.dtype != ros2_cuda_ipc_core::view::DType::U8) {
     RCLCPP_ERROR(logger_, "Unsupported dtype for Julia set rendering");
     return std::nullopt;
   }
@@ -156,7 +156,7 @@ std::optional<ros2_cuda_ipc_core::ImageView> JuliaPublisherHelper::produce(
     return std::nullopt;
   }
 
-  ros2_cuda_ipc_core::ImageView view;
+  ros2_cuda_ipc_core::view::ImageView view;
   view.core.dev_ptr = slot->device_ptr;
   view.core.ready_evt = slot->event;
   view.core.device_id = config_.device_index;

--- a/julia_set/src/julia_set_publisher.cpp
+++ b/julia_set/src/julia_set_publisher.cpp
@@ -17,27 +17,27 @@ namespace julia_set {
 using ros2_cuda_ipc_core::cuda::NvtxScopedRange;
 namespace {
 
-ros2_cuda_ipc_core::DType parse_dtype(const std::string& name) {
+ros2_cuda_ipc_core::view::DType parse_dtype(const std::string& name) {
   if (name == "u8") {
-    return ros2_cuda_ipc_core::DType::U8;
+    return ros2_cuda_ipc_core::view::DType::U8;
   }
   if (name == "u16") {
-    return ros2_cuda_ipc_core::DType::U16;
+    return ros2_cuda_ipc_core::view::DType::U16;
   }
   if (name == "f32") {
-    return ros2_cuda_ipc_core::DType::F32;
+    return ros2_cuda_ipc_core::view::DType::F32;
   }
   if (name == "f64") {
-    return ros2_cuda_ipc_core::DType::F64;
+    return ros2_cuda_ipc_core::view::DType::F64;
   }
   if (name == "s16") {
-    return ros2_cuda_ipc_core::DType::S16;
+    return ros2_cuda_ipc_core::view::DType::S16;
   }
   if (name == "s32") {
-    return ros2_cuda_ipc_core::DType::S32;
+    return ros2_cuda_ipc_core::view::DType::S32;
   }
   if (name == "u32") {
-    return ros2_cuda_ipc_core::DType::U32;
+    return ros2_cuda_ipc_core::view::DType::U32;
   }
   throw std::runtime_error("Unsupported dtype: " + name);
 }
@@ -99,7 +99,7 @@ class JuliaSetPublisherNode : public rclcpp::Node {
 
     rclcpp::PublisherOptions options;
     options.use_intra_process_comm = rclcpp::IntraProcessSetting::Disable;
-    publisher_ = create_publisher<ros2_cuda_ipc_core::ImageView>(
+    publisher_ = create_publisher<ros2_cuda_ipc_core::view::ImageView>(
         topic_name_, rclcpp::QoS(rclcpp::KeepLast(10)).reliable(), options);
 
     if (publish_rate_hz_ <= 0.0) {
@@ -141,7 +141,7 @@ class JuliaSetPublisherNode : public rclcpp::Node {
     publisher_->publish(*view);
   }
 
-  rclcpp::Publisher<ros2_cuda_ipc_core::ImageView>::SharedPtr publisher_;
+  rclcpp::Publisher<ros2_cuda_ipc_core::view::ImageView>::SharedPtr publisher_;
   std::unique_ptr<JuliaPublisherHelper> helper_;
   rclcpp::TimerBase::SharedPtr timer_;
   rclcpp::Time start_time_{};

--- a/ros2_cuda_ipc_core/CMakeLists.txt
+++ b/ros2_cuda_ipc_core/CMakeLists.txt
@@ -28,11 +28,11 @@ add_library(${PROJECT_NAME}
   src/cuda/gpu_lease_pool.cpp
   src/cuda/memory_backend_cuda_ipc.cpp
   src/cuda/memory_backend_vmm_fd.cpp
-  src/buffer_view.cpp
-  src/image_view.cpp
+  src/view/buffer_view.cpp
+  src/view/image_view.cpp
+  src/view/pointcloud2_view.cpp
   src/ipc_handle_cache.cpp
   src/lease_handle.cpp
-  src/pointcloud2_view.cpp
   src/backend/backend_importer.cpp
   src/backend/cuda_ipc_importer.cpp
   src/backend/vmm_fd_importer.cpp

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/mapper/buffer_view_mapper.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/mapper/buffer_view_mapper.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "rclcpp/logging.hpp"
-#include "ros2_cuda_ipc_core/buffer_view.hpp"
+#include "ros2_cuda_ipc_core/view/buffer_view.hpp"
 #include "ros2_cuda_ipc_msgs/msg/buffer_core.hpp"
 
 namespace ros2_cuda_ipc_core::mapper {
@@ -18,15 +18,16 @@ class BufferViewMapper {
  public:
   explicit BufferViewMapper(BufferViewMapperOptions options = {});
 
-  BufferView map(const ros2_cuda_ipc_msgs::msg::BufferCore& msg) const;
+  view::BufferView map(const ros2_cuda_ipc_msgs::msg::BufferCore& msg) const;
 
  private:
   BufferViewMapperOptions options_;
 };
 
-BufferView map_buffer_view(const ros2_cuda_ipc_msgs::msg::BufferCore& msg);
+view::BufferView map_buffer_view(
+    const ros2_cuda_ipc_msgs::msg::BufferCore& msg);
 
-void fill_buffer_core_message(const BufferView& view,
+void fill_buffer_core_message(const view::BufferView& view,
                               ros2_cuda_ipc_msgs::msg::BufferCore& msg);
 
 }  // namespace ros2_cuda_ipc_core::mapper

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/mapper/image_view_mapper.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/mapper/image_view_mapper.hpp
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "ros2_cuda_ipc_core/image_view.hpp"
 #include "ros2_cuda_ipc_core/mapper/buffer_view_mapper.hpp"
+#include "ros2_cuda_ipc_core/view/image_view.hpp"
 #include "ros2_cuda_ipc_msgs/msg/gpu_image.hpp"
 
 namespace ros2_cuda_ipc_core::mapper {
@@ -13,15 +13,15 @@ class ImageViewMapper {
  public:
   explicit ImageViewMapper(BufferViewMapper buffer_mapper = BufferViewMapper{});
 
-  ImageView map(const ros2_cuda_ipc_msgs::msg::GpuImage& msg) const;
+  view::ImageView map(const ros2_cuda_ipc_msgs::msg::GpuImage& msg) const;
 
  private:
   BufferViewMapper buffer_mapper_;
 };
 
-ImageView map_image_view(const ros2_cuda_ipc_msgs::msg::GpuImage& msg);
+view::ImageView map_image_view(const ros2_cuda_ipc_msgs::msg::GpuImage& msg);
 
-void fill_gpu_image_message(const ImageView& view,
+void fill_gpu_image_message(const view::ImageView& view,
                             ros2_cuda_ipc_msgs::msg::GpuImage& msg);
 
 }  // namespace ros2_cuda_ipc_core::mapper

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/mapper/pointcloud2_view_mapper.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/mapper/pointcloud2_view_mapper.hpp
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "ros2_cuda_ipc_core/mapper/buffer_view_mapper.hpp"
-#include "ros2_cuda_ipc_core/pointcloud2_view.hpp"
+#include "ros2_cuda_ipc_core/view/pointcloud2_view.hpp"
 #include "ros2_cuda_ipc_msgs/msg/gpu_point_cloud2.hpp"
 
 namespace ros2_cuda_ipc_core::mapper {
@@ -14,16 +14,17 @@ class PointCloud2ViewMapper {
   explicit PointCloud2ViewMapper(
       BufferViewMapper buffer_mapper = BufferViewMapper{});
 
-  PointCloud2View map(const ros2_cuda_ipc_msgs::msg::GpuPointCloud2& msg) const;
+  view::PointCloud2View map(
+      const ros2_cuda_ipc_msgs::msg::GpuPointCloud2& msg) const;
 
  private:
   BufferViewMapper buffer_mapper_;
 };
 
-PointCloud2View map_pointcloud2_view(
+view::PointCloud2View map_pointcloud2_view(
     const ros2_cuda_ipc_msgs::msg::GpuPointCloud2& msg);
 
-void fill_gpu_pointcloud2_message(const PointCloud2View& view,
+void fill_gpu_pointcloud2_message(const view::PointCloud2View& view,
                                   ros2_cuda_ipc_msgs::msg::GpuPointCloud2& msg);
 
 }  // namespace ros2_cuda_ipc_core::mapper

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/type_adapters.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/type_adapters.hpp
@@ -16,10 +16,10 @@
 namespace rclcpp {
 
 template <>
-struct TypeAdapter<ros2_cuda_ipc_core::BufferView,
+struct TypeAdapter<ros2_cuda_ipc_core::view::BufferView,
                    ros2_cuda_ipc_msgs::msg::BufferCore> {
   using is_specialized = std::true_type;
-  using custom_type = ros2_cuda_ipc_core::BufferView;
+  using custom_type = ros2_cuda_ipc_core::view::BufferView;
   using ros_message_type = ros2_cuda_ipc_msgs::msg::BufferCore;
 
   static void convert_to_custom(const ros_message_type& msg,
@@ -34,10 +34,10 @@ struct TypeAdapter<ros2_cuda_ipc_core::BufferView,
 };
 
 template <>
-struct TypeAdapter<ros2_cuda_ipc_core::ImageView,
+struct TypeAdapter<ros2_cuda_ipc_core::view::ImageView,
                    ros2_cuda_ipc_msgs::msg::GpuImage> {
   using is_specialized = std::true_type;
-  using custom_type = ros2_cuda_ipc_core::ImageView;
+  using custom_type = ros2_cuda_ipc_core::view::ImageView;
   using ros_message_type = ros2_cuda_ipc_msgs::msg::GpuImage;
 
   static void convert_to_custom(const ros_message_type& msg,
@@ -52,10 +52,10 @@ struct TypeAdapter<ros2_cuda_ipc_core::ImageView,
 };
 
 template <>
-struct TypeAdapter<ros2_cuda_ipc_core::PointCloud2View,
+struct TypeAdapter<ros2_cuda_ipc_core::view::PointCloud2View,
                    ros2_cuda_ipc_msgs::msg::GpuPointCloud2> {
   using is_specialized = std::true_type;
-  using custom_type = ros2_cuda_ipc_core::PointCloud2View;
+  using custom_type = ros2_cuda_ipc_core::view::PointCloud2View;
   using ros_message_type = ros2_cuda_ipc_msgs::msg::GpuPointCloud2;
 
   static void convert_to_custom(const ros_message_type& msg,
@@ -72,9 +72,9 @@ struct TypeAdapter<ros2_cuda_ipc_core::PointCloud2View,
 }  // namespace rclcpp
 
 RCLCPP_USING_CUSTOM_TYPE_AS_ROS_MESSAGE_TYPE(
-    ros2_cuda_ipc_core::BufferView, ros2_cuda_ipc_msgs::msg::BufferCore);
-RCLCPP_USING_CUSTOM_TYPE_AS_ROS_MESSAGE_TYPE(ros2_cuda_ipc_core::ImageView,
-                                             ros2_cuda_ipc_msgs::msg::GpuImage);
+    ros2_cuda_ipc_core::view::BufferView, ros2_cuda_ipc_msgs::msg::BufferCore);
 RCLCPP_USING_CUSTOM_TYPE_AS_ROS_MESSAGE_TYPE(
-    ros2_cuda_ipc_core::PointCloud2View,
+    ros2_cuda_ipc_core::view::ImageView, ros2_cuda_ipc_msgs::msg::GpuImage);
+RCLCPP_USING_CUSTOM_TYPE_AS_ROS_MESSAGE_TYPE(
+    ros2_cuda_ipc_core::view::PointCloud2View,
     ros2_cuda_ipc_msgs::msg::GpuPointCloud2);

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/view/buffer_view.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/view/buffer_view.hpp
@@ -13,7 +13,7 @@
 #include "ros2_cuda_ipc_core/lease_handle.hpp"
 #include "ros2_cuda_ipc_core/memory_types.hpp"
 
-namespace ros2_cuda_ipc_core {
+namespace ros2_cuda_ipc_core::view {
 
 struct BufferView {
   void* dev_ptr = nullptr;
@@ -62,4 +62,4 @@ struct BufferView {
   bool handles_ready_ = false;
 };
 
-}  // namespace ros2_cuda_ipc_core
+}  // namespace ros2_cuda_ipc_core::view

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/view/image_view.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/view/image_view.hpp
@@ -7,10 +7,10 @@
 #include <cstdint>
 #include <string>
 
-#include "ros2_cuda_ipc_core/buffer_view.hpp"
+#include "ros2_cuda_ipc_core/view/buffer_view.hpp"
 #include "std_msgs/msg/header.hpp"
 
-namespace ros2_cuda_ipc_core {
+namespace ros2_cuda_ipc_core::view {
 
 enum class DType : uint8_t {
   U8 = 0,
@@ -80,4 +80,4 @@ struct ImageView {
   bool sanity_check() const noexcept;
 };
 
-}  // namespace ros2_cuda_ipc_core
+}  // namespace ros2_cuda_ipc_core::view

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/view/pointcloud2_view.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/view/pointcloud2_view.hpp
@@ -8,9 +8,9 @@
 #include <string>
 #include <vector>
 
-#include "ros2_cuda_ipc_core/buffer_view.hpp"
+#include "ros2_cuda_ipc_core/view/buffer_view.hpp"
 
-namespace ros2_cuda_ipc_core {
+namespace ros2_cuda_ipc_core::view {
 
 struct PointCloud2View {
   struct Field {
@@ -74,4 +74,4 @@ struct PointCloud2View {
   }
 };
 
-}  // namespace ros2_cuda_ipc_core
+}  // namespace ros2_cuda_ipc_core::view

--- a/ros2_cuda_ipc_core/src/mapper/buffer_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/src/mapper/buffer_view_mapper.cpp
@@ -36,7 +36,7 @@ BufferViewMapper& default_buffer_view_mapper() {
 BufferViewMapper::BufferViewMapper(BufferViewMapperOptions options)
     : options_(std::move(options)) {}
 
-BufferView BufferViewMapper::map(
+view::BufferView BufferViewMapper::map(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg) const {
   if (!is_supported_backend(static_cast<uint8_t>(msg.backend))) {
     RCLCPP_WARN(options_.logger, "Unsupported BufferCore.backend=%u",
@@ -75,7 +75,7 @@ BufferView BufferViewMapper::map(
         IpcHandleCache::instance().insert_or_discard_duplicate(key, *opened);
   }
 
-  BufferView view;
+  view::BufferView view;
   view.dev_ptr = imported.dev_ptr;
   view.ready_evt = imported.event;
   view.device_id = static_cast<int>(msg.device_id);
@@ -90,11 +90,12 @@ BufferView BufferViewMapper::map(
   return view;
 }
 
-BufferView map_buffer_view(const ros2_cuda_ipc_msgs::msg::BufferCore& msg) {
+view::BufferView map_buffer_view(
+    const ros2_cuda_ipc_msgs::msg::BufferCore& msg) {
   return default_buffer_view_mapper().map(msg);
 }
 
-void fill_buffer_core_message(const BufferView& view,
+void fill_buffer_core_message(const view::BufferView& view,
                               ros2_cuda_ipc_msgs::msg::BufferCore& msg) {
   msg.shm_name = view.shm_name;
   msg.device_id = static_cast<uint32_t>(view.device_id);

--- a/ros2_cuda_ipc_core/src/mapper/image_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/src/mapper/image_view_mapper.cpp
@@ -17,28 +17,28 @@ ImageViewMapper& default_image_view_mapper() {
 ImageViewMapper::ImageViewMapper(BufferViewMapper buffer_mapper)
     : buffer_mapper_(std::move(buffer_mapper)) {}
 
-ImageView ImageViewMapper::map(
+view::ImageView ImageViewMapper::map(
     const ros2_cuda_ipc_msgs::msg::GpuImage& msg) const {
-  BufferView core = buffer_mapper_.map(msg.core);
+  view::BufferView core = buffer_mapper_.map(msg.core);
   if (!core.valid()) {
-    return ImageView{};
+    return view::ImageView{};
   }
 
-  ImageView view;
-  view.core = std::move(core);
-  view.dtype = static_cast<DType>(msg.dtype);
-  view.shape = msg.shape;
-  view.strides = msg.strides;
-  view.encoding = msg.encoding;
-  view.header = msg.header;
-  return view;
+  view::ImageView mapped_view;
+  mapped_view.core = std::move(core);
+  mapped_view.dtype = static_cast<view::DType>(msg.dtype);
+  mapped_view.shape = msg.shape;
+  mapped_view.strides = msg.strides;
+  mapped_view.encoding = msg.encoding;
+  mapped_view.header = msg.header;
+  return mapped_view;
 }
 
-ImageView map_image_view(const ros2_cuda_ipc_msgs::msg::GpuImage& msg) {
+view::ImageView map_image_view(const ros2_cuda_ipc_msgs::msg::GpuImage& msg) {
   return default_image_view_mapper().map(msg);
 }
 
-void fill_gpu_image_message(const ImageView& view,
+void fill_gpu_image_message(const view::ImageView& view,
                             ros2_cuda_ipc_msgs::msg::GpuImage& msg) {
   msg.dtype = static_cast<uint8_t>(view.dtype);
   msg.shape = view.shape;

--- a/ros2_cuda_ipc_core/src/mapper/pointcloud2_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/src/mapper/pointcloud2_view_mapper.cpp
@@ -19,42 +19,43 @@ PointCloud2ViewMapper& default_pointcloud2_view_mapper() {
 PointCloud2ViewMapper::PointCloud2ViewMapper(BufferViewMapper buffer_mapper)
     : buffer_mapper_(std::move(buffer_mapper)) {}
 
-PointCloud2View PointCloud2ViewMapper::map(
+view::PointCloud2View PointCloud2ViewMapper::map(
     const ros2_cuda_ipc_msgs::msg::GpuPointCloud2& msg) const {
-  BufferView core = buffer_mapper_.map(msg.core);
+  view::BufferView core = buffer_mapper_.map(msg.core);
 
-  PointCloud2View view;
-  view.header = msg.header;
+  view::PointCloud2View mapped_view;
+  mapped_view.header = msg.header;
   if (!core.valid()) {
-    return view;
+    return mapped_view;
   }
 
-  view.core = std::move(core);
-  view.height = msg.height;
-  view.width = msg.width;
-  view.point_step = msg.point_step;
-  view.row_step = msg.row_step;
-  view.is_dense = msg.is_dense;
-  view.fields.reserve(msg.fields.size());
+  mapped_view.core = std::move(core);
+  mapped_view.height = msg.height;
+  mapped_view.width = msg.width;
+  mapped_view.point_step = msg.point_step;
+  mapped_view.row_step = msg.row_step;
+  mapped_view.is_dense = msg.is_dense;
+  mapped_view.fields.reserve(msg.fields.size());
   for (const auto& field : msg.fields) {
-    PointCloud2View::Field converted;
+    view::PointCloud2View::Field converted;
     converted.name = field.name;
     converted.offset = field.offset;
     converted.datatype = field.datatype;
     converted.count = field.count;
-    view.fields.emplace_back(std::move(converted));
+    mapped_view.fields.emplace_back(std::move(converted));
   }
 
-  return view;
+  return mapped_view;
 }
 
-PointCloud2View map_pointcloud2_view(
+view::PointCloud2View map_pointcloud2_view(
     const ros2_cuda_ipc_msgs::msg::GpuPointCloud2& msg) {
   return default_pointcloud2_view_mapper().map(msg);
 }
 
 void fill_gpu_pointcloud2_message(
-    const PointCloud2View& view, ros2_cuda_ipc_msgs::msg::GpuPointCloud2& msg) {
+    const view::PointCloud2View& view,
+    ros2_cuda_ipc_msgs::msg::GpuPointCloud2& msg) {
   msg.header = view.header;
   msg.height = view.height;
   msg.width = view.width;

--- a/ros2_cuda_ipc_core/src/pointcloud2_view.cpp
+++ b/ros2_cuda_ipc_core/src/pointcloud2_view.cpp
@@ -1,6 +1,0 @@
-// Copyright (c) 2026 Daisuke Kato
-// SPDX-License-Identifier: MIT
-
-#include "ros2_cuda_ipc_core/pointcloud2_view.hpp"
-
-namespace ros2_cuda_ipc_core {}  // namespace ros2_cuda_ipc_core

--- a/ros2_cuda_ipc_core/src/view/buffer_view.cpp
+++ b/ros2_cuda_ipc_core/src/view/buffer_view.cpp
@@ -1,12 +1,12 @@
 // Copyright (c) 2026 Daisuke Kato
 // SPDX-License-Identifier: MIT
 
-#include "ros2_cuda_ipc_core/buffer_view.hpp"
+#include "ros2_cuda_ipc_core/view/buffer_view.hpp"
 
 #include <algorithm>
 #include <cstring>
 
-namespace ros2_cuda_ipc_core {
+namespace ros2_cuda_ipc_core::view {
 
 BufferView::~BufferView() { reset(); }
 
@@ -104,4 +104,4 @@ void BufferView::set_ipc_handles(MemoryBackendKind backend,
   handles_ready_ = true;
 }
 
-}  // namespace ros2_cuda_ipc_core
+}  // namespace ros2_cuda_ipc_core::view

--- a/ros2_cuda_ipc_core/src/view/image_view.cpp
+++ b/ros2_cuda_ipc_core/src/view/image_view.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) 2026 Daisuke Kato
 // SPDX-License-Identifier: MIT
 
-#include "ros2_cuda_ipc_core/image_view.hpp"
+#include "ros2_cuda_ipc_core/view/image_view.hpp"
 
-namespace ros2_cuda_ipc_core {
+namespace ros2_cuda_ipc_core::view {
 
 uint32_t ImageView::elem_size_bytes() const noexcept {
   switch (dtype) {
@@ -35,4 +35,4 @@ bool ImageView::sanity_check() const noexcept {
   return core.byte_size >= needed;
 }
 
-}  // namespace ros2_cuda_ipc_core
+}  // namespace ros2_cuda_ipc_core::view

--- a/ros2_cuda_ipc_core/src/view/pointcloud2_view.cpp
+++ b/ros2_cuda_ipc_core/src/view/pointcloud2_view.cpp
@@ -1,0 +1,6 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#include "ros2_cuda_ipc_core/view/pointcloud2_view.hpp"
+
+namespace ros2_cuda_ipc_core::view {}  // namespace ros2_cuda_ipc_core::view

--- a/ros2_cuda_ipc_core/test/mapper/test_buffer_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/test/mapper/test_buffer_view_mapper.cpp
@@ -134,7 +134,7 @@ TEST_F(BufferViewMapperTest, MissingVmmSocketReturnsInvalidAndReleasesLease) {
 }
 
 TEST_F(BufferViewMapperTest, FillBufferCoreMessageCopiesCudaIpcHandles) {
-  ros2_cuda_ipc_core::BufferView view;
+  ros2_cuda_ipc_core::view::BufferView view;
   view.device_id = 2;
   view.byte_size = 64;
   view.slot_id = 5;
@@ -163,7 +163,7 @@ TEST_F(BufferViewMapperTest, FillBufferCoreMessageCopiesCudaIpcHandles) {
 }
 
 TEST_F(BufferViewMapperTest, FillBufferCoreMessagePreservesVmmPayload) {
-  ros2_cuda_ipc_core::BufferView view;
+  ros2_cuda_ipc_core::view::BufferView view;
   view.device_id = 3;
   view.byte_size = 128;
   view.slot_id = 7;

--- a/ros2_cuda_ipc_core/test/mapper/test_image_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/test/mapper/test_image_view_mapper.cpp
@@ -26,7 +26,7 @@ TEST_F(ImageViewMapperTest, InvalidCoreReturnsDefaultImageView) {
 
   ros2_cuda_ipc_msgs::msg::GpuImage msg;
   msg.header.frame_id = "frame";
-  msg.dtype = static_cast<uint8_t>(ros2_cuda_ipc_core::DType::U8);
+  msg.dtype = static_cast<uint8_t>(ros2_cuda_ipc_core::view::DType::U8);
   msg.shape = {4, 5, 3};
   msg.strides = {15, 3, 1};
   msg.encoding = "rgb8";
@@ -51,7 +51,7 @@ TEST_F(ImageViewMapperTest, CopiesMetadataWhenCoreIsValid) {
 
   ros2_cuda_ipc_msgs::msg::GpuImage msg;
   msg.header.frame_id = "camera_frame";
-  msg.dtype = static_cast<uint8_t>(ros2_cuda_ipc_core::DType::U16);
+  msg.dtype = static_cast<uint8_t>(ros2_cuda_ipc_core::view::DType::U16);
   msg.shape = {4, 5, 3};
   msg.strides = {30, 6, 2};
   msg.encoding = "mono16";
@@ -61,7 +61,7 @@ TEST_F(ImageViewMapperTest, CopiesMetadataWhenCoreIsValid) {
   auto view = mapper.map(msg);
   ASSERT_TRUE(view.core.valid());
   EXPECT_EQ(view.header.frame_id, "camera_frame");
-  EXPECT_EQ(view.dtype, ros2_cuda_ipc_core::DType::U16);
+  EXPECT_EQ(view.dtype, ros2_cuda_ipc_core::view::DType::U16);
   EXPECT_EQ(view.shape[1], 5u);
   EXPECT_EQ(view.strides[0], 30u);
   EXPECT_EQ(view.encoding, "mono16");
@@ -71,9 +71,9 @@ TEST_F(ImageViewMapperTest, CopiesMetadataWhenCoreIsValid) {
 }
 
 TEST_F(ImageViewMapperTest, FillGpuImageMessageCopiesMetadataAndCore) {
-  ros2_cuda_ipc_core::ImageView view;
+  ros2_cuda_ipc_core::view::ImageView view;
   view.header.frame_id = "frame";
-  view.dtype = ros2_cuda_ipc_core::DType::U8;
+  view.dtype = ros2_cuda_ipc_core::view::DType::U8;
   view.shape = {4, 5, 3};
   view.strides = {15, 3, 1};
   view.encoding = "rgb8";

--- a/ros2_cuda_ipc_core/test/mapper/test_pointcloud2_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/test/mapper/test_pointcloud2_view_mapper.cpp
@@ -86,7 +86,7 @@ TEST_F(PointCloud2ViewMapperTest, CopiesLayoutWhenCoreIsValid) {
 
 TEST_F(PointCloud2ViewMapperTest,
        FillGpuPointCloud2MessageCopiesLayoutAndCore) {
-  ros2_cuda_ipc_core::PointCloud2View view;
+  ros2_cuda_ipc_core::view::PointCloud2View view;
   view.header.frame_id = "frame";
   view.core.device_id = 1;
   view.core.byte_size = 120;

--- a/ros2_cuda_ipc_core/test/test_type_adapters.cpp
+++ b/ros2_cuda_ipc_core/test/test_type_adapters.cpp
@@ -24,9 +24,9 @@ TEST_F(TypeAdapterTest, BufferViewAdapterDelegatesReceivePath) {
   auto msg = ros2_cuda_ipc_core::test::make_seeded_buffer_core_message(
       "adapter_buffer", 41);
 
-  ros2_cuda_ipc_core::BufferView view;
+  ros2_cuda_ipc_core::view::BufferView view;
   rclcpp::TypeAdapter<
-      ros2_cuda_ipc_core::BufferView,
+      ros2_cuda_ipc_core::view::BufferView,
       ros2_cuda_ipc_msgs::msg::BufferCore>::convert_to_custom(msg, view);
 
   EXPECT_TRUE(view.valid());
@@ -38,9 +38,9 @@ TEST_F(TypeAdapterTest, BufferViewAdapterDelegatesReceivePath) {
 }
 
 TEST_F(TypeAdapterTest, ImageViewAdapterDelegatesSendPath) {
-  ros2_cuda_ipc_core::ImageView view;
+  ros2_cuda_ipc_core::view::ImageView view;
   view.header.frame_id = "frame";
-  view.dtype = ros2_cuda_ipc_core::DType::U8;
+  view.dtype = ros2_cuda_ipc_core::view::DType::U8;
   view.shape = {4, 5, 3};
   view.strides = {15, 3, 1};
   view.encoding = "rgb8";
@@ -57,7 +57,7 @@ TEST_F(TypeAdapterTest, ImageViewAdapterDelegatesSendPath) {
 
   ros2_cuda_ipc_msgs::msg::GpuImage msg;
   rclcpp::TypeAdapter<
-      ros2_cuda_ipc_core::ImageView,
+      ros2_cuda_ipc_core::view::ImageView,
       ros2_cuda_ipc_msgs::msg::GpuImage>::convert_to_ros_message(view, msg);
 
   EXPECT_EQ(msg.header.frame_id, "frame");
@@ -85,9 +85,9 @@ TEST_F(TypeAdapterTest, PointCloud2AdapterDelegatesReceiveAndSendPath) {
   field_x.count = 1;
   msg.fields = {field_x};
 
-  ros2_cuda_ipc_core::PointCloud2View view;
+  ros2_cuda_ipc_core::view::PointCloud2View view;
   rclcpp::TypeAdapter<
-      ros2_cuda_ipc_core::PointCloud2View,
+      ros2_cuda_ipc_core::view::PointCloud2View,
       ros2_cuda_ipc_msgs::msg::GpuPointCloud2>::convert_to_custom(msg, view);
 
   ASSERT_TRUE(view.core.valid());
@@ -95,7 +95,7 @@ TEST_F(TypeAdapterTest, PointCloud2AdapterDelegatesReceiveAndSendPath) {
   EXPECT_EQ(view.fields.size(), 1u);
 
   ros2_cuda_ipc_msgs::msg::GpuPointCloud2 roundtrip;
-  rclcpp::TypeAdapter<ros2_cuda_ipc_core::PointCloud2View,
+  rclcpp::TypeAdapter<ros2_cuda_ipc_core::view::PointCloud2View,
                       ros2_cuda_ipc_msgs::msg::GpuPointCloud2>::
       convert_to_ros_message(view, roundtrip);
 


### PR DESCRIPTION
## Pull request overview

This PR reorganizes the “view” data types in `ros2_cuda_ipc_core` by moving them under a dedicated `view/` header/source layout and the `ros2_cuda_ipc_core::view` namespace, then updates all dependent mappers, type adapters, tests, and downstream example nodes/docs accordingly.

**Changes:**
- Move `BufferView` / `ImageView` / `PointCloud2View` headers & sources under `ros2_cuda_ipc_core/view/*` and into `ros2_cuda_ipc_core::view`.
- Update mapper APIs and `rclcpp::TypeAdapter` specializations to use the new `view::` types.
- Update tests, example nodes (`julia_set`, `gpu_image_transport`), and documentation to match the new locations/namespacing.