### PR TITLE
Implement slot mapping in GpuLeasePool

### DIFF
--- a/examples/multi_process_image_fanout/src/image_publisher_helper.cpp
+++ b/examples/multi_process_image_fanout/src/image_publisher_helper.cpp
@@ -99,7 +99,10 @@ ImagePublisherHelper::produce(std::size_t subscriber_count,
   if (err != cudaSuccess) {
     RCLCPP_ERROR(logger_, "launch_generate_rgba_pattern_kernel failed: %s",
                  ros2_cuda_ipc_core::cuda::cuda_error_to_string(err).c_str());
-    pool_.cancel_pending(*slot);
+    if (!pool_.cancel_pending(*slot)) {
+      RCLCPP_WARN(logger_, "Failed to cancel pending lease for slot %u",
+                  slot->index);
+    }
     return std::nullopt;
   }
 

--- a/examples/multi_process_image_fanout/src/image_publisher_helper.cpp
+++ b/examples/multi_process_image_fanout/src/image_publisher_helper.cpp
@@ -118,7 +118,7 @@ ImagePublisherHelper::produce(std::size_t subscriber_count,
   // Publishable metadata for the GPU buffer and IPC handles. The pixel payload
   // stays on the device.
   ros2_cuda_ipc_core::view::ImageView view;
-  view.core = pool_.map_slot(*slot);
+  view.core = pool_.buffer_view_from(*slot);
   view.dtype = ros2_cuda_ipc_core::view::DType::U8;
   view.shape = {config_.height, config_.width, kDefaultChannels};
   view.strides = {config_.width * kBytesPerPixel, kDefaultChannels, 1};

--- a/examples/multi_process_image_fanout/src/image_publisher_helper.cpp
+++ b/examples/multi_process_image_fanout/src/image_publisher_helper.cpp
@@ -99,6 +99,7 @@ ImagePublisherHelper::produce(std::size_t subscriber_count,
   if (err != cudaSuccess) {
     RCLCPP_ERROR(logger_, "launch_generate_rgba_pattern_kernel failed: %s",
                  ros2_cuda_ipc_core::cuda::cuda_error_to_string(err).c_str());
+    pool_.cancel_pending(*slot);
     return std::nullopt;
   }
 
@@ -110,21 +111,14 @@ ImagePublisherHelper::produce(std::size_t subscriber_count,
   if (err != cudaSuccess) {
     RCLCPP_ERROR(logger_, "cudaEventRecord failed for slot %u: %s", slot->index,
                  ros2_cuda_ipc_core::cuda::cuda_error_to_string(err).c_str());
+    pool_.cancel_pending(*slot);
     return std::nullopt;
   }
 
   // Publishable metadata for the GPU buffer and IPC handles. The pixel payload
   // stays on the device.
   ros2_cuda_ipc_core::view::ImageView view;
-  view.core.dev_ptr = slot->device_ptr;
-  view.core.ready_evt = slot->event;
-  view.core.device_id = config_.device_index;
-  view.core.byte_size = frame_size_bytes_;
-  view.core.slot_id = slot->index;
-  view.core.generation = slot->generation;
-  view.core.shm_name = config_.shm_name;
-  view.core.set_ipc_handles(slot->backend, slot->mem_handle.data(),
-                            slot->mem_handle.size(), slot->event_handle);
+  view.core = pool_.map_slot(*slot);
   view.dtype = ros2_cuda_ipc_core::view::DType::U8;
   view.shape = {config_.height, config_.width, kDefaultChannels};
   view.strides = {config_.width * kBytesPerPixel, kDefaultChannels, 1};

--- a/examples/multi_process_image_fanout/src/image_publisher_helper.cpp
+++ b/examples/multi_process_image_fanout/src/image_publisher_helper.cpp
@@ -114,7 +114,10 @@ ImagePublisherHelper::produce(std::size_t subscriber_count,
   if (err != cudaSuccess) {
     RCLCPP_ERROR(logger_, "cudaEventRecord failed for slot %u: %s", slot->index,
                  ros2_cuda_ipc_core::cuda::cuda_error_to_string(err).c_str());
-    pool_.cancel_pending(*slot);
+    if (!pool_.cancel_pending(*slot)) {
+      RCLCPP_WARN(logger_, "Failed to cancel pending lease for slot %u",
+                  slot->index);
+    }
     return std::nullopt;
   }
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/cuda/gpu_lease_pool.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/cuda/gpu_lease_pool.hpp
@@ -13,6 +13,7 @@
 
 #include "rclcpp/logger.hpp"
 #include "ros2_cuda_ipc_core/memory_types.hpp"
+#include "ros2_cuda_ipc_core/view/buffer_view.hpp"
 
 namespace ros2_cuda_ipc_core::cuda {
 
@@ -63,6 +64,8 @@ class GpuLeasePool {
 
   uint64_t frame_size_bytes() const noexcept { return frame_size_bytes_; }
   int device_index() const noexcept { return device_index_; }
+
+  view::BufferView map_slot(const Slot& slot) const noexcept;
 
   class MemoryBackend {
    public:

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/cuda/gpu_lease_pool.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/cuda/gpu_lease_pool.hpp
@@ -65,7 +65,7 @@ class GpuLeasePool {
   uint64_t frame_size_bytes() const noexcept { return frame_size_bytes_; }
   int device_index() const noexcept { return device_index_; }
 
-  view::BufferView buffer_view_from(const Slot& slot) const noexcept;
+  view::BufferView buffer_view_from(const Slot& slot) const;
 
   class MemoryBackend {
    public:

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/cuda/gpu_lease_pool.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/cuda/gpu_lease_pool.hpp
@@ -65,7 +65,7 @@ class GpuLeasePool {
   uint64_t frame_size_bytes() const noexcept { return frame_size_bytes_; }
   int device_index() const noexcept { return device_index_; }
 
-  view::BufferView map_slot(const Slot& slot) const noexcept;
+  view::BufferView buffer_view_from(const Slot& slot) const noexcept;
 
   class MemoryBackend {
    public:

--- a/ros2_cuda_ipc_core/src/cuda/gpu_lease_pool.cpp
+++ b/ros2_cuda_ipc_core/src/cuda/gpu_lease_pool.cpp
@@ -167,6 +167,20 @@ bool GpuLeasePool::cancel_pending(Slot& slot) {
   return false;
 }
 
+view::BufferView GpuLeasePool::map_slot(const Slot& slot) const noexcept {
+  view::BufferView view;
+  view.dev_ptr = slot.device_ptr;
+  view.ready_evt = slot.event;
+  view.device_id = device_index_;
+  view.byte_size = frame_size_bytes_;
+  view.slot_id = slot.index;
+  view.generation = slot.generation;
+  view.shm_name = config_.shm_name;
+  view.set_ipc_handles(slot.backend, slot.mem_handle.data(),
+                       slot.mem_handle.size(), slot.event_handle);
+  return view;
+}
+
 bool GpuLeasePool::allocate_slots() {
   memory_backend_ = make_backend(config_.backend);
   if (!memory_backend_) {

--- a/ros2_cuda_ipc_core/src/cuda/gpu_lease_pool.cpp
+++ b/ros2_cuda_ipc_core/src/cuda/gpu_lease_pool.cpp
@@ -167,7 +167,8 @@ bool GpuLeasePool::cancel_pending(Slot& slot) {
   return false;
 }
 
-view::BufferView GpuLeasePool::map_slot(const Slot& slot) const noexcept {
+view::BufferView GpuLeasePool::buffer_view_from(
+    const Slot& slot) const noexcept {
   view::BufferView view;
   view.dev_ptr = slot.device_ptr;
   view.ready_evt = slot.event;

--- a/ros2_cuda_ipc_core/src/cuda/gpu_lease_pool.cpp
+++ b/ros2_cuda_ipc_core/src/cuda/gpu_lease_pool.cpp
@@ -167,8 +167,7 @@ bool GpuLeasePool::cancel_pending(Slot& slot) {
   return false;
 }
 
-view::BufferView GpuLeasePool::buffer_view_from(
-    const Slot& slot) const noexcept {
+view::BufferView GpuLeasePool::buffer_view_from(const Slot& slot) const {
   view::BufferView view;
   view.dev_ptr = slot.device_ptr;
   view.ready_evt = slot.event;

--- a/ros2_cuda_ipc_core/test/test_gpu_lease_pool.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_lease_pool.cpp
@@ -8,6 +8,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstring>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -114,6 +115,35 @@ TEST_F(GpuLeasePoolTest, ReclaimStalePendingClearsLease) {
       ros2_cuda_ipc_core::LeaseHandle::current_pending(shm_name, slot->index);
   ASSERT_TRUE(pending_after.has_value());
   EXPECT_EQ(pending_after.value(), 0u);
+
+  pool.reset();
+  ::shm_unlink(shm_name.c_str());
+}
+
+TEST_F(GpuLeasePoolTest, BufferViewFromCopiesSlotMetadataAndIpcHandles) {
+  const std::string shm_name = make_unique_shm_name("gpu_buffer_view_from");
+  auto logger = rclcpp::get_logger("GpuLeasePoolTest");
+  GpuLeasePool pool({shm_name, 1, std::chrono::milliseconds(100)}, logger);
+
+  ASSERT_TRUE(pool.initialise(1024, 0));
+  auto* slot = pool.acquire(0);
+  ASSERT_NE(slot, nullptr);
+
+  const auto view = pool.buffer_view_from(*slot);
+  EXPECT_TRUE(view.valid());
+  EXPECT_EQ(view.dev_ptr, slot->device_ptr);
+  EXPECT_EQ(view.ready_evt, slot->event);
+  EXPECT_EQ(view.device_id, 0);
+  EXPECT_EQ(view.byte_size, 1024u);
+  EXPECT_EQ(view.slot_id, slot->index);
+  EXPECT_EQ(view.generation, slot->generation);
+  EXPECT_EQ(view.shm_name, shm_name);
+  EXPECT_EQ(view.backend(), slot->backend);
+  EXPECT_TRUE(view.handles_ready());
+  EXPECT_EQ(view.mem_payload(), slot->mem_handle);
+  EXPECT_EQ(std::memcmp(&view.event_handle(), &slot->event_handle,
+                        sizeof(cudaIpcEventHandle_t)),
+            0);
 
   pool.reset();
   ::shm_unlink(shm_name.c_str());


### PR DESCRIPTION
## Pull request overview

This PR introduces a centralized “slot → publishable view” conversion helper in `GpuLeasePool`, and updates the multi-process image fanout example to use it while also improving cleanup on CUDA error paths.
