### PR TITLE
Refactor publisher-side API and documentation

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -19,14 +19,14 @@ who want to try the demo first.
 - `ros2_cuda_ipc_core::subscriber::BufferViewMapper` and `ros2_cuda_ipc_core::image::ImageViewMapper` / `ros2_cuda_ipc_core::pointcloud2::PointCloud2ViewMapper`: explicit mapping APIs from raw messages to imported views.
 - `ros2_cuda_ipc_core::lease::LeaseHandle`: process-shared slot lease accounting.
 - `ros2_cuda_ipc_core::publisher::GpuBufferPool`: publisher-side GPU resource ownership.
-- `ros2_cuda_ipc_core::publisher::SlotController`: publisher reservation, pending, generation, and TTL state.
-- `ros2_cuda_ipc_core::publisher::GpuBufferController`: publisher-facing buffer controller.
+- `ros2_cuda_ipc_core::publisher::LeaseManager`: publisher reservation, pending, generation, and TTL state.
+- `ros2_cuda_ipc_core::publisher::GpuBufferManager`: publisher-facing buffer manager.
 - `ros2_cuda_ipc_core::publisher::PublishSlot`: one move-only publish attempt with RAII cancellation.
 
 Publisher code should follow this order:
 
 ```cpp
-auto slot = controller.acquire_for_publish(pending_count);
+auto slot = manager.acquire_for_publish(pending_count);
 launch_gpu_work(slot->device_ptr(), stream);
 slot->record_ready(stream);
 auto descriptor = slot->descriptor();

--- a/doc/future_work.md
+++ b/doc/future_work.md
@@ -24,22 +24,22 @@ Publisherのmessageが残っている間に同じ名前でPublisherを再起動�
 - SHM state、GPU memory handle、ready event handleの組み合わせが、messageを作成した
   Publisher instanceと一致しなくなる。
 
-`SlotController`は、SHM capacity外のreservationを検出した場合にgenerationを確認して
+`LeaseManager`は、SHM capacity外のreservationを検出した場合にgenerationを確認して
 rollbackし、ERRORを記録する。この処理はreservation leakを防ぐための防御策であり、
 同名SHMの同時使用や再初期化を安全にするものではない。
 
 ### 推奨する設計
 
-設定上のSHM名をnamespaceの接頭辞として扱い、Publisher controllerの初期化ごとに一意な
+設定上のSHM名をnamespaceの接頭辞として扱い、Publisher managerの初期化ごとに一意な
 instance UUIDを生成する。POSIX SHMの実体名には、例えば
 `/ros2_cuda_ipc_fanout_<uuid>`のようにUUIDを付加し、ROS messageにはこの実体名を格納する。
 POSIX SHM名の移植性を保つため、先頭以外には`/`を使用しない。
 
 この方式では、次のownershipを明確にする。
 
-- controllerが実体SHM名を生成し、そのSHM objectを所有する。
+- managerが実体SHM名を生成し、そのSHM objectを所有する。
 - descriptorとROS messageは設定上の接頭辞ではなく実体SHM名を伝える。
-- controllerの終了時に、自身が作成した実体SHM名だけをunlinkする。
+- managerの終了時に、自身が作成した実体SHM名だけをunlinkする。
 - 実体SHM名は再利用しない。再起動後は必ず新しいUUIDを使用する。
 
 unlink済みSHMの既存mappingはOSの参照が残る間は有効だが、遅れて到着したmessageからの
@@ -52,7 +52,7 @@ unlink済みSHMの既存mappingはOSの参照が残る間は有効だが、遅�
 | --- | --- |
 | 設定値の意味 | 現在の「実体名」から「接頭辞」へ変更すると、設定と診断出力の互換性に影響する。 |
 | 実体名の公開 | logおよび診断APIから実体名を取得できるようにすると運用調査が容易になる。 |
-| 正常終了時のcleanup | controller終了時に即時unlinkするか、明示的なlifecycle操作を設けるかを決める。 |
+| 正常終了時のcleanup | manager終了時に即時unlinkするか、明示的なlifecycle操作を設けるかを決める。 |
 | crash後のorphan | UUID方式では名前衝突しない一方、異常終了したSHMが残る。列挙・期限付き削除toolまたは運用手順が必要になる。 |
 | 互換モード | 実体名をcallerが固定する高度なoptionを残す場合、その安全条件を別途定義する必要がある。 |
 | 他のIPC resource | CUDA VMM用Unix domain socketなど、instance identityを共有すべきresourceの範囲を決める。 |
@@ -68,7 +68,7 @@ unlink済みSHMの既存mappingはOSの参照が残る間は有効だが、遅�
 
 ### 完了条件
 
-- 同じ設定上の接頭辞で2つのPublisher controllerを同時に作成しても、異なる実体SHM名を
+- 同じ設定上の接頭辞で2つのPublisher managerを同時に作成しても、異なる実体SHM名を
   使用する。
 - capacityが異なるPublisher間でheaderとslot stateが干渉しない。
 - Publisher再起動前のmessageが、再起動後のinstanceへattachしない。

--- a/doc/lease_protocol.md
+++ b/doc/lease_protocol.md
@@ -42,9 +42,9 @@ ROS middlewareによる配送保証、Subscriber processの死活監視、Publis
 
 ```text
 Publisher process
-  GpuBufferController
+  GpuBufferManager
     GpuBufferPool       GPU allocationとready eventを所有
-    SlotController      reservation、pending、generation、TTLを管理
+    LeaseManager        reservation、pending、generation、TTLを管理
       LeaseHandle       process-shared lease stateを操作
     PublishSlot         1回のpublish試行を表すmove-only object
 
