### PR TITLE
fix test

### DIFF
--- a/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
@@ -32,7 +32,11 @@ TEST(IpcHandleCacheTest, KeyEqualityAndHashUseBackendPayloadAndEvent) {
 }
 
 TEST(IpcHandleCacheTest, DuplicateInsertReturnsExistingEntry) {
-  ros2_cuda_ipc_core::IpcHandleCache cache;
+  std::atomic<int> released{0};
+  ros2_cuda_ipc_core::IpcHandleCache cache(
+      [&released](const ros2_cuda_ipc_core::backend::ImportedBuffer&) {
+        released.fetch_add(1);
+      });
   ros2_cuda_ipc_core::IpcHandleKey key{};
   key.backend = 1;
   key.mem[0] = 11;

--- a/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
@@ -32,11 +32,8 @@ TEST(IpcHandleCacheTest, KeyEqualityAndHashUseBackendPayloadAndEvent) {
 }
 
 TEST(IpcHandleCacheTest, DuplicateInsertReturnsExistingEntry) {
-  std::atomic<int> released{0};
   ros2_cuda_ipc_core::IpcHandleCache cache(
-      [&released](const ros2_cuda_ipc_core::backend::ImportedBuffer&) {
-        released.fetch_add(1);
-      });
+      [](const ros2_cuda_ipc_core::backend::ImportedBuffer&) {});
   ros2_cuda_ipc_core::IpcHandleKey key{};
   key.backend = 1;
   key.mem[0] = 11;


### PR DESCRIPTION
## Pull request overview

This PR adjusts the `IpcHandleCache` unit test setup to avoid invoking the real `backend::release_imported_buffer` when inserting duplicate entries with fake CUDA handles/pointers.

**Changes:**
- Injects a custom release hook into `IpcHandleCache` construction in `DuplicateInsertReturnsExistingEntry` to prevent real CUDA resource cleanup on dummy values.

