### PR TITLE
Add clock support to GpuBufferController and SlotController

### DIFF
--- a/examples/multi_process_image_fanout/src/gpu_image_publisher.cpp
+++ b/examples/multi_process_image_fanout/src/gpu_image_publisher.cpp
@@ -69,7 +69,7 @@ class GpuImagePublisherNode : public rclcpp::Node {
             ros2_cuda_ipc_core::publisher::GpuBufferController::Config{
                 shm_name, slot_count, frame_size_bytes, device_index,
                 pending_ttl, backend},
-            get_logger().get_child("GpuBufferController"));
+            get_logger().get_child("GpuBufferController"), get_clock());
     if (!controller_->initialise()) {
       throw std::runtime_error("Failed to initialise GPU buffer controller");
     }

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_controller.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_controller.hpp
@@ -73,8 +73,8 @@ class GpuBufferController {
         transport::MemoryBackendKind::CUDA_IPC;
   };
 
-  /// The clock must be the owning Node's get_clock() result so pending TTL
-  /// follows use_sim_time.
+  /// The clock must be non-null. Pass the owning Node's get_clock() result to
+  /// make pending TTL follow that node's use_sim_time setting.
   GpuBufferController(Config config, rclcpp::Logger logger,
                       rclcpp::Clock::SharedPtr clock);
   ~GpuBufferController() = default;
@@ -101,6 +101,7 @@ class GpuBufferController {
 
   Config config_;
   rclcpp::Logger logger_;
+  rclcpp::Clock::SharedPtr clock_;
   GpuBufferPool buffer_pool_;
   SlotController slot_controller_;
 };

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_controller.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_controller.hpp
@@ -10,6 +10,7 @@
 #include <optional>
 #include <string>
 
+#include "rclcpp/clock.hpp"
 #include "rclcpp/logger.hpp"
 #include "ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp"
 #include "ros2_cuda_ipc_core/publisher/slot_controller.hpp"
@@ -72,7 +73,10 @@ class GpuBufferController {
         transport::MemoryBackendKind::CUDA_IPC;
   };
 
-  GpuBufferController(Config config, rclcpp::Logger logger);
+  /// The clock must be the owning Node's get_clock() result so pending TTL
+  /// follows use_sim_time.
+  GpuBufferController(Config config, rclcpp::Logger logger,
+                      rclcpp::Clock::SharedPtr clock);
   ~GpuBufferController() = default;
   GpuBufferController(const GpuBufferController&) = delete;
   GpuBufferController& operator=(const GpuBufferController&) = delete;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/slot_controller.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/slot_controller.hpp
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "rclcpp/clock.hpp"
 #include "rclcpp/logger.hpp"
 
 namespace ros2_cuda_ipc_core::publisher {
@@ -22,7 +23,8 @@ class SlotController {
   };
 
   SlotController(std::string shm_name, std::size_t slot_count,
-                 std::chrono::milliseconds pending_ttl, rclcpp::Logger logger);
+                 std::chrono::milliseconds pending_ttl, rclcpp::Logger logger,
+                 rclcpp::Clock::SharedPtr clock);
 
   bool initialise();
   void reset() noexcept;
@@ -32,16 +34,16 @@ class SlotController {
   void reclaim_stale_pending();
 
   const std::string& shm_name() const noexcept { return shm_name_; }
-  std::chrono::steady_clock::time_point pending_deadline(
-      uint32_t slot_id) const noexcept;
+  rclcpp::Time pending_deadline(uint32_t slot_id) const noexcept;
 
  private:
   std::string shm_name_;
   std::size_t slot_count_;
   std::chrono::milliseconds pending_ttl_;
+  rclcpp::Clock::SharedPtr clock_;
   rclcpp::Logger logger_;
   mutable std::mutex deadlines_mutex_;
-  std::vector<std::chrono::steady_clock::time_point> pending_deadlines_;
+  std::vector<rclcpp::Time> pending_deadlines_;
   bool initialised_ = false;
 };
 