@@ -98,7 +98,7 @@ reserved == 0 && refcnt == 0 && pending == 0
 Publisherの公開APIは次の順序で使用する。
 
 ```cpp
-auto slot = controller.acquire_for_publish(pending_count);
+auto slot = manager.acquire_for_publish(pending_count);
 
 launch_gpu_work(slot->device_ptr(), stream);
 slot->record_ready(stream);
@@ -172,7 +172,7 @@ reservationのgenerationが現在も一致し、かつ`refcnt == 0`の場合だ�
 古いreservationから新しいgenerationのpendingを消去してはならない。retry上限、
 generation不一致、active leaseによりcancelできない場合はERRORとして記録する。
 
-`GpuBufferController::reset()`後でも、controller objectが生存している間は
+`GpuBufferManager::reset()`後でも、manager objectが生存している間は
 `PublishSlot`のdestructorがshared-memory reservationをcancelできる。
 
 ---
@@ -241,7 +241,7 @@ deadline reached && reservedを取得できる && refcnt == 0
 
 TTL回収はbackground timerではない。次の場合に実行される。
 
-- `GpuBufferController::acquire_for_publish()`の先頭
+- `GpuBufferManager::acquire_for_publish()`の先頭
 - `reclaim_stale_pending()`の明示呼び出し
 
 TTLを過ぎても、slotがまだ再利用されずgenerationが一致していれば、遅延Subscriberの
@@ -287,18 +287,18 @@ acquireまたはpublish試行を失敗させることである。
 
 ## 11. Lifetime contract
 
-`PublishSlot`は所有元`GpuBufferController`への非所有pointerを保持する。すべての
-`PublishSlot`は、そのcontroller objectより先に破棄しなければならない。
+`PublishSlot`は所有元`GpuBufferManager`への非所有pointerを保持する。すべての
+`PublishSlot`は、そのmanager objectより先に破棄しなければならない。
 
 ```text
 required:
   PublishSlot destruction
     before
