### PR TITLE
Update CI configuration to include 'lyrical' ROS distribution and remove 'iron'

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,14 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.6",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:93b1cb77ac61b53dc987c1ae77f5dc9bb1ba73cb0b82204141a5b120e0d62860",
+      "integrity": "sha256:93b1cb77ac61b53dc987c1ae77f5dc9bb1ba73cb0b82204141a5b120e0d62860"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,13 +1,13 @@
 {
   "name": "ros2-cuda-ipc",
-  "image": "ghcr.io/dskkato/ros2-cuda-ipc-dev:latest",
+  "image": "ghcr.io/dskkato/ros2-cuda-ipc-dev:lyrical",
   "runArgs": [
     "--gpus=all",
     "--env",
     "NVIDIA_DRIVER_CAPABILITIES=compute,utility,graphics"
   ],
   "containerEnv": {
-    "ROS_DISTRO": "humble",
+    "ROS_DISTRO": "lyrical",
     "NVIDIA_VISIBLE_DEVICES": "all"
   },
   "remoteEnv": {

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,10 @@ jobs:
         include:
           - ros_distro: humble
             container_tag: humble
-          - ros_distro: iron
-            container_tag: iron
           - ros_distro: jazzy
             container_tag: jazzy
+          - ros_distro: lyrical
+            container_tag: lyrical
     container:
       image: ghcr.io/dskkato/ros2-cuda-ipc-dev:${{ matrix.container_tag }}
     env:

--- a/gpu_image_transport/CMakeLists.txt
+++ b/gpu_image_transport/CMakeLists.txt
@@ -28,13 +28,11 @@ target_include_directories(gpu_image_transport_base
 )
 
 target_link_libraries(gpu_image_transport_base
-  CUDA::cudart
-)
-
-ament_target_dependencies(gpu_image_transport_base
-  rclcpp
-  ros2_cuda_ipc_core
-  ros2_cuda_ipc_msgs
+  PUBLIC
+    rclcpp::rclcpp
+    ros2_cuda_ipc_core::ros2_cuda_ipc_core
+    ${ros2_cuda_ipc_msgs_TARGETS}
+    CUDA::cudart
 )
 
 add_executable(gpu_image_transport
@@ -43,13 +41,7 @@ add_executable(gpu_image_transport
 
 target_link_libraries(gpu_image_transport
   gpu_image_transport_base
-)
-
-ament_target_dependencies(gpu_image_transport
-  rclcpp
-  sensor_msgs
-  ros2_cuda_ipc_core
-  ros2_cuda_ipc_msgs
+  ${sensor_msgs_TARGETS}
 )
 
 add_executable(gpu_image_transport_compressed
@@ -64,14 +56,8 @@ target_include_directories(gpu_image_transport_compressed
 
 target_link_libraries(gpu_image_transport_compressed
   gpu_image_transport_base
+  ${sensor_msgs_TARGETS}
   ${OpenCV_LIBRARIES}
-)
-
-ament_target_dependencies(gpu_image_transport_compressed
-  rclcpp
-  sensor_msgs
-  ros2_cuda_ipc_core
-  ros2_cuda_ipc_msgs
 )
 
 install(TARGETS

--- a/julia_set/CMakeLists.txt
+++ b/julia_set/CMakeLists.txt
@@ -38,12 +38,10 @@ target_include_directories(julia_set_helpers
 )
 
 target_link_libraries(julia_set_helpers
-  CUDA::cudart
-)
-
-ament_target_dependencies(julia_set_helpers
-  rclcpp
-  ros2_cuda_ipc_core
+  PUBLIC
+    rclcpp::rclcpp
+    ros2_cuda_ipc_core::ros2_cuda_ipc_core
+    CUDA::cudart
 )
 
 # executables
@@ -54,24 +52,14 @@ add_executable(julia_set_publisher
 )
 target_link_libraries(julia_set_publisher
   julia_set_helpers
+  ${ros2_cuda_ipc_msgs_TARGETS}
 )
 
 ## Colorize Node
 add_executable(colorize_node src/colorize_node.cpp)
 target_link_libraries(colorize_node
   julia_set_helpers
-)
-
-ament_target_dependencies(julia_set_publisher
-  rclcpp
-  ros2_cuda_ipc_core
-  ros2_cuda_ipc_msgs
-)
-
-ament_target_dependencies(colorize_node
-  rclcpp
-  ros2_cuda_ipc_core
-  ros2_cuda_ipc_msgs
+  ${ros2_cuda_ipc_msgs_TARGETS}
 )
 
 install(TARGETS

--- a/ros2_cuda_ipc_core/CMakeLists.txt
+++ b/ros2_cuda_ipc_core/CMakeLists.txt
@@ -47,15 +47,18 @@ target_include_directories(${PROJECT_NAME}
   $<INSTALL_INTERFACE:include>
 )
 
-ament_target_dependencies(${PROJECT_NAME}
-  rclcpp
-  rcpputils
-  ros2_cuda_ipc_msgs
-  sensor_msgs
-  std_msgs
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+    rclcpp::rclcpp
+    rcpputils::rcpputils
+    ${ros2_cuda_ipc_msgs_TARGETS}
+    ${sensor_msgs_TARGETS}
+    ${std_msgs_TARGETS}
+    CUDA::cudart
+    CUDA::cuda_driver
+  PRIVATE
+    ${UUID_LIB}
 )
-
-target_link_libraries(${PROJECT_NAME} CUDA::cudart CUDA::cuda_driver ${UUID_LIB})
 
 install(TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}


### PR DESCRIPTION
## Pull request overview

Updates the CI build matrix to track the current ROS 2 release set for this repository by replacing the `iron` job entry with `lyrical`.

**Changes:**
- Removed `iron` from the GitHub Actions matrix.
- Added `lyrical` to the GitHub Actions matrix (with matching `container_tag` and `ROS_DISTRO`).