--- a/ros2_cuda_ipc_core/src/publisher/gpu_buffer_controller.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/gpu_buffer_controller.cpp
@@ -77,14 +77,15 @@ void PublishSlot::cancel() noexcept {
   }
 }
 
-GpuBufferController::GpuBufferController(Config config, rclcpp::Logger logger)
+GpuBufferController::GpuBufferController(Config config, rclcpp::Logger logger,
+                                         rclcpp::Clock::SharedPtr clock)
     : config_(std::move(config)),
       logger_(std::move(logger)),
       buffer_pool_(config_.slot_count, config_.backend,
                    logger_.get_child("GpuBufferPool")),
       slot_controller_(config_.shm_name, config_.slot_count,
-                       config_.pending_ttl,
-                       logger_.get_child("SlotController")) {}
+                       config_.pending_ttl, logger_.get_child("SlotController"),
+                       std::move(clock)) {}
 
 bool GpuBufferController::initialise() {
   reset();

--- a/ros2_cuda_ipc_core/src/publisher/gpu_buffer_controller.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/gpu_buffer_controller.cpp
@@ -4,9 +4,21 @@
 #include "ros2_cuda_ipc_core/publisher/gpu_buffer_controller.hpp"
 
 #include <cassert>
+#include <stdexcept>
 #include <utility>
 
 namespace ros2_cuda_ipc_core::publisher {
+namespace {
+
+rclcpp::Clock::SharedPtr require_clock(rclcpp::Clock::SharedPtr clock) {
+  if (!clock) {
+    throw std::invalid_argument(
+        "GpuBufferController requires a non-null clock");
+  }
+  return clock;
+}
+
+}  // namespace
 
 PublishSlot::PublishSlot(GpuBufferController* owner,
                          SlotController::Reservation reservation) noexcept
@@ -81,11 +93,12 @@ GpuBufferController::GpuBufferController(Config config, rclcpp::Logger logger,
                                          rclcpp::Clock::SharedPtr clock)
     : config_(std::move(config)),
       logger_(std::move(logger)),
+      clock_(require_clock(std::move(clock))),
       buffer_pool_(config_.slot_count, config_.backend,
                    logger_.get_child("GpuBufferPool")),
       slot_controller_(config_.shm_name, config_.slot_count,
                        config_.pending_ttl, logger_.get_child("SlotController"),
-                       std::move(clock)) {}
+                       clock_) {}
 
 bool GpuBufferController::initialise() {
   reset();

--- a/ros2_cuda_ipc_core/src/publisher/slot_controller.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/slot_controller.cpp
@@ -3,25 +3,37 @@
 
 #include "ros2_cuda_ipc_core/publisher/slot_controller.hpp"
 
+#include <stdexcept>
+
 #include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/lease/lease_handle.hpp"
 
 namespace ros2_cuda_ipc_core::publisher {
 namespace {
-using Clock = std::chrono::steady_clock;
+rclcpp::Clock::SharedPtr require_clock(rclcpp::Clock::SharedPtr clock) {
+  if (!clock) {
+    throw std::invalid_argument("SlotController requires a clock");
+  }
+  return clock;
+}
 
-bool deadline_reached(const Clock::time_point& deadline,
-                      const Clock::time_point& now) {
-  return deadline.time_since_epoch().count() != 0 && now >= deadline;
+rclcpp::Time zero_time(rcl_clock_type_t clock_type) {
+  return rclcpp::Time(int64_t{0}, clock_type);
+}
+
+bool deadline_reached(const rclcpp::Time& deadline, const rclcpp::Time& now) {
+  return deadline.nanoseconds() != 0 && now >= deadline;
 }
 }  // namespace
 
 SlotController::SlotController(std::string shm_name, std::size_t slot_count,
                                std::chrono::milliseconds pending_ttl,
-                               rclcpp::Logger logger)
+                               rclcpp::Logger logger,
+                               rclcpp::Clock::SharedPtr clock)
     : shm_name_(std::move(shm_name)),
       slot_count_(slot_count),
       pending_ttl_(pending_ttl),
+      clock_(require_clock(std::move(clock))),
       logger_(std::move(logger)) {}
 
 bool SlotController::initialise() {
@@ -32,7 +44,7 @@ bool SlotController::initialise() {
   }
   {
     std::lock_guard<std::mutex> lock(deadlines_mutex_);
-    pending_deadlines_.assign(slot_count_, {});
+    pending_deadlines_.assign(slot_count_, zero_time(clock_->get_clock_type()));
     initialised_ = true;
   }
   return true;
@@ -81,9 +93,11 @@ std::optional<SlotController::Reservation> SlotController::reserve_for_publish(
     std::lock_guard<std::mutex> lock(deadlines_mutex_);
     if (initialised_ && reservation->slot_id < pending_deadlines_.size()) {
       if (pending_count > 0 && pending_ttl_.count() > 0) {
-        pending_deadlines_[reservation->slot_id] = Clock::now() + pending_ttl_;
+        pending_deadlines_[reservation->slot_id] =
+            clock_->now() + rclcpp::Duration(pending_ttl_);
       } else {
-        pending_deadlines_[reservation->slot_id] = {};
+        pending_deadlines_[reservation->slot_id] =
+            zero_time(clock_->get_clock_type());
       }
       return Reservation{reservation->slot_id, reservation->generation};
     }
@@ -112,7 +126,8 @@ bool SlotController::cancel(const Reservation& reservation) noexcept {
   if (cancelled) {
     std::lock_guard<std::mutex> lock(deadlines_mutex_);
     if (reservation.slot_id < pending_deadlines_.size()) {
-      pending_deadlines_[reservation.slot_id] = {};
+      pending_deadlines_[reservation.slot_id] =
+          zero_time(clock_->get_clock_type());
     }
   }
   return cancelled;
@@ -123,7 +138,7 @@ void SlotController::reclaim_stale_pending() {
   if (!initialised_ || pending_ttl_.count() <= 0) {
     return;
   }
-  const auto now = Clock::now();
+  const auto now = clock_->now();
   for (uint32_t slot_id = 0; slot_id < pending_deadlines_.size(); ++slot_id) {
     auto& deadline = pending_deadlines_[slot_id];
     if (!deadline_reached(deadline, now)) {
@@ -135,23 +150,22 @@ void SlotController::reclaim_stale_pending() {
       continue;
     }
     if (*pending == 0) {
-      deadline = {};
+      deadline = zero_time(clock_->get_clock_type());
       continue;
     }
     if (lease::LeaseHandle::force_clear_pending(shm_name_, slot_id)) {
       RCLCPP_WARN(logger_,
                   "Force-cleared pending lease slot=%u after %lld ms timeout",
                   slot_id, static_cast<long long>(pending_ttl_.count()));
-      deadline = {};
+      deadline = zero_time(clock_->get_clock_type());
     }
   }
 }
 
-Clock::time_point SlotController::pending_deadline(
-    uint32_t slot_id) const noexcept {
+rclcpp::Time SlotController::pending_deadline(uint32_t slot_id) const noexcept {
   std::lock_guard<std::mutex> lock(deadlines_mutex_);
   if (slot_id >= pending_deadlines_.size()) {
-    return {};
+    return zero_time(clock_->get_clock_type());
   }
   return pending_deadlines_[slot_id];
 }

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_controller.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_controller.cpp
@@ -8,6 +8,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <string>

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_controller.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_controller.cpp
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <chrono>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <type_traits>
@@ -54,10 +55,20 @@ class GpuBufferControllerTest : public ::testing::Test {
     return GpuBufferController(
         {shm_name_, 1, 1024, 0, pending_ttl,
          ros2_cuda_ipc_core::transport::MemoryBackendKind::CUDA_IPC},
-        rclcpp::get_logger("GpuBufferControllerTest"));
+        rclcpp::get_logger("GpuBufferControllerTest"),
+        std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME));
   }
   std::string shm_name_;
 };
+
+TEST(GpuBufferControllerClockTest, RejectsNullClock) {
+  EXPECT_THROW(GpuBufferController(
+                   {"/gpu_controller_null_clock", 1, 1024, 0,
+                    std::chrono::milliseconds(100),
+                    ros2_cuda_ipc_core::transport::MemoryBackendKind::CUDA_IPC},
+                   rclcpp::get_logger("GpuBufferControllerTest"), nullptr),
+               std::invalid_argument);
+}
 
 TEST_F(GpuBufferControllerTest, DescriptorIsGatedByReadyRecording) {
   auto controller = make_controller();

--- a/ros2_cuda_ipc_core/test/test_slot_controller.cpp
+++ b/ros2_cuda_ipc_core/test/test_slot_controller.cpp
@@ -14,6 +14,7 @@
 #include <thread>
 #include <utility>
 
+#include "rcl/time.h"
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_cuda_ipc_core/lease/lease_handle.hpp"
 #include "ros2_cuda_ipc_core/publisher/slot_controller.hpp"
@@ -37,6 +38,30 @@ class ShmUnlinkGuard {
 
  private:
   std::string name_;
+};
+
+class RosTimeOverrideGuard {
+ public:
+  explicit RosTimeOverrideGuard(rcl_clock_t* clock) : clock_(clock) {}
+  ~RosTimeOverrideGuard() {
+    if (enabled_) {
+      const rcl_ret_t result = rcl_disable_ros_time_override(clock_);
+      (void)result;
+    }
+  }
+
+  rcl_ret_t enable() {
+    const rcl_ret_t result = rcl_enable_ros_time_override(clock_);
+    enabled_ = result == RCL_RET_OK;
+    return result;
+  }
+
+  RosTimeOverrideGuard(const RosTimeOverrideGuard&) = delete;
+  RosTimeOverrideGuard& operator=(const RosTimeOverrideGuard&) = delete;
+
+ private:
+  rcl_clock_t* clock_;
+  bool enabled_ = false;
 };
 
 }  // namespace
@@ -113,8 +138,8 @@ TEST(SlotControllerTest, ReclaimsPendingUsingInjectedRosClock) {
   const std::string shm_name = make_unique_shm_name();
   const ShmUnlinkGuard shm_guard(shm_name);
   const auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
-  ASSERT_EQ(rcl_enable_ros_time_override(clock->get_clock_handle()),
-            RCL_RET_OK);
+  RosTimeOverrideGuard ros_time_override(clock->get_clock_handle());
+  ASSERT_EQ(ros_time_override.enable(), RCL_RET_OK);
   ASSERT_EQ(rcl_set_ros_time_override(clock->get_clock_handle(), 0),
             RCL_RET_OK);
 
@@ -134,9 +159,6 @@ TEST(SlotControllerTest, ReclaimsPendingUsingInjectedRosClock) {
     controller.reclaim_stale_pending();
     EXPECT_TRUE(controller.reserve_for_publish(0).has_value());
   }
-
-  EXPECT_EQ(rcl_disable_ros_time_override(clock->get_clock_handle()),
-            RCL_RET_OK);
 }
 
 TEST(SlotControllerTest, RejectsNullClock) {

--- a/ros2_cuda_ipc_core/test/test_slot_controller.cpp
+++ b/ros2_cuda_ipc_core/test/test_slot_controller.cpp
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <optional>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <utility>
@@ -41,12 +42,13 @@ class ShmUnlinkGuard {
 }  // namespace
 
 TEST(SlotControllerTest, ResetRacingWithReserveDoesNotLeavePending) {
+  const auto clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
   for (int iteration = 0; iteration < 1000; ++iteration) {
     const std::string shm_name = make_unique_shm_name();
     const ShmUnlinkGuard shm_guard(shm_name);
     ros2_cuda_ipc_core::publisher::SlotController controller(
         shm_name, 1, std::chrono::milliseconds(100),
-        rclcpp::get_logger("SlotControllerTest"));
+        rclcpp::get_logger("SlotControllerTest"), clock);
     ASSERT_TRUE(controller.initialise());
 
     std::atomic<bool> start{false};
@@ -82,9 +84,10 @@ TEST(SlotControllerTest, ResetRacingWithReserveDoesNotLeavePending) {
 TEST(SlotControllerTest, CapacityMismatchRollsBackOutOfRangeReservation) {
   const std::string shm_name = make_unique_shm_name();
   const ShmUnlinkGuard shm_guard(shm_name);
+  const auto clock = std::make_shared<rclcpp::Clock>(RCL_SYSTEM_TIME);
   ros2_cuda_ipc_core::publisher::SlotController controller(
       shm_name, 1, std::chrono::milliseconds(100),
-      rclcpp::get_logger("SlotControllerTest"));
+      rclcpp::get_logger("SlotControllerTest"), clock);
   ASSERT_TRUE(controller.initialise());
 
   // Simulate an unsupported second Publisher reinitialising the same name
@@ -104,4 +107,41 @@ TEST(SlotControllerTest, CapacityMismatchRollsBackOutOfRangeReservation) {
 
   EXPECT_TRUE(ros2_cuda_ipc_core::lease::LeaseHandle::cancel_pending(
       shm_name, occupied->slot_id, occupied->generation));
+}
+
+TEST(SlotControllerTest, ReclaimsPendingUsingInjectedRosClock) {
+  const std::string shm_name = make_unique_shm_name();
+  const ShmUnlinkGuard shm_guard(shm_name);
+  const auto clock = std::make_shared<rclcpp::Clock>(RCL_ROS_TIME);
+  ASSERT_EQ(rcl_enable_ros_time_override(clock->get_clock_handle()),
+            RCL_RET_OK);
+  ASSERT_EQ(rcl_set_ros_time_override(clock->get_clock_handle(), 0),
+            RCL_RET_OK);
+
+  {
+    ros2_cuda_ipc_core::publisher::SlotController controller(
+        shm_name, 1, std::chrono::milliseconds(100),
+        rclcpp::get_logger("SlotControllerTest"), clock);
+    ASSERT_TRUE(controller.initialise());
+    auto reservation = controller.reserve_for_publish(1);
+    ASSERT_TRUE(reservation.has_value());
+
+    controller.reclaim_stale_pending();
+    EXPECT_FALSE(controller.reserve_for_publish(0).has_value());
+
+    ASSERT_EQ(rcl_set_ros_time_override(clock->get_clock_handle(), 100000000),
+              RCL_RET_OK);
+    controller.reclaim_stale_pending();
+    EXPECT_TRUE(controller.reserve_for_publish(0).has_value());
+  }
+
+  EXPECT_EQ(rcl_disable_ros_time_override(clock->get_clock_handle()),
+            RCL_RET_OK);
+}
+
+TEST(SlotControllerTest, RejectsNullClock) {
+  EXPECT_THROW(ros2_cuda_ipc_core::publisher::SlotController(
+                   make_unique_shm_name(), 1, std::chrono::milliseconds(100),
+                   rclcpp::get_logger("SlotControllerTest"), nullptr),
+               std::invalid_argument);
 }

--- a/ros2_cuda_ipc_core/test/test_slot_controller.cpp
+++ b/ros2_cuda_ipc_core/test/test_slot_controller.cpp
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <memory>
 #include <optional>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
- Updated constructors to accept rclcpp::Clock::SharedPtr.
- Modified methods to utilize the injected clock for time management.
- Added tests to validate clock handling and null clock rejection.