-  GpuBufferController destruction
+  GpuBufferManager destruction
 ```
 
-この順序に反してcontrollerを先に破棄することはAPI contract violationであり、libraryは
-shared ownershipによって補償しない。`reset()`はresource操作を無効にするが、controller
+この順序に反してmanagerを先に破棄することはAPI contract violationであり、libraryは
+shared ownershipによって補償しない。`reset()`はresource操作を無効にするが、manager
 objectが生存していれば未commit slotのshared-memory cancelは可能である。
 
 ---

--- a/examples/multi_process_image_fanout/src/gpu_image_publisher.cpp
+++ b/examples/multi_process_image_fanout/src/gpu_image_publisher.cpp
@@ -16,7 +16,7 @@
 #include "ros2_cuda_ipc_core/backend/memory_backend_utils.hpp"
 #include "ros2_cuda_ipc_core/detail/nvtx_scoped_range.hpp"
 #include "ros2_cuda_ipc_core/image/image_view.hpp"
-#include "ros2_cuda_ipc_core/publisher/gpu_buffer_controller.hpp"
+#include "ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp"
 #include "ros2_cuda_ipc_core/transport/message_utils.hpp"
 #include "ros2_cuda_ipc_msgs/msg/gpu_image.hpp"
 
@@ -64,14 +64,14 @@ class GpuImagePublisherNode : public rclcpp::Node {
     throw_on_cuda_error(cudaSetDevice(device_index), "cudaSetDevice");
     const uint64_t frame_size_bytes =
         static_cast<uint64_t>(width_) * height_ * kBytesPerPixel;
-    controller_ =
-        std::make_unique<ros2_cuda_ipc_core::publisher::GpuBufferController>(
-            ros2_cuda_ipc_core::publisher::GpuBufferController::Config{
+    manager_ =
+        std::make_unique<ros2_cuda_ipc_core::publisher::GpuBufferManager>(
+            ros2_cuda_ipc_core::publisher::GpuBufferManager::Config{
                 shm_name, slot_count, frame_size_bytes, device_index,
                 pending_ttl, backend},
-            get_logger().get_child("GpuBufferController"));
-    if (!controller_->initialise()) {
-      throw std::runtime_error("Failed to initialise GPU buffer controller");
+            get_logger().get_child("GpuBufferManager"));
+    if (!manager_->initialise()) {
+      throw std::runtime_error("Failed to initialise GPU buffer manager");
     }
     throw_on_cuda_error(
         cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking),
@@ -94,7 +94,7 @@ class GpuImagePublisherNode : public rclcpp::Node {
     } catch (...) {
       cudaStreamDestroy(stream_);
       stream_ = nullptr;
-      controller_.reset();
+      manager_.reset();
       throw;
     }
 
@@ -113,7 +113,7 @@ class GpuImagePublisherNode : public rclcpp::Node {
       }
       stream_ = nullptr;
     }
-    controller_.reset();
+    manager_.reset();
   }
 
  private:
@@ -124,8 +124,7 @@ class GpuImagePublisherNode : public rclcpp::Node {
     std::optional<ros2_cuda_ipc_core::publisher::PublishSlot> slot;
     {
       NvtxScopedRange acquire_range("GpuImagePublisherNode::acquire_slot");
-      slot =
-          controller_->acquire_for_publish(static_cast<uint32_t>(subscribers));
+      slot = manager_->acquire_for_publish(static_cast<uint32_t>(subscribers));
     }
     if (!slot) {
       RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,
@@ -177,8 +176,7 @@ class GpuImagePublisherNode : public rclcpp::Node {
   }
 
   rclcpp::Publisher<ros2_cuda_ipc_msgs::msg::GpuImage>::SharedPtr publisher_;
-  std::unique_ptr<ros2_cuda_ipc_core::publisher::GpuBufferController>
-      controller_;
+  std::unique_ptr<ros2_cuda_ipc_core::publisher::GpuBufferManager> manager_;
   rclcpp::TimerBase::SharedPtr timer_;
   cudaStream_t stream_ = nullptr;
   double publish_rate_hz_ = 30.0;

--- a/ros2_cuda_ipc_core/CMakeLists.txt
+++ b/ros2_cuda_ipc_core/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 
 add_library(${PROJECT_NAME}
   src/detail/cuda_util.cpp
-  src/publisher/gpu_buffer_controller.cpp
+  src/publisher/gpu_buffer_manager.cpp
   src/publisher/gpu_buffer_pool.cpp
   src/backend/memory_importer.cpp
   src/backend/cuda_ipc/memory_backend.cpp
@@ -37,7 +37,7 @@ add_library(${PROJECT_NAME}
   src/pointcloud2/pointcloud2_view.cpp
   src/subscriber/ipc_handle_cache.cpp
   src/lease/lease_handle.cpp
-  src/publisher/slot_controller.cpp
+  src/publisher/lease_manager.cpp
   src/subscriber/buffer_view_mapper.cpp
   src/image/image_view_mapper.cpp
   src/pointcloud2/pointcloud2_view_mapper.cpp
@@ -89,13 +89,13 @@ if(BUILD_TESTING)
   target_link_libraries(test_pointcloud2_view_mapper ${PROJECT_NAME})
   ament_add_gtest(test_publisher_messages test/test_publisher_messages.cpp)
   target_link_libraries(test_publisher_messages ${PROJECT_NAME})
-  ament_add_gtest(test_gpu_buffer_controller
-                  test/test_gpu_buffer_controller.cpp)
-  target_link_libraries(test_gpu_buffer_controller ${PROJECT_NAME})
+  ament_add_gtest(test_gpu_buffer_manager
+                  test/test_gpu_buffer_manager.cpp)
+  target_link_libraries(test_gpu_buffer_manager ${PROJECT_NAME})
   ament_add_gtest(test_gpu_buffer_pool test/test_gpu_buffer_pool.cpp)
   target_link_libraries(test_gpu_buffer_pool ${PROJECT_NAME})
-  ament_add_gtest(test_slot_controller test/test_slot_controller.cpp)
-  target_link_libraries(test_slot_controller ${PROJECT_NAME})
+  ament_add_gtest(test_lease_manager test/test_lease_manager.cpp)
+  target_link_libraries(test_lease_manager ${PROJECT_NAME})
 endif()
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/lease/lease_handle.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/lease/lease_handle.hpp
@@ -23,25 +23,25 @@ class LeaseHandle {
 
   /// Create or reset the shared-memory layout for a lease pool.
   ///
-  /// \param shm_name Shared-memory name (POSIX shm_open identifier).
-  /// \param capacity Number of slots to allocate in the pool.
-  /// \return true when the memory is initialized successfully.
+  /// @param shm_name Shared-memory name (POSIX shm_open identifier).
+  /// @param capacity Number of slots to allocate in the pool.
+  /// @return true when the memory is initialized successfully.
   static bool init(const std::string& shm_name, uint32_t capacity);
 
   /// Read the current generation value for a slot.
   ///
-  /// \param shm_name Shared-memory name to query.
-  /// \param slot_id Slot index inside the pool.
-  /// \return generation number; std::nullopt if attachment fails or the slot is
+  /// @param shm_name Shared-memory name to query.
+  /// @param slot_id Slot index inside the pool.
+  /// @return generation number; std::nullopt if attachment fails or the slot is
   /// out of range.
   static std::optional<uint32_t> current_generation(const std::string& shm_name,
                                                     uint32_t slot_id);
 
   /// Read the current reference count for a slot.
   ///
-  /// \param shm_name Shared-memory name to query.
-  /// \param slot_id Slot index inside the pool.
-  /// \return reference count; std::nullopt if attachment fails or the slot is
+  /// @param shm_name Shared-memory name to query.
+  /// @param slot_id Slot index inside the pool.
+  /// @return reference count; std::nullopt if attachment fails or the slot is
   /// out of range.
   static std::optional<uint32_t> current_refcount(const std::string& shm_name,
                                                   uint32_t slot_id);
@@ -70,10 +70,10 @@ class LeaseHandle {
   /// Acquire a lease for a slot if the generation matches and increment its
   /// reference count.
   ///
-  /// \param shm_name Shared-memory name containing the slot metadata.
-  /// \param slot_id Slot index that should be leased.
-  /// \param generation Expected generation for the slot.
-  /// \return Valid LeaseHandle when the slot is obtained; otherwise an invalid
+  /// @param shm_name Shared-memory name containing the slot metadata.
+  /// @param slot_id Slot index that should be leased.
+  /// @param generation Expected generation for the slot.
+  /// @return Valid LeaseHandle when the slot is obtained; otherwise an invalid
   /// (empty) handle.
   static LeaseHandle acquire(const std::string& shm_name, uint32_t slot_id,
                              uint32_t generation);

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_controller.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_controller.hpp
@@ -20,29 +20,58 @@ namespace ros2_cuda_ipc_core::publisher {
 
 class GpuBufferController;
 
-// Represents one active publish attempt. The owning GpuBufferController must
-// outlive every PublishSlot created from it. Calling controller.reset()
-// invalidates slot resource operations, but slot destruction can still cancel
-// its shared-memory reservation while the controller object remains alive.
+/// Represents one active publish attempt.
+///
+/// The owning GpuBufferController must outlive every PublishSlot created from
+/// it. Calling GpuBufferController::reset() invalidates slot resource
+/// operations, but slot destruction can still cancel its shared-memory
+/// reservation while the controller object remains alive.
 class PublishSlot {
  public:
+  /// Move a publish slot while transferring ownership of its reservation.
   PublishSlot(PublishSlot&& other) noexcept;
+
+  /// Cancel the current reservation, if any, before taking ownership of other.
   PublishSlot& operator=(PublishSlot&& other) noexcept;
+
   PublishSlot(const PublishSlot&) = delete;
   PublishSlot& operator=(const PublishSlot&) = delete;
+
+  /// Cancel an uncommitted reservation on destruction.
   ~PublishSlot();
 
+  /// Return the device pointer associated with the reserved slot.
+  ///
+  /// @return Device pointer when the slot is usable; nullptr otherwise.
   void* device_ptr() const noexcept;
+
+  /// Record that the slot's GPU payload is ready on the given stream.
+  ///
+  /// @return CUDA error code, or cudaErrorInvalidResourceHandle when the slot
+  /// is not in the reserved state.
   cudaError_t record_ready(cudaStream_t stream) noexcept;
+
+  /// Build the transport descriptor after the ready event has been recorded.
+  ///
+  /// @return Descriptor when the slot is ready; std::nullopt otherwise.
   std::optional<transport::BufferDescriptor> descriptor() const;
-  // Marks a descriptor as handed to the middleware. Requires successful
-  // record_ready(); repeated calls after commit are harmless.
+
+  /// Mark the descriptor as handed to the middleware.
+  ///
+  /// Requires a successful record_ready() call. Repeated calls after commit
+  /// are harmless.
   void commit_publish() noexcept;
+
+  /// Cancel the reservation when it has not been committed.
   void cancel() noexcept;
+
+  /// Check whether the slot can still be used for publishing.
   bool valid() const noexcept;
 
  private:
+  /// Allow the controller to construct slots only from valid reservations.
   friend class GpuBufferController;
+
   enum class State {
     reserved,
     ready_recorded,
@@ -60,33 +89,70 @@ class PublishSlot {
   State state_ = State::moved_from;
 };
 
+/// Owns the GPU buffer pool and shared-memory slot reservations used for
+/// publishing.
 class GpuBufferController {
  public:
+  /// Configuration for a GPU buffer controller.
   struct Config {
+    /// Shared-memory name used for slot lease metadata.
     std::string shm_name;
+
+    /// Number of reusable GPU buffer slots.
     std::size_t slot_count = 0;
+
+    /// Size in bytes of each GPU buffer.
     uint64_t byte_size = 0;
+
+    /// CUDA device index on which the buffers are allocated.
     int device_index = 0;
+
+    /// Age after which stale pending reservations may be reclaimed.
     std::chrono::milliseconds pending_ttl{0};
+
+    /// Memory backend used to allocate and export the buffers.
     transport::MemoryBackendKind backend =
         transport::MemoryBackendKind::CUDA_IPC;
   };
 
+  /// Construct a controller with the given configuration and logger.
   GpuBufferController(Config config, rclcpp::Logger logger);
+
+  /// Release controller-owned resources.
   ~GpuBufferController() = default;
+
   GpuBufferController(const GpuBufferController&) = delete;
   GpuBufferController& operator=(const GpuBufferController&) = delete;
   GpuBufferController(GpuBufferController&&) = delete;
   GpuBufferController& operator=(GpuBufferController&&) = delete;
 
+  /// Initialize the shared-memory lease pool and GPU buffer pool.
+  ///
+  /// @return true when both pools are initialized successfully.
   bool initialise();
+
+  /// Release pool resources and reset the controller to an uninitialized state.
   void reset() noexcept;
+
+  /// Check whether both the lease pool and buffer pool are initialized.
   bool is_initialised() const noexcept;
+
+  /// Reserve a slot for a new publish attempt.
+  ///
+  /// @param pending_count Number of subscribers that are expected to consume
+  /// the published payload.
+  /// @return A publish slot when a reservation is available; std::nullopt
+  /// otherwise.
   std::optional<PublishSlot> acquire_for_publish(uint32_t pending_count);
+
+  /// Reclaim pending reservations that have exceeded the configured TTL.
   void reclaim_stale_pending();
 
  private:
+  /// Allow a slot to delegate resource operations to its owning controller
+  /// without exposing those operations as part of the public controller API.
   friend class PublishSlot;
+
   void* device_ptr(
       const SlotController::Reservation& reservation) const noexcept;
   cudaError_t record_ready(const SlotController::Reservation& reservation,

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp
@@ -12,20 +12,20 @@
 
 #include "rclcpp/logger.hpp"
 #include "ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp"
-#include "ros2_cuda_ipc_core/publisher/slot_controller.hpp"
+#include "ros2_cuda_ipc_core/publisher/lease_manager.hpp"
 #include "ros2_cuda_ipc_core/transport/buffer_descriptor.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 
 namespace ros2_cuda_ipc_core::publisher {
 
-class GpuBufferController;
+class GpuBufferManager;
 
 /// Represents one active publish attempt.
 ///
-/// The owning GpuBufferController must outlive every PublishSlot created from
-/// it. Calling GpuBufferController::reset() invalidates slot resource
+/// The owning GpuBufferManager must outlive every PublishSlot created from
+/// it. Calling GpuBufferManager::reset() invalidates slot resource
 /// operations, but slot destruction can still cancel its shared-memory
-/// reservation while the controller object remains alive.
+/// reservation while the manager object remains alive.
 class PublishSlot {
  public:
   /// Move a publish slot while transferring ownership of its reservation.
@@ -69,8 +69,8 @@ class PublishSlot {
   bool valid() const noexcept;
 
  private:
-  /// Allow the controller to construct slots only from valid reservations.
-  friend class GpuBufferController;
+  /// Allow the manager to construct slots only from valid reservations.
+  friend class GpuBufferManager;
 
   enum class State {
     reserved,
@@ -80,20 +80,20 @@ class PublishSlot {
     moved_from
   };
 
-  PublishSlot(GpuBufferController* owner,
-              SlotController::Reservation reservation) noexcept;
+  PublishSlot(GpuBufferManager* owner,
+              LeaseManager::Reservation reservation) noexcept;
   void move_from(PublishSlot&& other) noexcept;
 
-  GpuBufferController* owner_ = nullptr;
-  SlotController::Reservation reservation_{};
+  GpuBufferManager* owner_ = nullptr;
+  LeaseManager::Reservation reservation_{};
   State state_ = State::moved_from;
 };
 
 /// Owns the GPU buffer pool and shared-memory slot reservations used for
 /// publishing.
-class GpuBufferController {
+class GpuBufferManager {
  public:
-  /// Configuration for a GPU buffer controller.
+  /// Configuration for a GPU buffer manager.
   struct Config {
     /// Shared-memory name used for slot lease metadata.
     std::string shm_name;
@@ -115,23 +115,23 @@ class GpuBufferController {
         transport::MemoryBackendKind::CUDA_IPC;
   };
 
-  /// Construct a controller with the given configuration and logger.
-  GpuBufferController(Config config, rclcpp::Logger logger);
+  /// Construct a manager with the given configuration and logger.
+  GpuBufferManager(Config config, rclcpp::Logger logger);
 
-  /// Release controller-owned resources.
-  ~GpuBufferController() = default;
+  /// Release manager-owned resources.
+  ~GpuBufferManager() = default;
 
-  GpuBufferController(const GpuBufferController&) = delete;
-  GpuBufferController& operator=(const GpuBufferController&) = delete;
-  GpuBufferController(GpuBufferController&&) = delete;
-  GpuBufferController& operator=(GpuBufferController&&) = delete;
+  GpuBufferManager(const GpuBufferManager&) = delete;
+  GpuBufferManager& operator=(const GpuBufferManager&) = delete;
+  GpuBufferManager(GpuBufferManager&&) = delete;
+  GpuBufferManager& operator=(GpuBufferManager&&) = delete;
 
   /// Initialize the shared-memory lease pool and GPU buffer pool.
   ///
   /// @return true when both pools are initialized successfully.
   bool initialise();
 
-  /// Release pool resources and reset the controller to an uninitialized state.
+  /// Release pool resources and reset the manager to an uninitialized state.
   void reset() noexcept;
 
   /// Check whether both the lease pool and buffer pool are initialized.
@@ -149,22 +149,21 @@ class GpuBufferController {
   void reclaim_stale_pending();
 
  private:
-  /// Allow a slot to delegate resource operations to its owning controller
-  /// without exposing those operations as part of the public controller API.
+  /// Allow a slot to delegate resource operations to its owning manager
+  /// without exposing those operations as part of the public manager API.
   friend class PublishSlot;
 
-  void* device_ptr(
-      const SlotController::Reservation& reservation) const noexcept;
-  cudaError_t record_ready(const SlotController::Reservation& reservation,
+  void* device_ptr(const LeaseManager::Reservation& reservation) const noexcept;
+  cudaError_t record_ready(const LeaseManager::Reservation& reservation,
                            cudaStream_t stream) noexcept;
   std::optional<transport::BufferDescriptor> descriptor(
-      const SlotController::Reservation& reservation) const;
-  void cancel(const SlotController::Reservation& reservation) noexcept;
+      const LeaseManager::Reservation& reservation) const;
+  void cancel(const LeaseManager::Reservation& reservation) noexcept;
 
   Config config_;
   rclcpp::Logger logger_;
   GpuBufferPool buffer_pool_;
-  SlotController slot_controller_;
+  LeaseManager lease_manager_;
 };
 
 }  // namespace ros2_cuda_ipc_core::publisher

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp
@@ -6,7 +6,6 @@
 #include <cuda_runtime_api.h>
 
 #include <cstdint>
-#include <optional>
 #include <vector>
 
 #include "rclcpp/logger.hpp"

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/lease_manager.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/lease_manager.hpp
@@ -14,15 +14,15 @@
 
 namespace ros2_cuda_ipc_core::publisher {
 
-class SlotController {
+class LeaseManager {
  public:
   struct Reservation {
     uint32_t slot_id = 0;
     uint32_t generation = 0;
   };
 
-  SlotController(std::string shm_name, std::size_t slot_count,
-                 std::chrono::milliseconds pending_ttl, rclcpp::Logger logger);
+  LeaseManager(std::string shm_name, std::size_t slot_count,
+               std::chrono::milliseconds pending_ttl, rclcpp::Logger logger);
 
   bool initialise();
   void reset() noexcept;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view.hpp
@@ -5,7 +5,6 @@
 
 #include <cuda_runtime_api.h>
 
-#include <array>
 #include <cstdint>
 #include <memory>
 #include <string>

--- a/ros2_cuda_ipc_core/src/lease/lease_handle.cpp
+++ b/ros2_cuda_ipc_core/src/lease/lease_handle.cpp
@@ -36,8 +36,8 @@ struct ShmHeader {
 /// Treat a `uint32_t` reference as an `std::atomic<uint32_t>` to apply atomic
 /// operations without altering the POD layout.
 ///
-/// \param value Reference to a slot field inside shared memory.
-/// \return std::atomic<uint32_t>& alias to the given reference.
+/// @param value Reference to a slot field inside shared memory.
+/// @return std::atomic<uint32_t>& alias to the given reference.
 inline std::atomic<uint32_t>& as_atomic(uint32_t& value) {
   return reinterpret_cast<std::atomic<uint32_t>&>(value);
 }

--- a/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
@@ -1,15 +1,15 @@
 // Copyright (c) 2026 Daisuke Kato
 // SPDX-License-Identifier: MIT
 
-#include "ros2_cuda_ipc_core/publisher/gpu_buffer_controller.hpp"
+#include "ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp"
 
 #include <cassert>
 #include <utility>
 
 namespace ros2_cuda_ipc_core::publisher {
 
-PublishSlot::PublishSlot(GpuBufferController* owner,
-                         SlotController::Reservation reservation) noexcept
+PublishSlot::PublishSlot(GpuBufferManager* owner,
+                         LeaseManager::Reservation reservation) noexcept
     : owner_(owner), reservation_(reservation), state_(State::reserved) {}
 
 PublishSlot::PublishSlot(PublishSlot&& other) noexcept {
@@ -77,66 +77,65 @@ void PublishSlot::cancel() noexcept {
   }
 }
 
-GpuBufferController::GpuBufferController(Config config, rclcpp::Logger logger)
+GpuBufferManager::GpuBufferManager(Config config, rclcpp::Logger logger)
     : config_(std::move(config)),
       logger_(std::move(logger)),
       buffer_pool_(config_.slot_count, config_.backend,
                    logger_.get_child("GpuBufferPool")),
-      slot_controller_(config_.shm_name, config_.slot_count,
-                       config_.pending_ttl,
-                       logger_.get_child("SlotController")) {}
+      lease_manager_(config_.shm_name, config_.slot_count, config_.pending_ttl,
+                     logger_.get_child("LeaseManager")) {}
 
-bool GpuBufferController::initialise() {
+bool GpuBufferManager::initialise() {
   reset();
-  if (!slot_controller_.initialise()) {
+  if (!lease_manager_.initialise()) {
     return false;
   }
   if (!buffer_pool_.initialise(config_.byte_size, config_.device_index)) {
-    slot_controller_.reset();
+    lease_manager_.reset();
     return false;
   }
   return true;
 }
 
-void GpuBufferController::reset() noexcept {
+void GpuBufferManager::reset() noexcept {
   buffer_pool_.reset();
-  slot_controller_.reset();
+  lease_manager_.reset();
 }
 
-bool GpuBufferController::is_initialised() const noexcept {
-  return buffer_pool_.is_initialised() && slot_controller_.is_initialised();
+bool GpuBufferManager::is_initialised() const noexcept {
+  return buffer_pool_.is_initialised() && lease_manager_.is_initialised();
 }
 
-std::optional<PublishSlot> GpuBufferController::acquire_for_publish(
+std::optional<PublishSlot> GpuBufferManager::acquire_for_publish(
     uint32_t pending_count) {
   if (!is_initialised()) {
     return std::nullopt;
   }
-  slot_controller_.reclaim_stale_pending();
-  auto reservation = slot_controller_.reserve_for_publish(pending_count);
+  lease_manager_.reclaim_stale_pending();
+  auto reservation = lease_manager_.reserve_for_publish(pending_count);
   if (!reservation) {
     return std::nullopt;
   }
   return PublishSlot(this, *reservation);
 }
 
-void GpuBufferController::reclaim_stale_pending() {
-  slot_controller_.reclaim_stale_pending();
+void GpuBufferManager::reclaim_stale_pending() {
+  lease_manager_.reclaim_stale_pending();
 }
 
-void* GpuBufferController::device_ptr(
-    const SlotController::Reservation& reservation) const noexcept {
+void* GpuBufferManager::device_ptr(
+    const LeaseManager::Reservation& reservation) const noexcept {
   return buffer_pool_.device_ptr(reservation.slot_id);
 }
 
-cudaError_t GpuBufferController::record_ready(
-    const SlotController::Reservation& reservation,
+cudaError_t GpuBufferManager::record_ready(
+    const LeaseManager::Reservation& reservation,
     cudaStream_t stream) noexcept {
   return buffer_pool_.record_ready(reservation.slot_id, stream);
 }
 
-std::optional<transport::BufferDescriptor> GpuBufferController::descriptor(
-    const SlotController::Reservation& reservation) const {
+std::optional<transport::BufferDescriptor> GpuBufferManager::descriptor(
+    const LeaseManager::Reservation& reservation) const {
   const auto* resources = buffer_pool_.resources(reservation.slot_id);
   if (resources == nullptr) {
     return std::nullopt;
@@ -153,9 +152,9 @@ std::optional<transport::BufferDescriptor> GpuBufferController::descriptor(
   return result;
 }
 
-void GpuBufferController::cancel(
-    const SlotController::Reservation& reservation) noexcept {
-  slot_controller_.cancel(reservation);
+void GpuBufferManager::cancel(
+    const LeaseManager::Reservation& reservation) noexcept {
+  lease_manager_.cancel(reservation);
 }
 
 }  // namespace ros2_cuda_ipc_core::publisher

--- a/ros2_cuda_ipc_core/src/publisher/lease_manager.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/lease_manager.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 Daisuke Kato
 // SPDX-License-Identifier: MIT
 
-#include "ros2_cuda_ipc_core/publisher/slot_controller.hpp"
+#include "ros2_cuda_ipc_core/publisher/lease_manager.hpp"
 
 #include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/lease/lease_handle.hpp"
@@ -16,15 +16,15 @@ bool deadline_reached(const Clock::time_point& deadline,
 }
 }  // namespace
 
-SlotController::SlotController(std::string shm_name, std::size_t slot_count,
-                               std::chrono::milliseconds pending_ttl,
-                               rclcpp::Logger logger)
+LeaseManager::LeaseManager(std::string shm_name, std::size_t slot_count,
+                           std::chrono::milliseconds pending_ttl,
+                           rclcpp::Logger logger)
     : shm_name_(std::move(shm_name)),
       slot_count_(slot_count),
       pending_ttl_(pending_ttl),
       logger_(std::move(logger)) {}
 
-bool SlotController::initialise() {
+bool LeaseManager::initialise() {
   reset();
   if (slot_count_ == 0 || !lease::LeaseHandle::init(
                               shm_name_, static_cast<uint32_t>(slot_count_))) {
@@ -38,18 +38,18 @@ bool SlotController::initialise() {
   return true;
 }
 
-void SlotController::reset() noexcept {
+void LeaseManager::reset() noexcept {
   std::lock_guard<std::mutex> lock(deadlines_mutex_);
   pending_deadlines_.clear();
   initialised_ = false;
 }
 
-bool SlotController::is_initialised() const noexcept {
+bool LeaseManager::is_initialised() const noexcept {
   std::lock_guard<std::mutex> lock(deadlines_mutex_);
   return initialised_;
 }
 
-std::optional<SlotController::Reservation> SlotController::reserve_for_publish(
+std::optional<LeaseManager::Reservation> LeaseManager::reserve_for_publish(
     uint32_t pending_count) {
   {
     std::lock_guard<std::mutex> lock(deadlines_mutex_);
@@ -99,7 +99,7 @@ std::optional<SlotController::Reservation> SlotController::reserve_for_publish(
   return std::nullopt;
 }
 
-bool SlotController::cancel(const Reservation& reservation) noexcept {
+bool LeaseManager::cancel(const Reservation& reservation) noexcept {
   if (reservation.slot_id >= slot_count_) {
     return false;
   }
@@ -118,7 +118,7 @@ bool SlotController::cancel(const Reservation& reservation) noexcept {
   return cancelled;
 }
 
-void SlotController::reclaim_stale_pending() {
+void LeaseManager::reclaim_stale_pending() {
   std::lock_guard<std::mutex> lock(deadlines_mutex_);
   if (!initialised_ || pending_ttl_.count() <= 0) {
     return;
@@ -147,7 +147,7 @@ void SlotController::reclaim_stale_pending() {
   }
 }
 
-Clock::time_point SlotController::pending_deadline(
+Clock::time_point LeaseManager::pending_deadline(
     uint32_t slot_id) const noexcept {
   std::lock_guard<std::mutex> lock(deadlines_mutex_);
   if (slot_id >= pending_deadlines_.size()) {

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
@@ -15,18 +15,18 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_cuda_ipc_core/lease/lease_handle.hpp"
-#include "ros2_cuda_ipc_core/publisher/gpu_buffer_controller.hpp"
+#include "ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp"
 
 namespace {
 std::string unique_name() {
   static std::atomic<int> counter{0};
   std::ostringstream out;
-  out << "/gpu_controller_" << ::getpid() << "_" << counter.fetch_add(1);
+  out << "/gpu_buffer_manager_" << ::getpid() << "_" << counter.fetch_add(1);
   return out.str();
 }
 }  // namespace
 
-using ros2_cuda_ipc_core::publisher::GpuBufferController;
+using ros2_cuda_ipc_core::publisher::GpuBufferManager;
 using ros2_cuda_ipc_core::publisher::PublishSlot;
 
 static_assert(!std::is_copy_constructible_v<PublishSlot>);
@@ -34,7 +34,7 @@ static_assert(!std::is_copy_assignable_v<PublishSlot>);
 static_assert(std::is_nothrow_move_constructible_v<PublishSlot>);
 static_assert(std::is_nothrow_move_assignable_v<PublishSlot>);
 
-class GpuBufferControllerTest : public ::testing::Test {
+class GpuBufferManagerTest : public ::testing::Test {
  protected:
   void SetUp() override {
     int count = 0;
@@ -49,20 +49,20 @@ class GpuBufferControllerTest : public ::testing::Test {
       ::shm_unlink(shm_name_.c_str());
     }
   }
-  GpuBufferController make_controller(
+  GpuBufferManager make_manager(
       std::chrono::milliseconds pending_ttl = std::chrono::milliseconds(100)) {
-    return GpuBufferController(
+    return GpuBufferManager(
         {shm_name_, 1, 1024, 0, pending_ttl,
          ros2_cuda_ipc_core::transport::MemoryBackendKind::CUDA_IPC},
-        rclcpp::get_logger("GpuBufferControllerTest"));
+        rclcpp::get_logger("GpuBufferManagerTest"));
   }
   std::string shm_name_;
 };
 
-TEST_F(GpuBufferControllerTest, DescriptorIsGatedByReadyRecording) {
-  auto controller = make_controller();
-  ASSERT_TRUE(controller.initialise());
-  auto slot = controller.acquire_for_publish(1);
+TEST_F(GpuBufferManagerTest, DescriptorIsGatedByReadyRecording) {
+  auto manager = make_manager();
+  ASSERT_TRUE(manager.initialise());
+  auto slot = manager.acquire_for_publish(1);
   ASSERT_TRUE(slot.has_value());
   EXPECT_EQ(slot->descriptor(), std::nullopt);
   ASSERT_EQ(slot->record_ready(nullptr), cudaSuccess);
@@ -77,32 +77,32 @@ TEST_F(GpuBufferControllerTest, DescriptorIsGatedByReadyRecording) {
   EXPECT_FALSE(slot->valid());
 }
 
-TEST_F(GpuBufferControllerTest, UncommittedDestructionCancelsReservation) {
-  auto controller = make_controller();
-  ASSERT_TRUE(controller.initialise());
+TEST_F(GpuBufferManagerTest, UncommittedDestructionCancelsReservation) {
+  auto manager = make_manager();
+  ASSERT_TRUE(manager.initialise());
   {
-    auto slot = controller.acquire_for_publish(1);
+    auto slot = manager.acquire_for_publish(1);
     ASSERT_TRUE(slot.has_value());
   }
-  EXPECT_TRUE(controller.acquire_for_publish(1).has_value());
+  EXPECT_TRUE(manager.acquire_for_publish(1).has_value());
 }
 
-TEST_F(GpuBufferControllerTest, CommittedDestructionKeepsPending) {
-  auto controller = make_controller();
-  ASSERT_TRUE(controller.initialise());
+TEST_F(GpuBufferManagerTest, CommittedDestructionKeepsPending) {
+  auto manager = make_manager();
+  ASSERT_TRUE(manager.initialise());
   {
-    auto slot = controller.acquire_for_publish(1);
+    auto slot = manager.acquire_for_publish(1);
     ASSERT_TRUE(slot.has_value());
     ASSERT_EQ(slot->record_ready(nullptr), cudaSuccess);
     slot->commit_publish();
   }
-  EXPECT_FALSE(controller.acquire_for_publish(1).has_value());
+  EXPECT_FALSE(manager.acquire_for_publish(1).has_value());
 }
 
-TEST_F(GpuBufferControllerTest, MovedFromSlotIsInert) {
-  auto controller = make_controller();
-  ASSERT_TRUE(controller.initialise());
-  auto source = controller.acquire_for_publish(1);
+TEST_F(GpuBufferManagerTest, MovedFromSlotIsInert) {
+  auto manager = make_manager();
+  ASSERT_TRUE(manager.initialise());
+  auto source = manager.acquire_for_publish(1);
   ASSERT_TRUE(source.has_value());
   PublishSlot destination(std::move(*source));
   EXPECT_FALSE(source->valid());
@@ -111,20 +111,20 @@ TEST_F(GpuBufferControllerTest, MovedFromSlotIsInert) {
   destination.cancel();
   destination.cancel();
   EXPECT_FALSE(destination.valid());
-  EXPECT_TRUE(controller.acquire_for_publish(1).has_value());
+  EXPECT_TRUE(manager.acquire_for_publish(1).has_value());
 }
 
-TEST_F(GpuBufferControllerTest, ResetDoesNotPreventReservationCancellation) {
-  auto controller = make_controller();
-  ASSERT_TRUE(controller.initialise());
-  auto slot = controller.acquire_for_publish(1);
+TEST_F(GpuBufferManagerTest, ResetDoesNotPreventReservationCancellation) {
+  auto manager = make_manager();
+  ASSERT_TRUE(manager.initialise());
+  auto slot = manager.acquire_for_publish(1);
   ASSERT_TRUE(slot.has_value());
   const auto pending_before =
       ros2_cuda_ipc_core::lease::LeaseHandle::current_pending(shm_name_, 0);
   ASSERT_TRUE(pending_before.has_value());
   ASSERT_EQ(*pending_before, 1u);
 
-  controller.reset();
+  manager.reset();
   slot.reset();
 
   const auto pending =
@@ -133,16 +133,16 @@ TEST_F(GpuBufferControllerTest, ResetDoesNotPreventReservationCancellation) {
   EXPECT_EQ(*pending, 0u);
 }
 
-TEST_F(GpuBufferControllerTest, AcquireAutomaticallyReclaimsExpiredPending) {
-  auto controller = make_controller(std::chrono::milliseconds(1));
-  ASSERT_TRUE(controller.initialise());
+TEST_F(GpuBufferManagerTest, AcquireAutomaticallyReclaimsExpiredPending) {
+  auto manager = make_manager(std::chrono::milliseconds(1));
+  ASSERT_TRUE(manager.initialise());
   {
-    auto slot = controller.acquire_for_publish(1);
+    auto slot = manager.acquire_for_publish(1);
     ASSERT_TRUE(slot.has_value());
     ASSERT_EQ(slot->record_ready(nullptr), cudaSuccess);
     slot->commit_publish();
   }
 
   std::this_thread::sleep_for(std::chrono::milliseconds(5));
-  EXPECT_TRUE(controller.acquire_for_publish(1).has_value());
+  EXPECT_TRUE(manager.acquire_for_publish(1).has_value());
 }

--- a/ros2_cuda_ipc_core/test/test_lease_manager.cpp
+++ b/ros2_cuda_ipc_core/test/test_lease_manager.cpp
@@ -15,14 +15,14 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_cuda_ipc_core/lease/lease_handle.hpp"
-#include "ros2_cuda_ipc_core/publisher/slot_controller.hpp"
+#include "ros2_cuda_ipc_core/publisher/lease_manager.hpp"
 
 namespace {
 
 std::string make_unique_shm_name() {
   static std::atomic<int> counter{0};
   std::ostringstream out;
-  out << "/slot_controller_" << ::getpid() << "_" << counter.fetch_add(1);
+  out << "/lease_manager_" << ::getpid() << "_" << counter.fetch_add(1);
   return out.str();
 }
 
@@ -40,29 +40,29 @@ class ShmUnlinkGuard {
 
 }  // namespace
 
-TEST(SlotControllerTest, ResetRacingWithReserveDoesNotLeavePending) {
+TEST(LeaseManagerTest, ResetRacingWithReserveDoesNotLeavePending) {
   for (int iteration = 0; iteration < 1000; ++iteration) {
     const std::string shm_name = make_unique_shm_name();
     const ShmUnlinkGuard shm_guard(shm_name);
-    ros2_cuda_ipc_core::publisher::SlotController controller(
+    ros2_cuda_ipc_core::publisher::LeaseManager manager(
         shm_name, 1, std::chrono::milliseconds(100),
-        rclcpp::get_logger("SlotControllerTest"));
-    ASSERT_TRUE(controller.initialise());
+        rclcpp::get_logger("LeaseManagerTest"));
+    ASSERT_TRUE(manager.initialise());
 
     std::atomic<bool> start{false};
-    std::optional<ros2_cuda_ipc_core::publisher::SlotController::Reservation>
+    std::optional<ros2_cuda_ipc_core::publisher::LeaseManager::Reservation>
         reservation;
     std::thread reserve_thread([&]() {
       while (!start.load(std::memory_order_acquire)) {
         std::this_thread::yield();
       }
-      reservation = controller.reserve_for_publish(1);
+      reservation = manager.reserve_for_publish(1);
     });
     std::thread reset_thread([&]() {
       while (!start.load(std::memory_order_acquire)) {
         std::this_thread::yield();
       }
-      controller.reset();
+      manager.reset();
     });
 
     start.store(true, std::memory_order_release);
@@ -70,7 +70,7 @@ TEST(SlotControllerTest, ResetRacingWithReserveDoesNotLeavePending) {
     reset_thread.join();
 
     if (reservation) {
-      controller.cancel(*reservation);
+      manager.cancel(*reservation);
     }
     const auto pending =
         ros2_cuda_ipc_core::lease::LeaseHandle::current_pending(shm_name, 0);
@@ -79,16 +79,16 @@ TEST(SlotControllerTest, ResetRacingWithReserveDoesNotLeavePending) {
   }
 }
 
-TEST(SlotControllerTest, CapacityMismatchRollsBackOutOfRangeReservation) {
+TEST(LeaseManagerTest, CapacityMismatchRollsBackOutOfRangeReservation) {
   const std::string shm_name = make_unique_shm_name();
   const ShmUnlinkGuard shm_guard(shm_name);
-  ros2_cuda_ipc_core::publisher::SlotController controller(
+  ros2_cuda_ipc_core::publisher::LeaseManager manager(
       shm_name, 1, std::chrono::milliseconds(100),
-      rclcpp::get_logger("SlotControllerTest"));
-  ASSERT_TRUE(controller.initialise());
+      rclcpp::get_logger("LeaseManagerTest"));
+  ASSERT_TRUE(manager.initialise());
 
   // Simulate an unsupported second Publisher reinitialising the same name
-  // with a different capacity, then occupy slot 0 so the local controller
+  // with a different capacity, then occupy slot 0 so the local manager
   // observes an out-of-range reservation for slot 1.
   ASSERT_TRUE(ros2_cuda_ipc_core::lease::LeaseHandle::init(shm_name, 2));
   const auto occupied =
@@ -96,7 +96,7 @@ TEST(SlotControllerTest, CapacityMismatchRollsBackOutOfRangeReservation) {
   ASSERT_TRUE(occupied.has_value());
   ASSERT_EQ(occupied->slot_id, 0u);
 
-  EXPECT_FALSE(controller.reserve_for_publish(1).has_value());
+  EXPECT_FALSE(manager.reserve_for_publish(1).has_value());
   const auto out_of_range_pending =
       ros2_cuda_ipc_core::lease::LeaseHandle::current_pending(shm_name, 1);
   ASSERT_TRUE(out_of_range_pending.has_value());


### PR DESCRIPTION
## Pull request overview

This PR refactors the publisher-side API and documentation by renaming the “controller” components to “manager” terminology, updating call sites (tests/examples/docs), and aligning related implementation files and build targets in `ros2_cuda_ipc_core`.