### PR TITLE
Update launch command in README to use width and height parameters instead of resolution

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -105,7 +105,7 @@ ros2 launch multi_process_image_fanout multi_process_image_fanout.launch.py \
 ```
 
 This writes separate reports named
-`fanout-<arch>-<resolution>-<rate>-<label>-<node>`. Override
+`fanout-<arch>-<width>x<height>-<rate>-<label>-<node>`. Override
 `nsys_profile_flags` to change the default `--trace=osrt,nvtx,cuda` flags.
 
 Expected NVTX ranges include slot acquisition, producer kernel work, input

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ export CUDACXX=/usr/local/cuda/bin/nvcc
 
 ```bash
 ros2 launch multi_process_image_fanout multi_process_image_fanout.launch.py \
-  resolution:=720p \
+  width:=1280 \
+  height:=720 \
   publish_rate_hz:=60.0 \
   memory_backend:=cuda_ipc \
   slot_count:=4 \
@@ -53,9 +54,6 @@ ros2 launch multi_process_image_fanout multi_process_image_fanout.launch.py \
   shm_name:=/ros2_cuda_ipc_fanout \
   device_index:=0
 ```
-
-`resolution` accepts `480p`, `720p`, `1080p`, `4K`, `8K`, and `16K`. If you
-need a custom size, pass `width` and `height`.
 
 The memory backend can be selected at launch:
 


### PR DESCRIPTION
## Pull request overview

Updates documentation to reflect that the `multi_process_image_fanout.launch.py` launch file is configured via explicit `width`/`height` arguments (rather than a `resolution` preset), aligning the top-level docs with the actual launch interface and profiling output naming scheme.

**Changes:**
- README launch example now uses `width:=...` and `height:=...` instead of `resolution:=...`.
- DEVELOPING profiling report filename template updated to include `<width>x<height>` instead of `<resolution>`.
