### PR TITLE
feat: Introduce publisher instance ID for enhanced message identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ ros2 launch multi_process_image_fanout multi_process_image_fanout.launch.py \
   memory_backend:=cuda_ipc \
   slot_count:=4 \
   pending_ttl_ms:=300 \
-  shm_name:=/ros2_cuda_ipc_fanout \
+  shm_name_prefix:=/ros2_cuda_ipc_fanout \
   device_index:=0
 ```
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -15,6 +15,7 @@
 * メモリ共有方式の識別子（CUDA IPC / VMM + FD）
 * CUDA IPC ハンドル (mem_handle, event_handle)
 * 参照カウント用共有メモリ名 (shm_name)
+* Publisher instance ID (`publisher_instance_id`)
 * 識別情報 (device_id, slot_id, generation)
 * バイトサイズ (byte_size)
 * これだけで GPU バッファの受け渡しが可能。
@@ -33,6 +34,7 @@ uint8[64] event_handle      # cudaIpcEventHandle_t
 
 # Shared memory for reference counting
 string shm_name
+uint8[16] publisher_instance_id
 
 # Identification
 uint32 device_id
@@ -113,6 +115,7 @@ struct BufferView {
   uint32_t slot_id = 0;
   uint32_t generation = 0;
   std::string shm_name;                // LeaseHandle のキー
+  PublisherInstanceId publisher_instance_id;
   std::shared_ptr<LeaseHandle> lease;  // 共有メモリrefcntのRAIIハンドル
 
   // === ライフサイクル ===

--- a/doc/future_work.md
+++ b/doc/future_work.md
@@ -1,77 +1,17 @@
 # 今後の課題
 
-この文書は、現行protocolの既知制約のうち、局所的な修正では解消できず、設計変更を
-伴う課題を追跡する。現行の保証とcallerが守るべき契約は
+現行の保証とcallerが守るべき契約は
 [`lease_protocol.md`](lease_protocol.md)を参照すること。
 
-## Publisher instanceごとのshared memory identity
+## Publisher shutdown時のdrain
 
-### 状態
+正常終了時はpublisher所有のGPU resourceを破棄し、instance固有のPOSIX SHM名をunlinkする。
+Subscriber queue内のmessageや処理中のCUDA workをdrainするprotocolはまだ実装していない。
+graceful shutdownを保証するには、publish停止、queue drain、active lease完了待ち、resource破棄の
+順序とtimeoutを定義する必要がある。
 
-設計レベルの課題。現時点では、同時に存在するPublisher instanceごとに一意な
-shared memory（SHM）名をcallerが指定する必要がある。
+## Crash後のorphan SHM
 
-### 問題
-
-現在は設定されたSHM名を、そのままPOSIX SHM objectの実体名およびROS message内の
-識別子として使用する。このため、複数のPublisherが同じ名前を使用した場合や、古い
-Publisherのmessageが残っている間に同じ名前でPublisherを再起動した場合、次の競合が
-起こり得る。
-
-- 異なるcapacityで同じSHM headerとslot stateを初期化する。
-- 既存mappingと再作成後のSHM objectが、同じ名前で異なる状態を参照する。
-- 古いmessageが新しいPublisher instanceのSHMへattachする。
-- SHM state、GPU memory handle、ready event handleの組み合わせが、messageを作成した
-  Publisher instanceと一致しなくなる。
-
-`LeaseManager`は、SHM capacity外のreservationを検出した場合にgenerationを確認して
-rollbackし、ERRORを記録する。この処理はreservation leakを防ぐための防御策であり、
-同名SHMの同時使用や再初期化を安全にするものではない。
-
-### 推奨する設計
-
-設定上のSHM名をnamespaceの接頭辞として扱い、Publisher managerの初期化ごとに一意な
-instance UUIDを生成する。POSIX SHMの実体名には、例えば
-`/ros2_cuda_ipc_fanout_<uuid>`のようにUUIDを付加し、ROS messageにはこの実体名を格納する。
-POSIX SHM名の移植性を保つため、先頭以外には`/`を使用しない。
-
-この方式では、次のownershipを明確にする。
-
-- managerが実体SHM名を生成し、そのSHM objectを所有する。
-- descriptorとROS messageは設定上の接頭辞ではなく実体SHM名を伝える。
-- managerの終了時に、自身が作成した実体SHM名だけをunlinkする。
-- 実体SHM名は再利用しない。再起動後は必ず新しいUUIDを使用する。
-
-unlink済みSHMの既存mappingはOSの参照が残る間は有効だが、遅れて到着したmessageからの
-新規attachは失敗する。このfail-closedな挙動により、古いmessageが別instanceのstateへ
-誤ってattachすることを防ぐ。
-
-### 設計時に決める事項
-
-| 項目 | 選択肢とtrade-off |
-| --- | --- |
-| 設定値の意味 | 現在の「実体名」から「接頭辞」へ変更すると、設定と診断出力の互換性に影響する。 |
-| 実体名の公開 | logおよび診断APIから実体名を取得できるようにすると運用調査が容易になる。 |
-| 正常終了時のcleanup | manager終了時に即時unlinkするか、明示的なlifecycle操作を設けるかを決める。 |
-| crash後のorphan | UUID方式では名前衝突しない一方、異常終了したSHMが残る。列挙・期限付き削除toolまたは運用手順が必要になる。 |
-| 互換モード | 実体名をcallerが固定する高度なoptionを残す場合、その安全条件を別途定義する必要がある。 |
-| 他のIPC resource | CUDA VMM用Unix domain socketなど、instance identityを共有すべきresourceの範囲を決める。 |
-
-### 検討した代替案
-
-- `O_CREAT | O_EXCL`のみを使用する方法は、同時起動の衝突をfail-fastにできる。ただし、
-  crash後のorphanが再起動を妨げ、unlinkして同名で再作成すると古いmessageとのABA問題が
-  残る。
-- owner PIDをheaderへ保存する方法は、死活判定とPID再利用を安全に扱えない。
-- headerとmessageへinstance epochを追加する方法でも識別できるが、wire formatとSHM
-  layoutの双方を変更し、名前自体が衝突する場合のlifecycle管理も必要になる。
-
-### 完了条件
-
-- 同じ設定上の接頭辞で2つのPublisher managerを同時に作成しても、異なる実体SHM名を
-  使用する。
-- capacityが異なるPublisher間でheaderとslot stateが干渉しない。
-- Publisher再起動前のmessageが、再起動後のinstanceへattachしない。
-- 正常終了、異常終了、遅延messageに対するcleanupとfailure semanticsが文書化される。
-- CUDA IPC memory backendとVMM-FD backendの双方でmulti-process testが通る。
-- 実体SHM名と関連するUnix domain socket等のidentityに一貫性がある。
+Publisherがdestructorを通らず終了するとUUID付きSHM objectが残り得る。再起動後は別の
+`publisher_instance_id`とSHM名を使うため、新instanceとの状態混同は発生しない。
+一方、orphanを列挙・検証・期限付きで削除するtoolまたは運用手順は今後追加する必要がある。

--- a/doc/lease_protocol.md
+++ b/doc/lease_protocol.md
@@ -58,6 +58,7 @@ Subscriber process
 ROS messageには少なくとも次が含まれる。
 
 - shared memory名
+- 16-byte `publisher_instance_id`
 - `slot_id`
 - `generation`
 - device IDとbyte size
@@ -79,8 +80,9 @@ application固有の画像shape、encoding、point cloud layoutなどはlease pr
 | `pending` | lease取得がまだ期待される数 | 0でなければ再利用不可 |
 | `reserved` | Publisher更新中の排他flag | 0でなければPublisher reserveとSubscriber acquireを拒否 |
 
-現在のshared memory layout versionは2である。attach時にmagicとlayout versionを検証し、
-各APIは`slot_id`がheaderのcapacity範囲内であることを検証する。
+現在のshared memory layout versionは3であり、headerに16-byte
+`publisher_instance_id`を保持する。attach時にmagic、layout version、messageから渡された
+instance IDを検証し、各APIは`slot_id`がheaderのcapacity範囲内であることを検証する。
 
 slotを再利用できる基本条件は次である。
 
@@ -179,18 +181,21 @@ generation不一致、active leaseによりcancelできない場合はERRORと�
 
 ## 6. Subscriber acquireとrelease
 
-Subscriberはmessageの`shm_name`、`slot_id`、`generation`を使ってleaseを取得する。
+Subscriberはmessageの`shm_name`、`publisher_instance_id`、`slot_id`、`generation`を
+使ってleaseを取得する。`shm_name`はresource locatorであり、publisher instanceの同一性は
+headerとmessageの`publisher_instance_id`の一致によって確認する。
 
 acquireは次を行う。
 
-1. shared memoryへattachし、slot範囲を検証する。
-2. `reserved == 0`を確認する。
-3. `generation`がmessageと一致することを確認する。
-4. `refcnt`をCASで1増加する。
-5. `reserved == 0`と`generation`一致を再確認する。
-6. 再確認に失敗した場合は`refcnt`を戻し、acquireを失敗させる。
-7. `pending > 0`ならCASで1減少する。
-8. 有効な`LeaseHandle`を返す。
+1. shared memoryへattachし、layoutとslot範囲を検証する。
+2. headerとmessageの`publisher_instance_id`一致を検証する。
+3. `reserved == 0`を確認する。
+4. `generation`がmessageと一致することを確認する。
+5. `refcnt`をCASで1増加する。
+6. `reserved == 0`と`generation`一致を再確認する。
+7. 再確認に失敗した場合は`refcnt`を戻し、acquireを失敗させる。
+8. `pending > 0`ならCASで1減少する。
+9. 有効な`LeaseHandle`を返す。
 
 有効な`LeaseHandle`の破棄またはmove assignmentによるreleaseは`refcnt`を1減少する。
 `BufferView`は内部で`LeaseHandle`を保持するため、viewの生存中はslotを再利用できない。
@@ -314,22 +319,16 @@ crash、machine failureなどでdestructorを通らず終了するとrefcntが�
 これはmemory safety上は安全側だが、pool capacityを失うavailability上の問題である。
 現在はprocess identity、heartbeat、process death detectionを実装していない。
 
-### 12.2 Publisher restartと同一SHM名
+### 12.2 Publisher restart
 
-`LeaseHandle::init()`は指定されたshared memory layoutを再初期化する。同じ`shm_name`で
-Publisherを再起動した場合、古いSubscriber mapping、古いmessage、古いlease、古いGPU
-handleと新しい状態を安全に引き継ぐprotocolにはなっていない。
+`GpuBufferManager::initialise()`は毎回新しいUUIDを生成する。UUIDは実体SHM名へ付加され、
+同じ16-byte値がSHM headerとROS messageの`publisher_instance_id`へ格納される。正常な
+`reset()`またはdestructorは実体SHM名をunlinkするため、遅延messageからの新規attachは
+失敗する。既存mapping cacheを使用する場合にもinstance IDを照合する。
 
-Publisher instanceごとに一意なSHM名を使用することを推奨する。
-
-```text
-/base_name/<publisher_instance_uuid>
-```
-
-実装はlocal configurationを超える`slot_id`を検出した場合、取得したreservationを
-generation付きでrollbackしてERRORを記録する。ただし、これはcapacity不一致時の
-defensive cleanupであり、同じSHM名を複数Publisherが再初期化することを安全にする
-仕組みではない。
+Publisherが正常終了処理を通らずcrashした場合はorphan SHMが残り得る。再起動後の
+Publisherは別名・別instance IDを使用するため新instanceとの混同は起こらないが、orphanの
+列挙と回収は現在のprotocolには含まれない。
 
 ### 12.3 generation wraparound
 

--- a/examples/multi_process_image_fanout/README.md
+++ b/examples/multi_process_image_fanout/README.md
@@ -64,7 +64,7 @@ ros2 launch multi_process_image_fanout multi_process_image_fanout.launch.py \
   memory_backend:=cuda_ipc \
   slot_count:=4 \
   pending_ttl_ms:=300 \
-  shm_name:=/ros2_cuda_ipc_fanout \
+  shm_name_prefix:=/ros2_cuda_ipc_fanout \
   device_index:=0
 ```
 
@@ -77,7 +77,7 @@ ros2 launch multi_process_image_fanout multi_process_image_fanout.launch.py \
 ```
 
 The `width`, `height`, `memory_backend`, `slot_count`, `pending_ttl_ms`,
-`shm_name`, and `device_index` arguments are publisher-side pseudo-camera
+`shm_name_prefix`, and `device_index` arguments are publisher-side pseudo-camera
 parameters.
 
 ## Visualize preview

--- a/examples/multi_process_image_fanout/launch/multi_process_image_fanout.launch.py
+++ b/examples/multi_process_image_fanout/launch/multi_process_image_fanout.launch.py
@@ -33,7 +33,9 @@ def generate_launch_description() -> LaunchDescription:
         DeclareLaunchArgument("frame_id", default_value="fanout_camera_frame"),
         DeclareLaunchArgument("slot_count", default_value="4"),
         DeclareLaunchArgument("pending_ttl_ms", default_value="300"),
-        DeclareLaunchArgument("shm_name", default_value="/ros2_cuda_ipc_fanout"),
+        DeclareLaunchArgument(
+            "shm_name_prefix", default_value="/ros2_cuda_ipc_fanout"
+        ),
         DeclareLaunchArgument("preview_copy_every_n", default_value="1"),
         DeclareLaunchArgument("log_every_n", default_value="30"),
         DeclareLaunchArgument("encoder_downscale", default_value="2"),
@@ -105,7 +107,7 @@ def launch_setup(context) -> List[Node]:
                 "frame_id": value("frame_id"),
                 "slot_count": slot_count,
                 "pending_ttl_ms": pending_ttl_ms,
-                "shm_name": value("shm_name"),
+                "shm_name_prefix": value("shm_name_prefix"),
                 "device_index": device_index,
                 "memory_backend": memory_backend,
             }

--- a/examples/multi_process_image_fanout/src/gpu_image_publisher.cpp
+++ b/examples/multi_process_image_fanout/src/gpu_image_publisher.cpp
@@ -43,8 +43,8 @@ class GpuImagePublisherNode : public rclcpp::Node {
     const int slot_count_parameter = declare_parameter<int>("slot_count", 4);
     const auto pending_ttl = std::chrono::milliseconds(
         declare_parameter<int>("pending_ttl_ms", 300));
-    const auto shm_name =
-        declare_parameter<std::string>("shm_name", "/ros2_cuda_ipc_fanout");
+    const auto shm_name_prefix = declare_parameter<std::string>(
+        "shm_name_prefix", "/ros2_cuda_ipc_fanout");
     const int device_index = declare_parameter<int>("device_index", 0);
     const auto backend = ros2_cuda_ipc_core::backend::parse_memory_backend(
         declare_parameter<std::string>("memory_backend", "cuda_ipc"),
@@ -67,7 +67,7 @@ class GpuImagePublisherNode : public rclcpp::Node {
     manager_ =
         std::make_unique<ros2_cuda_ipc_core::publisher::GpuBufferManager>(
             ros2_cuda_ipc_core::publisher::GpuBufferManager::Config{
-                shm_name, slot_count, frame_size_bytes, device_index,
+                shm_name_prefix, slot_count, frame_size_bytes, device_index,
                 pending_ttl, backend},
             get_logger().get_child("GpuBufferManager"));
     if (!manager_->initialise()) {

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/lease/lease_handle.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/lease/lease_handle.hpp
@@ -10,6 +10,8 @@
 #include <string>
 #include <unordered_map>
 
+#include "ros2_cuda_ipc_core/publisher_instance_id.hpp"
+
 namespace ros2_cuda_ipc_core::lease {
 
 /// LeaseHandle manages the lifetime of a shared-memory slot using process-wide
@@ -21,12 +23,14 @@ class LeaseHandle {
     uint32_t generation;
   };
 
-  /// Create or reset the shared-memory layout for a lease pool.
+  /// Exclusively create the shared-memory layout for a lease pool.
   ///
   /// @param shm_name Shared-memory name (POSIX shm_open identifier).
   /// @param capacity Number of slots to allocate in the pool.
   /// @return true when the memory is initialized successfully.
-  static bool init(const std::string& shm_name, uint32_t capacity);
+  static bool init(const std::string& shm_name,
+                   const PublisherInstanceId& publisher_instance_id,
+                   uint32_t capacity);
 
   /// Read the current generation value for a slot.
   ///
@@ -34,8 +38,9 @@ class LeaseHandle {
   /// @param slot_id Slot index inside the pool.
   /// @return generation number; std::nullopt if attachment fails or the slot is
   /// out of range.
-  static std::optional<uint32_t> current_generation(const std::string& shm_name,
-                                                    uint32_t slot_id);
+  static std::optional<uint32_t> current_generation(
+      const std::string& shm_name,
+      const PublisherInstanceId& publisher_instance_id, uint32_t slot_id);
 
   /// Read the current reference count for a slot.
   ///
@@ -43,29 +48,34 @@ class LeaseHandle {
   /// @param slot_id Slot index inside the pool.
   /// @return reference count; std::nullopt if attachment fails or the slot is
   /// out of range.
-  static std::optional<uint32_t> current_refcount(const std::string& shm_name,
-                                                  uint32_t slot_id);
+  static std::optional<uint32_t> current_refcount(
+      const std::string& shm_name,
+      const PublisherInstanceId& publisher_instance_id, uint32_t slot_id);
 
   /// Atomically claim an idle slot against concurrent Publisher reservations
   /// and Subscriber acquisitions, then advance generation and seed pending.
   static std::optional<PublisherReservation> reserve_for_publish(
-      const std::string& shm_name, uint32_t pending);
+      const std::string& shm_name,
+      const PublisherInstanceId& publisher_instance_id, uint32_t pending);
 
   /// Read the current pending count for a slot.
-  static std::optional<uint32_t> current_pending(const std::string& shm_name,
-                                                 uint32_t slot_id);
+  static std::optional<uint32_t> current_pending(
+      const std::string& shm_name,
+      const PublisherInstanceId& publisher_instance_id, uint32_t slot_id);
 
   /// Forcefully reset the pending counter for a slot when the publisher decides
   /// the payload has expired (e.g., TTL elapsed).
   ///
   /// The counter is only cleared when the reference count is zero to avoid
   /// interfering with active consumers.
-  static bool force_clear_pending(const std::string& shm_name,
-                                  uint32_t slot_id);
+  static bool force_clear_pending(
+      const std::string& shm_name,
+      const PublisherInstanceId& publisher_instance_id, uint32_t slot_id);
 
   /// Clear pending only when the slot still belongs to the given generation.
   static bool cancel_pending(const std::string& shm_name, uint32_t slot_id,
-                             uint32_t generation);
+                             uint32_t generation,
+                             const PublisherInstanceId& publisher_instance_id);
 
   /// Acquire a lease for a slot if the generation matches and increment its
   /// reference count.
@@ -75,8 +85,9 @@ class LeaseHandle {
   /// @param generation Expected generation for the slot.
   /// @return Valid LeaseHandle when the slot is obtained; otherwise an invalid
   /// (empty) handle.
-  static LeaseHandle acquire(const std::string& shm_name, uint32_t slot_id,
-                             uint32_t generation);
+  static LeaseHandle acquire(const std::string& shm_name,
+                             const PublisherInstanceId& publisher_instance_id,
+                             uint32_t slot_id, uint32_t generation);
 
   /// Release any held lease on destruction.
   ~LeaseHandle();
@@ -111,7 +122,9 @@ class LeaseHandle {
   uint32_t slot_id_ = 0;
   uint32_t generation_ = 0;
 
-  static std::shared_ptr<Mapping> attach(const std::string& shm_name);
+  static std::shared_ptr<Mapping> attach(
+      const std::string& shm_name,
+      const PublisherInstanceId& publisher_instance_id);
   static std::mutex& registry_mutex();
   static std::unordered_map<std::string, std::shared_ptr<Mapping>>& registry();
 };

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp
@@ -95,8 +95,8 @@ class GpuBufferManager {
  public:
   /// Configuration for a GPU buffer manager.
   struct Config {
-    /// Shared-memory name used for slot lease metadata.
-    std::string shm_name;
+    /// Prefix used to create a publisher-instance-specific shared-memory name.
+    std::string shm_name_prefix;
 
     /// Number of reusable GPU buffer slots.
     std::size_t slot_count = 0;
@@ -119,7 +119,7 @@ class GpuBufferManager {
   GpuBufferManager(Config config, rclcpp::Logger logger);
 
   /// Release manager-owned resources.
-  ~GpuBufferManager() = default;
+  ~GpuBufferManager();
 
   GpuBufferManager(const GpuBufferManager&) = delete;
   GpuBufferManager& operator=(const GpuBufferManager&) = delete;
@@ -136,6 +136,12 @@ class GpuBufferManager {
 
   /// Check whether both the lease pool and buffer pool are initialized.
   bool is_initialised() const noexcept;
+
+  /// Return the current instance-specific shared-memory name.
+  std::string shm_name() const;
+
+  /// Return the current publisher instance identity.
+  PublisherInstanceId publisher_instance_id() const;
 
   /// Reserve a slot for a new publish attempt.
   ///

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/lease_manager.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/lease_manager.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "rclcpp/logger.hpp"
+#include "ros2_cuda_ipc_core/publisher_instance_id.hpp"
 
 namespace ros2_cuda_ipc_core::publisher {
 
@@ -19,10 +20,14 @@ class LeaseManager {
   struct Reservation {
     uint32_t slot_id = 0;
     uint32_t generation = 0;
+    std::string shm_name;
+    PublisherInstanceId publisher_instance_id{};
   };
 
-  LeaseManager(std::string shm_name, std::size_t slot_count,
+  LeaseManager(std::string shm_name_prefix, std::size_t slot_count,
                std::chrono::milliseconds pending_ttl, rclcpp::Logger logger);
+
+  ~LeaseManager();
 
   bool initialise();
   void reset() noexcept;
@@ -31,12 +36,15 @@ class LeaseManager {
   bool cancel(const Reservation& reservation) noexcept;
   void reclaim_stale_pending();
 
-  const std::string& shm_name() const noexcept { return shm_name_; }
+  std::string shm_name() const;
+  PublisherInstanceId publisher_instance_id() const;
   std::chrono::steady_clock::time_point pending_deadline(
       uint32_t slot_id) const noexcept;
 
  private:
+  std::string shm_name_prefix_;
   std::string shm_name_;
+  PublisherInstanceId publisher_instance_id_{};
   std::size_t slot_count_;
   std::chrono::milliseconds pending_ttl_;
   rclcpp::Logger logger_;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher_instance_id.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher_instance_id.hpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+
+namespace ros2_cuda_ipc_core {
+
+/// Protocol identity of one publisher initialisation.
+using PublisherInstanceId = std::array<uint8_t, 16>;
+
+inline bool is_nil(const PublisherInstanceId& id) noexcept {
+  return std::all_of(id.begin(), id.end(),
+                     [](uint8_t byte) { return byte == 0; });
+}
+
+}  // namespace ros2_cuda_ipc_core

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view.hpp
@@ -10,6 +10,7 @@
 #include <string>
 
 #include "ros2_cuda_ipc_core/lease/lease_handle.hpp"
+#include "ros2_cuda_ipc_core/publisher_instance_id.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 
 namespace ros2_cuda_ipc_core::subscriber {
@@ -22,6 +23,7 @@ struct BufferView {
   uint32_t slot_id = 0;
   uint32_t generation = 0;
   std::string shm_name;
+  PublisherInstanceId publisher_instance_id{};
   std::shared_ptr<lease::LeaseHandle> lease;
 
   BufferView() = default;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp
@@ -14,17 +14,20 @@
 #include <unordered_map>
 
 #include "ros2_cuda_ipc_core/backend/memory_importer.hpp"
+#include "ros2_cuda_ipc_core/publisher_instance_id.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 
 namespace ros2_cuda_ipc_core::subscriber {
 
 struct IpcHandleKey {
+  PublisherInstanceId publisher_instance_id{};
   uint8_t backend = 0;
   transport::MemoryHandlePayload mem{};
   std::array<uint8_t, sizeof(cudaIpcEventHandle_t)> event{};
 
   bool operator==(const IpcHandleKey& other) const noexcept {
-    return backend == other.backend && mem == other.mem && event == other.event;
+    return publisher_instance_id == other.publisher_instance_id &&
+           backend == other.backend && mem == other.mem && event == other.event;
   }
 };
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/transport/buffer_descriptor.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/transport/buffer_descriptor.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <string>
 
+#include "ros2_cuda_ipc_core/publisher_instance_id.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 #include "ros2_cuda_ipc_msgs/msg/buffer_core.hpp"
 
@@ -17,6 +18,7 @@ namespace ros2_cuda_ipc_core::transport {
 // does not own GPU resources and does not acquire or release a lease.
 struct BufferDescriptor {
   std::string lease_shm_name;
+  PublisherInstanceId publisher_instance_id{};
   uint32_t slot_id = 0;
   uint32_t generation = 0;
   int device_id = -1;

--- a/ros2_cuda_ipc_core/src/lease/lease_handle.cpp
+++ b/ros2_cuda_ipc_core/src/lease/lease_handle.cpp
@@ -21,7 +21,7 @@ namespace ros2_cuda_ipc_core::lease {
 namespace {
 
 constexpr uint32_t kShmMagic = 0x4C534531;  // 'LSE1'
-constexpr uint32_t kLayoutVersion = 2;
+constexpr uint32_t kLayoutVersion = 3;
 constexpr uint32_t kCancelReservationAttempts = 1024;
 
 /// Shared memory header structure stored at the start of the shared-memory
@@ -31,6 +31,7 @@ struct ShmHeader {
   uint32_t layout_version;
   uint32_t capacity;
   uint32_t consumer_count;
+  PublisherInstanceId publisher_instance_id;
 };
 
 /// Treat a `uint32_t` reference as an `std::atomic<uint32_t>` to apply atomic
@@ -65,6 +66,7 @@ struct LeaseHandle::Mapping {
   void* addr = nullptr;
   SlotMeta* slots = nullptr;
   ShmHeader* header = nullptr;
+  PublisherInstanceId publisher_instance_id{};
   std::atomic<uint32_t> next_slot{0};
 
   ~Mapping() {
@@ -135,15 +137,18 @@ void LeaseHandle::release() noexcept {
   mapping_.reset();
 }
 
-bool LeaseHandle::init(const std::string& shm_name, uint32_t capacity) {
-  if (capacity == 0) {
-    RCLCPP_ERROR(lease_logger(), "lease:init capacity must be >0");
+bool LeaseHandle::init(const std::string& shm_name,
+                       const PublisherInstanceId& publisher_instance_id,
+                       uint32_t capacity) {
+  if (capacity == 0 || is_nil(publisher_instance_id)) {
+    RCLCPP_ERROR(lease_logger(),
+                 "lease:init capacity must be >0 and instance ID non-nil");
     return false;
   }
 
   const size_t size =
       sizeof(ShmHeader) + static_cast<size_t>(capacity) * sizeof(SlotMeta);
-  const int fd = shm_open(shm_name.c_str(), O_CREAT | O_RDWR, 0660);
+  const int fd = shm_open(shm_name.c_str(), O_CREAT | O_EXCL | O_RDWR, 0660);
   if (fd < 0) {
     RCLCPP_ERROR(lease_logger(), "lease:init shm_open failed name=%s errno=%d",
                  shm_name.c_str(), errno);
@@ -154,6 +159,7 @@ bool LeaseHandle::init(const std::string& shm_name, uint32_t capacity) {
     RCLCPP_ERROR(lease_logger(), "lease:init ftruncate failed name=%s errno=%d",
                  shm_name.c_str(), errno);
     close(fd);
+    shm_unlink(shm_name.c_str());
     return false;
   }
 
@@ -162,6 +168,7 @@ bool LeaseHandle::init(const std::string& shm_name, uint32_t capacity) {
     RCLCPP_ERROR(lease_logger(), "lease:init mmap failed name=%s errno=%d",
                  shm_name.c_str(), errno);
     close(fd);
+    shm_unlink(shm_name.c_str());
     return false;
   }
 
@@ -170,6 +177,7 @@ bool LeaseHandle::init(const std::string& shm_name, uint32_t capacity) {
   header->layout_version = kLayoutVersion;
   header->capacity = capacity;
   header->consumer_count = 0;
+  header->publisher_instance_id = publisher_instance_id;
 
   auto* slots = reinterpret_cast<SlotMeta*>(header + 1);
   for (uint32_t i = 0; i < capacity; ++i) {
@@ -182,19 +190,24 @@ bool LeaseHandle::init(const std::string& shm_name, uint32_t capacity) {
   munmap(addr, size);
   close(fd);
 
-  {
-    std::lock_guard<std::mutex> lock(registry_mutex());
-    registry().erase(shm_name);
-  }
-
   return true;
 }
 
 std::shared_ptr<LeaseHandle::Mapping> LeaseHandle::attach(
-    const std::string& shm_name) {
+    const std::string& shm_name,
+    const PublisherInstanceId& publisher_instance_id) {
+  if (is_nil(publisher_instance_id)) {
+    return nullptr;
+  }
   std::lock_guard<std::mutex> lock(registry_mutex());
   auto& map = registry();
   if (auto it = map.find(shm_name); it != map.end()) {
+    if (it->second->publisher_instance_id != publisher_instance_id) {
+      RCLCPP_WARN(lease_logger(),
+                  "lease:attach cached publisher instance mismatch name=%s",
+                  shm_name.c_str());
+      return nullptr;
+    }
     return it->second;
   }
 
@@ -212,6 +225,12 @@ std::shared_ptr<LeaseHandle::Mapping> LeaseHandle::attach(
     close(fd);
     return nullptr;
   }
+  if (st.st_size < static_cast<off_t>(sizeof(ShmHeader))) {
+    RCLCPP_WARN(lease_logger(), "lease:attach segment too small name=%s",
+                shm_name.c_str());
+    close(fd);
+    return nullptr;
+  }
 
   void* addr =
       mmap(nullptr, st.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
@@ -225,10 +244,21 @@ std::shared_ptr<LeaseHandle::Mapping> LeaseHandle::attach(
   close(fd);
 
   auto header = static_cast<ShmHeader*>(addr);
-  if (header->magic != kShmMagic || header->layout_version != kLayoutVersion) {
+  if (header->magic != kShmMagic || header->layout_version != kLayoutVersion ||
+      header->publisher_instance_id != publisher_instance_id) {
     RCLCPP_WARN(lease_logger(),
-                "lease:attach header mismatch name=%s magic=%u ver=%u",
+                "lease:attach header or publisher instance mismatch "
+                "name=%s magic=%u ver=%u",
                 shm_name.c_str(), header->magic, header->layout_version);
+    munmap(addr, st.st_size);
+    return nullptr;
+  }
+  const size_t expected_size =
+      sizeof(ShmHeader) +
+      static_cast<size_t>(header->capacity) * sizeof(SlotMeta);
+  if (expected_size > static_cast<size_t>(st.st_size)) {
+    RCLCPP_WARN(lease_logger(), "lease:attach truncated layout name=%s",
+                shm_name.c_str());
     munmap(addr, st.st_size);
     return nullptr;
   }
@@ -239,6 +269,7 @@ std::shared_ptr<LeaseHandle::Mapping> LeaseHandle::attach(
   mapping->mapped_size = st.st_size;
   mapping->addr = addr;
   mapping->header = header;
+  mapping->publisher_instance_id = header->publisher_instance_id;
   mapping->slots = reinterpret_cast<SlotMeta*>(header + 1);
 
   map[shm_name] = mapping;
@@ -246,8 +277,9 @@ std::shared_ptr<LeaseHandle::Mapping> LeaseHandle::attach(
 }
 
 std::optional<uint32_t> LeaseHandle::current_generation(
-    const std::string& shm_name, uint32_t slot_id) {
-  auto mapping = attach(shm_name);
+    const std::string& shm_name,
+    const PublisherInstanceId& publisher_instance_id, uint32_t slot_id) {
+  auto mapping = attach(shm_name, publisher_instance_id);
   if (!mapping || slot_id >= mapping->capacity) {
     return std::nullopt;
   }
@@ -256,8 +288,9 @@ std::optional<uint32_t> LeaseHandle::current_generation(
 }
 
 std::optional<uint32_t> LeaseHandle::current_refcount(
-    const std::string& shm_name, uint32_t slot_id) {
-  auto mapping = attach(shm_name);
+    const std::string& shm_name,
+    const PublisherInstanceId& publisher_instance_id, uint32_t slot_id) {
+  auto mapping = attach(shm_name, publisher_instance_id);
   if (!mapping || slot_id >= mapping->capacity) {
     return std::nullopt;
   }
@@ -266,8 +299,9 @@ std::optional<uint32_t> LeaseHandle::current_refcount(
 }
 
 std::optional<uint32_t> LeaseHandle::current_pending(
-    const std::string& shm_name, uint32_t slot_id) {
-  auto mapping = attach(shm_name);
+    const std::string& shm_name,
+    const PublisherInstanceId& publisher_instance_id, uint32_t slot_id) {
+  auto mapping = attach(shm_name, publisher_instance_id);
   if (!mapping || slot_id >= mapping->capacity) {
     return std::nullopt;
   }
@@ -276,9 +310,10 @@ std::optional<uint32_t> LeaseHandle::current_pending(
 }
 
 std::optional<LeaseHandle::PublisherReservation>
-LeaseHandle::reserve_for_publish(const std::string& shm_name,
-                                 uint32_t pending_count) {
-  auto mapping = attach(shm_name);
+LeaseHandle::reserve_for_publish(
+    const std::string& shm_name,
+    const PublisherInstanceId& publisher_instance_id, uint32_t pending_count) {
+  auto mapping = attach(shm_name, publisher_instance_id);
   if (!mapping || mapping->capacity == 0) {
     return std::nullopt;
   }
@@ -324,9 +359,10 @@ LeaseHandle::reserve_for_publish(const std::string& shm_name,
   return std::nullopt;
 }
 
-bool LeaseHandle::force_clear_pending(const std::string& shm_name,
-                                      uint32_t slot_id) {
-  auto mapping = attach(shm_name);
+bool LeaseHandle::force_clear_pending(
+    const std::string& shm_name,
+    const PublisherInstanceId& publisher_instance_id, uint32_t slot_id) {
+  auto mapping = attach(shm_name, publisher_instance_id);
   if (!mapping || slot_id >= mapping->capacity) {
     return false;
   }
@@ -356,9 +392,10 @@ bool LeaseHandle::force_clear_pending(const std::string& shm_name,
   return true;
 }
 
-bool LeaseHandle::cancel_pending(const std::string& shm_name, uint32_t slot_id,
-                                 uint32_t generation) {
-  auto mapping = attach(shm_name);
+bool LeaseHandle::cancel_pending(
+    const std::string& shm_name, uint32_t slot_id, uint32_t generation,
+    const PublisherInstanceId& publisher_instance_id) {
+  auto mapping = attach(shm_name, publisher_instance_id);
   if (!mapping || slot_id >= mapping->capacity) {
     return false;
   }
@@ -392,9 +429,11 @@ bool LeaseHandle::cancel_pending(const std::string& shm_name, uint32_t slot_id,
   return true;
 }
 
-LeaseHandle LeaseHandle::acquire(const std::string& shm_name, uint32_t slot_id,
-                                 uint32_t generation) {
-  auto mapping = attach(shm_name);
+LeaseHandle LeaseHandle::acquire(
+    const std::string& shm_name,
+    const PublisherInstanceId& publisher_instance_id, uint32_t slot_id,
+    uint32_t generation) {
+  auto mapping = attach(shm_name, publisher_instance_id);
   if (!mapping || slot_id >= mapping->capacity) {
     return LeaseHandle{};
   }

--- a/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
@@ -82,8 +82,10 @@ GpuBufferManager::GpuBufferManager(Config config, rclcpp::Logger logger)
       logger_(std::move(logger)),
       buffer_pool_(config_.slot_count, config_.backend,
                    logger_.get_child("GpuBufferPool")),
-      lease_manager_(config_.shm_name, config_.slot_count, config_.pending_ttl,
-                     logger_.get_child("LeaseManager")) {}
+      lease_manager_(config_.shm_name_prefix, config_.slot_count,
+                     config_.pending_ttl, logger_.get_child("LeaseManager")) {}
+
+GpuBufferManager::~GpuBufferManager() { reset(); }
 
 bool GpuBufferManager::initialise() {
   reset();
@@ -106,6 +108,14 @@ bool GpuBufferManager::is_initialised() const noexcept {
   return buffer_pool_.is_initialised() && lease_manager_.is_initialised();
 }
 
+std::string GpuBufferManager::shm_name() const {
+  return lease_manager_.shm_name();
+}
+
+PublisherInstanceId GpuBufferManager::publisher_instance_id() const {
+  return lease_manager_.publisher_instance_id();
+}
+
 std::optional<PublishSlot> GpuBufferManager::acquire_for_publish(
     uint32_t pending_count) {
   if (!is_initialised()) {
@@ -125,12 +135,22 @@ void GpuBufferManager::reclaim_stale_pending() {
 
 void* GpuBufferManager::device_ptr(
     const LeaseManager::Reservation& reservation) const noexcept {
+  if (reservation.shm_name != lease_manager_.shm_name() ||
+      reservation.publisher_instance_id !=
+          lease_manager_.publisher_instance_id()) {
+    return nullptr;
+  }
   return buffer_pool_.device_ptr(reservation.slot_id);
 }
 
 cudaError_t GpuBufferManager::record_ready(
     const LeaseManager::Reservation& reservation,
     cudaStream_t stream) noexcept {
+  if (reservation.shm_name != lease_manager_.shm_name() ||
+      reservation.publisher_instance_id !=
+          lease_manager_.publisher_instance_id()) {
+    return cudaErrorInvalidResourceHandle;
+  }
   return buffer_pool_.record_ready(reservation.slot_id, stream);
 }
 
@@ -140,8 +160,14 @@ std::optional<transport::BufferDescriptor> GpuBufferManager::descriptor(
   if (resources == nullptr) {
     return std::nullopt;
   }
+  if (reservation.shm_name != lease_manager_.shm_name() ||
+      reservation.publisher_instance_id !=
+          lease_manager_.publisher_instance_id()) {
+    return std::nullopt;
+  }
   transport::BufferDescriptor result;
-  result.lease_shm_name = config_.shm_name;
+  result.lease_shm_name = reservation.shm_name;
+  result.publisher_instance_id = reservation.publisher_instance_id;
   result.slot_id = reservation.slot_id;
   result.generation = reservation.generation;
   result.device_id = config_.device_index;

--- a/ros2_cuda_ipc_core/src/publisher/lease_manager.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/lease_manager.cpp
@@ -53,8 +53,11 @@ LeaseManager::~LeaseManager() { reset(); }
 
 bool LeaseManager::initialise() {
   reset();
-  if (slot_count_ == 0 || slot_count_ > std::numeric_limits<uint32_t>::max() ||
-      !valid_prefix(shm_name_prefix_)) {
+  if (slot_count_ == 0 || slot_count_ > std::numeric_limits<uint32_t>::max()) {
+    RCLCPP_ERROR(logger_, "Invalid slot_count: %zu", slot_count_);
+    return false;
+  }
+  if (!valid_prefix(shm_name_prefix_)) {
     RCLCPP_ERROR(logger_, "Invalid shared-memory name prefix: %s",
                  shm_name_prefix_.c_str());
     return false;

--- a/ros2_cuda_ipc_core/src/publisher/lease_manager.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/lease_manager.cpp
@@ -3,6 +3,15 @@
 
 #include "ros2_cuda_ipc_core/publisher/lease_manager.hpp"
 
+#include <limits.h>
+#include <sys/mman.h>
+#include <uuid/uuid.h>
+
+#include <algorithm>
+#include <limits>
+#include <string>
+#include <utility>
+
 #include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/lease/lease_handle.hpp"
 
@@ -14,34 +23,78 @@ bool deadline_reached(const Clock::time_point& deadline,
                       const Clock::time_point& now) {
   return deadline.time_since_epoch().count() != 0 && now >= deadline;
 }
+
+bool valid_prefix(const std::string& prefix) {
+  return prefix.size() > 1 && prefix.front() == '/' &&
+         prefix.find('/', 1) == std::string::npos;
+}
+
+std::pair<PublisherInstanceId, std::string> make_instance_identity(
+    const std::string& prefix) {
+  uuid_t uuid;
+  uuid_generate(uuid);
+  PublisherInstanceId id{};
+  std::copy(std::begin(uuid), std::end(uuid), id.begin());
+  char text[37]{};
+  uuid_unparse_lower(uuid, text);
+  return {id, prefix + "_" + text};
+}
 }  // namespace
 
-LeaseManager::LeaseManager(std::string shm_name, std::size_t slot_count,
+LeaseManager::LeaseManager(std::string shm_name_prefix, std::size_t slot_count,
                            std::chrono::milliseconds pending_ttl,
                            rclcpp::Logger logger)
-    : shm_name_(std::move(shm_name)),
+    : shm_name_prefix_(std::move(shm_name_prefix)),
       slot_count_(slot_count),
       pending_ttl_(pending_ttl),
       logger_(std::move(logger)) {}
 
+LeaseManager::~LeaseManager() { reset(); }
+
 bool LeaseManager::initialise() {
   reset();
-  if (slot_count_ == 0 || !lease::LeaseHandle::init(
-                              shm_name_, static_cast<uint32_t>(slot_count_))) {
+  if (slot_count_ == 0 || slot_count_ > std::numeric_limits<uint32_t>::max() ||
+      !valid_prefix(shm_name_prefix_)) {
+    RCLCPP_ERROR(logger_, "Invalid shared-memory name prefix: %s",
+                 shm_name_prefix_.c_str());
+    return false;
+  }
+  auto [instance_id, instance_name] = make_instance_identity(shm_name_prefix_);
+  if (instance_name.size() > NAME_MAX) {
+    RCLCPP_ERROR(logger_, "Generated shared-memory name is too long");
+    return false;
+  }
+  std::vector<Clock::time_point> pending_deadlines(slot_count_);
+  if (!lease::LeaseHandle::init(instance_name, instance_id,
+                                static_cast<uint32_t>(slot_count_))) {
     return false;
   }
   {
     std::lock_guard<std::mutex> lock(deadlines_mutex_);
-    pending_deadlines_.assign(slot_count_, {});
+    shm_name_ = std::move(instance_name);
+    publisher_instance_id_ = instance_id;
+    pending_deadlines_ = std::move(pending_deadlines);
     initialised_ = true;
   }
   return true;
 }
 
 void LeaseManager::reset() noexcept {
-  std::lock_guard<std::mutex> lock(deadlines_mutex_);
-  pending_deadlines_.clear();
-  initialised_ = false;
+  std::string owned_name;
+  {
+    std::lock_guard<std::mutex> lock(deadlines_mutex_);
+    if (initialised_) {
+      owned_name = std::move(shm_name_);
+    }
+    shm_name_.clear();
+    publisher_instance_id_ = {};
+    pending_deadlines_.clear();
+    initialised_ = false;
+  }
+  if (!owned_name.empty() && ::shm_unlink(owned_name.c_str()) != 0) {
+    RCLCPP_WARN(logger_, "Failed to unlink lease shared memory name=%s",
+                owned_name.c_str());
+  }
 }
 
 bool LeaseManager::is_initialised() const noexcept {
@@ -51,14 +104,18 @@ bool LeaseManager::is_initialised() const noexcept {
 
 std::optional<LeaseManager::Reservation> LeaseManager::reserve_for_publish(
     uint32_t pending_count) {
+  std::string shm_name;
+  PublisherInstanceId instance_id{};
   {
     std::lock_guard<std::mutex> lock(deadlines_mutex_);
     if (!initialised_) {
       return std::nullopt;
     }
+    shm_name = shm_name_;
+    instance_id = publisher_instance_id_;
   }
-  const auto reservation =
-      lease::LeaseHandle::reserve_for_publish(shm_name_, pending_count);
+  const auto reservation = lease::LeaseHandle::reserve_for_publish(
+      shm_name, instance_id, pending_count);
   if (!reservation) {
     return std::nullopt;
   }
@@ -68,7 +125,7 @@ std::optional<LeaseManager::Reservation> LeaseManager::reserve_for_publish(
                  "slot=%u configured_count=%zu",
                  reservation->slot_id, slot_count_);
     const bool rolled_back = lease::LeaseHandle::cancel_pending(
-        shm_name_, reservation->slot_id, reservation->generation);
+        shm_name, reservation->slot_id, reservation->generation, instance_id);
     if (!rolled_back) {
       RCLCPP_ERROR(logger_,
                    "Failed to roll back out-of-range reservation slot=%u "
@@ -79,18 +136,21 @@ std::optional<LeaseManager::Reservation> LeaseManager::reserve_for_publish(
   }
   {
     std::lock_guard<std::mutex> lock(deadlines_mutex_);
-    if (initialised_ && reservation->slot_id < pending_deadlines_.size()) {
+    if (initialised_ && shm_name_ == shm_name &&
+        publisher_instance_id_ == instance_id &&
+        reservation->slot_id < pending_deadlines_.size()) {
       if (pending_count > 0 && pending_ttl_.count() > 0) {
         pending_deadlines_[reservation->slot_id] = Clock::now() + pending_ttl_;
       } else {
         pending_deadlines_[reservation->slot_id] = {};
       }
-      return Reservation{reservation->slot_id, reservation->generation};
+      return Reservation{reservation->slot_id, reservation->generation,
+                         shm_name, instance_id};
     }
   }
 
   const bool rolled_back = lease::LeaseHandle::cancel_pending(
-      shm_name_, reservation->slot_id, reservation->generation);
+      shm_name, reservation->slot_id, reservation->generation, instance_id);
   if (!rolled_back) {
     RCLCPP_ERROR(logger_,
                  "Failed to roll back reservation slot=%u generation=%u",
@@ -104,14 +164,17 @@ bool LeaseManager::cancel(const Reservation& reservation) noexcept {
     return false;
   }
   const bool cancelled = lease::LeaseHandle::cancel_pending(
-      shm_name_, reservation.slot_id, reservation.generation);
+      reservation.shm_name, reservation.slot_id, reservation.generation,
+      reservation.publisher_instance_id);
   if (!cancelled) {
     RCLCPP_ERROR(logger_, "Failed to cancel reservation slot=%u generation=%u",
                  reservation.slot_id, reservation.generation);
   }
   if (cancelled) {
     std::lock_guard<std::mutex> lock(deadlines_mutex_);
-    if (reservation.slot_id < pending_deadlines_.size()) {
+    if (reservation.shm_name == shm_name_ &&
+        reservation.publisher_instance_id == publisher_instance_id_ &&
+        reservation.slot_id < pending_deadlines_.size()) {
       pending_deadlines_[reservation.slot_id] = {};
     }
   }
@@ -129,8 +192,8 @@ void LeaseManager::reclaim_stale_pending() {
     if (!deadline_reached(deadline, now)) {
       continue;
     }
-    const auto pending =
-        lease::LeaseHandle::current_pending(shm_name_, slot_id);
+    const auto pending = lease::LeaseHandle::current_pending(
+        shm_name_, publisher_instance_id_, slot_id);
     if (!pending) {
       continue;
     }
@@ -138,7 +201,8 @@ void LeaseManager::reclaim_stale_pending() {
       deadline = {};
       continue;
     }
-    if (lease::LeaseHandle::force_clear_pending(shm_name_, slot_id)) {
+    if (lease::LeaseHandle::force_clear_pending(
+            shm_name_, publisher_instance_id_, slot_id)) {
       RCLCPP_WARN(logger_,
                   "Force-cleared pending lease slot=%u after %lld ms timeout",
                   slot_id, static_cast<long long>(pending_ttl_.count()));
@@ -154,6 +218,16 @@ Clock::time_point LeaseManager::pending_deadline(
     return {};
   }
   return pending_deadlines_[slot_id];
+}
+
+std::string LeaseManager::shm_name() const {
+  std::lock_guard<std::mutex> lock(deadlines_mutex_);
+  return shm_name_;
+}
+
+PublisherInstanceId LeaseManager::publisher_instance_id() const {
+  std::lock_guard<std::mutex> lock(deadlines_mutex_);
+  return publisher_instance_id_;
 }
 
 }  // namespace ros2_cuda_ipc_core::publisher

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp
@@ -26,6 +26,7 @@ BufferView& BufferView::operator=(const BufferView& other) {
   slot_id = other.slot_id;
   generation = other.generation;
   shm_name = other.shm_name;
+  publisher_instance_id = other.publisher_instance_id;
   lease = other.lease;
   mem_payload_ = other.mem_payload_;
   event_handle_ = other.event_handle_;
@@ -53,6 +54,7 @@ BufferView& BufferView::operator=(BufferView&& other) noexcept {
   slot_id = other.slot_id;
   generation = other.generation;
   shm_name = std::move(other.shm_name);
+  publisher_instance_id = other.publisher_instance_id;
   lease = std::move(other.lease);
   mem_payload_ = other.mem_payload_;
   event_handle_ = other.event_handle_;
@@ -64,6 +66,7 @@ BufferView& BufferView::operator=(BufferView&& other) noexcept {
   other.slot_id = 0;
   other.generation = 0;
   other.shm_name.clear();
+  other.publisher_instance_id = {};
   other.handles_ready_ = false;
 
   return *this;
@@ -84,6 +87,7 @@ void BufferView::reset() noexcept {
   slot_id = 0;
   generation = 0;
   shm_name.clear();
+  publisher_instance_id = {};
   handles_ready_ = false;
   backend_ = transport::MemoryBackendKind::CUDA_IPC;
   lease.reset();

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
@@ -48,8 +48,14 @@ BufferView BufferViewMapper::map(
     return {};
   }
 
-  auto lease =
-      lease::LeaseHandle::acquire(msg.shm_name, msg.slot_id, msg.generation);
+  const PublisherInstanceId instance_id = msg.publisher_instance_id;
+  if (is_nil(instance_id)) {
+    RCLCPP_WARN(options_.logger, "BufferCore publisher_instance_id is nil");
+    return {};
+  }
+
+  auto lease = lease::LeaseHandle::acquire(msg.shm_name, instance_id,
+                                           msg.slot_id, msg.generation);
   if (!lease.valid()) {
     RCLCPP_WARN(options_.logger,
                 "Failed to acquire lease shm=%s slot=%u gen=%u",
@@ -61,6 +67,7 @@ BufferView BufferViewMapper::map(
   const cudaIpcEventHandle_t event_handle = to_cuda_event_handle(msg);
 
   IpcHandleKey key{};
+  key.publisher_instance_id = instance_id;
   key.backend = static_cast<uint8_t>(msg.backend);
   key.mem = msg.mem_handle;
   std::memcpy(key.event.data(), &event_handle, sizeof(event_handle));
@@ -88,6 +95,7 @@ BufferView BufferViewMapper::map(
   view.slot_id = msg.slot_id;
   view.generation = msg.generation;
   view.shm_name = msg.shm_name;
+  view.publisher_instance_id = instance_id;
   view.lease = std::move(lease_ptr);
   view.set_ipc_handles(
       transport::backend_from_byte(static_cast<uint8_t>(msg.backend)),

--- a/ros2_cuda_ipc_core/src/subscriber/ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/ipc_handle_cache.cpp
@@ -9,6 +9,9 @@ std::size_t IpcHandleKeyHash::operator()(
     const IpcHandleKey& key) const noexcept {
   constexpr std::size_t PRIME{131};
   std::size_t hash = key.backend;
+  for (uint8_t byte : key.publisher_instance_id) {
+    hash = hash * PRIME + byte;
+  }
   for (uint8_t byte : key.mem) {
     hash = hash * PRIME + byte;
   }

--- a/ros2_cuda_ipc_core/src/transport/message_utils.cpp
+++ b/ros2_cuda_ipc_core/src/transport/message_utils.cpp
@@ -23,6 +23,7 @@ static_assert(sizeof(BufferCoreMessage::_event_handle_type) ==
 void fill_buffer_core_message(const BufferDescriptor& descriptor,
                               ros2_cuda_ipc_msgs::msg::BufferCore& message) {
   message.shm_name = descriptor.lease_shm_name;
+  message.publisher_instance_id = descriptor.publisher_instance_id;
   message.device_id = static_cast<uint32_t>(descriptor.device_id);
   message.slot_id = descriptor.slot_id;
   message.generation = descriptor.generation;

--- a/ros2_cuda_ipc_core/test/mapper/test_buffer_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/test/mapper/test_buffer_view_mapper.cpp
@@ -25,10 +25,12 @@ class BufferViewMapperTest : public ::testing::Test {
 
 TEST_F(BufferViewMapperTest, LeaseFailureReturnsInvalid) {
   const std::string shm_name = test::make_unique_shm_name("buffer_mapper_fail");
-  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, 1));
+  ASSERT_TRUE(lease::LeaseHandle::init(
+      shm_name, test::publisher_instance_id(shm_name), 1));
 
   ros2_cuda_ipc_msgs::msg::BufferCore msg;
   msg.shm_name = shm_name;
+  msg.publisher_instance_id = test::publisher_instance_id(shm_name);
   msg.slot_id = 0;
   msg.device_id = 0;
   msg.generation = 99;
@@ -42,15 +44,39 @@ TEST_F(BufferViewMapperTest, LeaseFailureReturnsInvalid) {
   ::shm_unlink(shm_name.c_str());
 }
 
+TEST_F(BufferViewMapperTest, PublisherInstanceMismatchRejectsMessage) {
+  const std::string shm_name =
+      test::make_unique_shm_name("buffer_mapper_instance");
+  const auto owner_id = test::publisher_instance_id(shm_name);
+  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, owner_id, 1));
+  auto reservation =
+      lease::LeaseHandle::reserve_for_publish(shm_name, owner_id, 1);
+  ASSERT_TRUE(reservation.has_value());
+
+  auto msg = test::make_cached_buffer_core_message(
+      shm_name, reservation->slot_id, reservation->generation, 91);
+  msg.publisher_instance_id =
+      test::publisher_instance_id(shm_name + "_different");
+  BufferViewMapper mapper;
+  EXPECT_FALSE(mapper.map(msg).valid());
+  auto refcnt = lease::LeaseHandle::current_refcount(shm_name, owner_id, 0);
+  ASSERT_TRUE(refcnt.has_value());
+  EXPECT_EQ(*refcnt, 0u);
+  ::shm_unlink(shm_name.c_str());
+}
+
 TEST_F(BufferViewMapperTest, UnsupportedBackendReturnsInvalid) {
   const std::string shm_name =
       test::make_unique_shm_name("buffer_mapper_backend");
-  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, 1));
-  auto reservation = lease::LeaseHandle::reserve_for_publish(shm_name, 0);
+  ASSERT_TRUE(lease::LeaseHandle::init(
+      shm_name, test::publisher_instance_id(shm_name), 1));
+  auto reservation = lease::LeaseHandle::reserve_for_publish(
+      shm_name, test::publisher_instance_id(shm_name), 0);
   ASSERT_TRUE(reservation.has_value());
 
   ros2_cuda_ipc_msgs::msg::BufferCore msg;
   msg.shm_name = shm_name;
+  msg.publisher_instance_id = test::publisher_instance_id(shm_name);
   msg.slot_id = 0;
   msg.device_id = 0;
   msg.generation = reservation->generation;
@@ -61,7 +87,8 @@ TEST_F(BufferViewMapperTest, UnsupportedBackendReturnsInvalid) {
   auto view = mapper.map(msg);
   EXPECT_FALSE(view.valid());
 
-  auto refcnt = lease::LeaseHandle::current_refcount(shm_name, 0);
+  auto refcnt = lease::LeaseHandle::current_refcount(
+      shm_name, test::publisher_instance_id(shm_name), 0);
   ASSERT_TRUE(refcnt.has_value());
   EXPECT_EQ(refcnt.value(), 0u);
 
@@ -71,12 +98,15 @@ TEST_F(BufferViewMapperTest, UnsupportedBackendReturnsInvalid) {
 TEST_F(BufferViewMapperTest, InvalidVmmPayloadReturnsInvalid) {
   const std::string shm_name =
       test::make_unique_shm_name("buffer_mapper_vmm_payload");
-  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, 1));
-  auto reservation = lease::LeaseHandle::reserve_for_publish(shm_name, 1);
+  ASSERT_TRUE(lease::LeaseHandle::init(
+      shm_name, test::publisher_instance_id(shm_name), 1));
+  auto reservation = lease::LeaseHandle::reserve_for_publish(
+      shm_name, test::publisher_instance_id(shm_name), 1);
   ASSERT_TRUE(reservation.has_value());
 
   ros2_cuda_ipc_msgs::msg::BufferCore msg;
   msg.shm_name = shm_name;
+  msg.publisher_instance_id = test::publisher_instance_id(shm_name);
   msg.slot_id = 0;
   msg.device_id = 0;
   msg.generation = reservation->generation;
@@ -89,7 +119,8 @@ TEST_F(BufferViewMapperTest, InvalidVmmPayloadReturnsInvalid) {
   auto view = mapper.map(msg);
   EXPECT_FALSE(view.valid());
 
-  auto refcnt = lease::LeaseHandle::current_refcount(shm_name, 0);
+  auto refcnt = lease::LeaseHandle::current_refcount(
+      shm_name, test::publisher_instance_id(shm_name), 0);
   ASSERT_TRUE(refcnt.has_value());
   EXPECT_EQ(refcnt.value(), 0u);
 
@@ -99,12 +130,15 @@ TEST_F(BufferViewMapperTest, InvalidVmmPayloadReturnsInvalid) {
 TEST_F(BufferViewMapperTest, MissingVmmSocketReturnsInvalidAndReleasesLease) {
   const std::string shm_name =
       test::make_unique_shm_name("buffer_mapper_vmm_sock");
-  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, 1));
-  auto reservation = lease::LeaseHandle::reserve_for_publish(shm_name, 1);
+  ASSERT_TRUE(lease::LeaseHandle::init(
+      shm_name, test::publisher_instance_id(shm_name), 1));
+  auto reservation = lease::LeaseHandle::reserve_for_publish(
+      shm_name, test::publisher_instance_id(shm_name), 1);
   ASSERT_TRUE(reservation.has_value());
 
   ros2_cuda_ipc_msgs::msg::BufferCore msg;
   msg.shm_name = shm_name;
+  msg.publisher_instance_id = test::publisher_instance_id(shm_name);
   msg.slot_id = 0;
   msg.device_id = 0;
   msg.generation = reservation->generation;
@@ -118,7 +152,8 @@ TEST_F(BufferViewMapperTest, MissingVmmSocketReturnsInvalidAndReleasesLease) {
   auto view = mapper.map(msg);
   EXPECT_FALSE(view.valid());
 
-  auto refcnt = lease::LeaseHandle::current_refcount(shm_name, 0);
+  auto refcnt = lease::LeaseHandle::current_refcount(
+      shm_name, test::publisher_instance_id(shm_name), 0);
   ASSERT_TRUE(refcnt.has_value());
   EXPECT_EQ(refcnt.value(), 0u);
 

--- a/ros2_cuda_ipc_core/test/mapper/test_image_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/test/mapper/test_image_view_mapper.cpp
@@ -18,7 +18,8 @@ class ImageViewMapperTest : public ::testing::Test {
 TEST_F(ImageViewMapperTest, InvalidCoreReturnsDefaultImageView) {
   const std::string shm_name =
       test::make_unique_shm_name("image_mapper_invalid");
-  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, 1));
+  ASSERT_TRUE(lease::LeaseHandle::init(
+      shm_name, test::publisher_instance_id(shm_name), 1));
 
   ros2_cuda_ipc_msgs::msg::GpuImage msg;
   msg.header.frame_id = "frame";
@@ -27,6 +28,7 @@ TEST_F(ImageViewMapperTest, InvalidCoreReturnsDefaultImageView) {
   msg.strides = {15, 3, 1};
   msg.encoding = "rgb8";
   msg.core.shm_name = shm_name;
+  msg.core.publisher_instance_id = test::publisher_instance_id(shm_name);
   msg.core.slot_id = 0;
   msg.core.device_id = 0;
   msg.core.generation = 42;
@@ -52,16 +54,16 @@ TEST_F(ImageViewMapperTest, CopiesMetadataWhenCoreIsValid) {
   msg.encoding = "mono16";
   msg.core = core;
 
-  auto before =
-      lease::LeaseHandle::current_refcount(core.shm_name, core.slot_id);
+  auto before = lease::LeaseHandle::current_refcount(
+      core.shm_name, core.publisher_instance_id, core.slot_id);
   ASSERT_TRUE(before.has_value());
   EXPECT_EQ(before.value(), 0u);
 
   image::ImageViewMapper mapper;
   auto view = mapper.map(msg);
   ASSERT_TRUE(view.core.valid());
-  auto during =
-      lease::LeaseHandle::current_refcount(core.shm_name, core.slot_id);
+  auto during = lease::LeaseHandle::current_refcount(
+      core.shm_name, core.publisher_instance_id, core.slot_id);
   ASSERT_TRUE(during.has_value());
   EXPECT_EQ(during.value(), 1u);
   EXPECT_EQ(view.header.frame_id, "camera_frame");
@@ -71,8 +73,8 @@ TEST_F(ImageViewMapperTest, CopiesMetadataWhenCoreIsValid) {
   EXPECT_EQ(view.encoding, "mono16");
 
   view.core.reset();
-  auto after =
-      lease::LeaseHandle::current_refcount(core.shm_name, core.slot_id);
+  auto after = lease::LeaseHandle::current_refcount(
+      core.shm_name, core.publisher_instance_id, core.slot_id);
   ASSERT_TRUE(after.has_value());
   EXPECT_EQ(after.value(), 0u);
   ::shm_unlink(core.shm_name.c_str());

--- a/ros2_cuda_ipc_core/test/mapper/test_pointcloud2_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/test/mapper/test_pointcloud2_view_mapper.cpp
@@ -19,7 +19,8 @@ class PointCloud2ViewMapperTest : public ::testing::Test {
 TEST_F(PointCloud2ViewMapperTest, InvalidCorePreservesHeaderOnlyBehavior) {
   const std::string shm_name =
       test::make_unique_shm_name("pointcloud_mapper_invalid");
-  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, 1));
+  ASSERT_TRUE(lease::LeaseHandle::init(
+      shm_name, test::publisher_instance_id(shm_name), 1));
 
   ros2_cuda_ipc_msgs::msg::GpuPointCloud2 msg;
   msg.header.frame_id = "frame_pc";
@@ -29,6 +30,7 @@ TEST_F(PointCloud2ViewMapperTest, InvalidCorePreservesHeaderOnlyBehavior) {
   msg.row_step = 24;
   msg.is_dense = true;
   msg.core.shm_name = shm_name;
+  msg.core.publisher_instance_id = test::publisher_instance_id(shm_name);
   msg.core.slot_id = 0;
   msg.core.device_id = 0;
   msg.core.generation = 42;

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
@@ -44,11 +44,6 @@ class GpuBufferManagerTest : public ::testing::Test {
     }
     shm_name_ = unique_name();
   }
-  void TearDown() override {
-    if (!shm_name_.empty()) {
-      ::shm_unlink(shm_name_.c_str());
-    }
-  }
   GpuBufferManager make_manager(
       std::chrono::milliseconds pending_ttl = std::chrono::milliseconds(100)) {
     return GpuBufferManager(
@@ -62,6 +57,7 @@ class GpuBufferManagerTest : public ::testing::Test {
 TEST_F(GpuBufferManagerTest, DescriptorIsGatedByReadyRecording) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
+  const auto instance_id = manager.publisher_instance_id();
   auto slot = manager.acquire_for_publish(1);
   ASSERT_TRUE(slot.has_value());
   EXPECT_EQ(slot->descriptor(), std::nullopt);
@@ -69,7 +65,9 @@ TEST_F(GpuBufferManagerTest, DescriptorIsGatedByReadyRecording) {
   auto descriptor = slot->descriptor();
   ASSERT_TRUE(descriptor.has_value());
   EXPECT_EQ(descriptor->slot_id, 0u);
-  EXPECT_EQ(descriptor->lease_shm_name, shm_name_);
+  EXPECT_NE(descriptor->lease_shm_name, shm_name_);
+  EXPECT_EQ(descriptor->lease_shm_name, manager.shm_name());
+  EXPECT_EQ(descriptor->publisher_instance_id, instance_id);
   EXPECT_EQ(descriptor->byte_size, 1024u);
   EXPECT_NE(slot->record_ready(nullptr), cudaSuccess);
   slot->commit_publish();
@@ -117,18 +115,21 @@ TEST_F(GpuBufferManagerTest, MovedFromSlotIsInert) {
 TEST_F(GpuBufferManagerTest, ResetDoesNotPreventReservationCancellation) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
+  const std::string actual_name = manager.shm_name();
+  const auto instance_id = manager.publisher_instance_id();
   auto slot = manager.acquire_for_publish(1);
   ASSERT_TRUE(slot.has_value());
   const auto pending_before =
-      ros2_cuda_ipc_core::lease::LeaseHandle::current_pending(shm_name_, 0);
+      ros2_cuda_ipc_core::lease::LeaseHandle::current_pending(actual_name,
+                                                              instance_id, 0);
   ASSERT_TRUE(pending_before.has_value());
   ASSERT_EQ(*pending_before, 1u);
 
   manager.reset();
   slot.reset();
 
-  const auto pending =
-      ros2_cuda_ipc_core::lease::LeaseHandle::current_pending(shm_name_, 0);
+  const auto pending = ros2_cuda_ipc_core::lease::LeaseHandle::current_pending(
+      actual_name, instance_id, 0);
   ASSERT_TRUE(pending.has_value());
   EXPECT_EQ(*pending, 0u);
 }

--- a/ros2_cuda_ipc_core/test/test_instance_id.hpp
+++ b/ros2_cuda_ipc_core/test/test_instance_id.hpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "ros2_cuda_ipc_core/publisher_instance_id.hpp"
+
+namespace ros2_cuda_ipc_core::test {
+
+inline PublisherInstanceId publisher_instance_id(const std::string& seed) {
+  PublisherInstanceId id{};
+  uint32_t state = 2166136261u;
+  for (uint8_t byte : seed) {
+    state = (state ^ byte) * 16777619u;
+  }
+  for (auto& byte : id) {
+    state = state * 1664525u + 1013904223u;
+    byte = static_cast<uint8_t>(state >> 24);
+  }
+  if (is_nil(id)) {
+    id.back() = 1;
+  }
+  return id;
+}
+
+}  // namespace ros2_cuda_ipc_core::test

--- a/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
@@ -6,11 +6,13 @@
 #include <atomic>
 
 #include "ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp"
+#include "test_instance_id.hpp"
 
 namespace ros2_cuda_ipc_core {
 
-TEST(IpcHandleCacheTest, KeyEqualityAndHashUseBackendPayloadAndEvent) {
+TEST(IpcHandleCacheTest, KeyEqualityAndHashUseInstanceBackendPayloadAndEvent) {
   subscriber::IpcHandleKey lhs{};
+  lhs.publisher_instance_id = test::publisher_instance_id("lhs");
   lhs.backend = 1;
   lhs.mem[0] = 3;
   lhs.event[0] = 5;
@@ -22,6 +24,9 @@ TEST(IpcHandleCacheTest, KeyEqualityAndHashUseBackendPayloadAndEvent) {
   different_mem.mem[1] = 7;
   subscriber::IpcHandleKey different_event = lhs;
   different_event.event[1] = 9;
+  subscriber::IpcHandleKey different_instance = lhs;
+  different_instance.publisher_instance_id =
+      test::publisher_instance_id("different");
 
   subscriber::IpcHandleKeyHash hash;
   EXPECT_TRUE(lhs == same);
@@ -29,6 +34,8 @@ TEST(IpcHandleCacheTest, KeyEqualityAndHashUseBackendPayloadAndEvent) {
   EXPECT_FALSE(lhs == different_backend);
   EXPECT_FALSE(lhs == different_mem);
   EXPECT_FALSE(lhs == different_event);
+  EXPECT_FALSE(lhs == different_instance);
+  EXPECT_NE(hash(lhs), hash(different_instance));
 }
 
 TEST(IpcHandleCacheTest, DuplicateInsertReturnsExistingEntry) {

--- a/ros2_cuda_ipc_core/test/test_lease_handle.cpp
+++ b/ros2_cuda_ipc_core/test/test_lease_handle.cpp
@@ -12,6 +12,7 @@
 #include <thread>
 
 #include "ros2_cuda_ipc_core/lease/lease_handle.hpp"
+#include "test_instance_id.hpp"
 
 namespace {
 
@@ -27,32 +28,37 @@ std::string make_unique_shm_name(const std::string& prefix) {
 namespace ros2_cuda_ipc_core {
 TEST(LeaseHandleTest, AcquireReleaseLifecycle) {
   const std::string shm_name = make_unique_shm_name("lease_ut");
-  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, 2));
+  ASSERT_TRUE(lease::LeaseHandle::init(
+      shm_name, test::publisher_instance_id(shm_name), 2));
 
-  auto reservation = lease::LeaseHandle::reserve_for_publish(shm_name, 0);
+  auto reservation = lease::LeaseHandle::reserve_for_publish(
+      shm_name, test::publisher_instance_id(shm_name), 0);
   ASSERT_TRUE(reservation.has_value());
 
   {
-    auto lease = lease::LeaseHandle::acquire(shm_name, reservation->slot_id,
-                                             reservation->generation);
+    auto lease = lease::LeaseHandle::acquire(
+        shm_name, test::publisher_instance_id(shm_name), reservation->slot_id,
+        reservation->generation);
     ASSERT_TRUE(lease.valid());
 
-    auto other = lease::LeaseHandle::reserve_for_publish(shm_name, 0);
+    auto other = lease::LeaseHandle::reserve_for_publish(
+        shm_name, test::publisher_instance_id(shm_name), 0);
     ASSERT_TRUE(other.has_value());
     EXPECT_NE(other->slot_id, reservation->slot_id);
 
-    auto ref =
-        lease::LeaseHandle::current_refcount(shm_name, reservation->slot_id);
+    auto ref = lease::LeaseHandle::current_refcount(
+        shm_name, test::publisher_instance_id(shm_name), reservation->slot_id);
     ASSERT_TRUE(ref.has_value());
     EXPECT_EQ(ref.value(), 1u);
   }
 
-  auto ref_after =
-      lease::LeaseHandle::current_refcount(shm_name, reservation->slot_id);
+  auto ref_after = lease::LeaseHandle::current_refcount(
+      shm_name, test::publisher_instance_id(shm_name), reservation->slot_id);
   ASSERT_TRUE(ref_after.has_value());
   EXPECT_EQ(ref_after.value(), 0u);
 
-  auto reservation_after = lease::LeaseHandle::reserve_for_publish(shm_name, 0);
+  auto reservation_after = lease::LeaseHandle::reserve_for_publish(
+      shm_name, test::publisher_instance_id(shm_name), 0);
   ASSERT_TRUE(reservation_after.has_value());
   EXPECT_EQ(reservation_after->slot_id, reservation->slot_id);
 
@@ -61,31 +67,111 @@ TEST(LeaseHandleTest, AcquireReleaseLifecycle) {
 
 TEST(LeaseHandleTest, GenerationMismatchReturnsInvalid) {
   const std::string shm_name = make_unique_shm_name("lease_mismatch");
-  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, 1));
+  ASSERT_TRUE(lease::LeaseHandle::init(
+      shm_name, test::publisher_instance_id(shm_name), 1));
 
-  auto reservation = lease::LeaseHandle::reserve_for_publish(shm_name, 0);
+  auto reservation = lease::LeaseHandle::reserve_for_publish(
+      shm_name, test::publisher_instance_id(shm_name), 0);
   ASSERT_TRUE(reservation.has_value());
 
-  auto lease = lease::LeaseHandle::acquire(shm_name, reservation->slot_id,
-                                           reservation->generation + 1);
+  auto lease = lease::LeaseHandle::acquire(
+      shm_name, test::publisher_instance_id(shm_name), reservation->slot_id,
+      reservation->generation + 1);
   EXPECT_FALSE(lease.valid());
 
   ::shm_unlink(shm_name.c_str());
 }
 
-TEST(LeaseHandleTest, PendingPreventsSlotReuse) {
-  const std::string shm_name = make_unique_shm_name("lease_pending");
-  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, 1));
-
-  auto reservation = lease::LeaseHandle::reserve_for_publish(shm_name, 2);
+TEST(LeaseHandleTest, PublisherInstanceMismatchReturnsInvalid) {
+  const std::string shm_name = make_unique_shm_name("lease_instance_mismatch");
+  const auto owner_id = test::publisher_instance_id(shm_name + "_owner");
+  const auto other_id = test::publisher_instance_id(shm_name + "_other");
+  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, owner_id, 1));
+  auto reservation =
+      lease::LeaseHandle::reserve_for_publish(shm_name, owner_id, 1);
   ASSERT_TRUE(reservation.has_value());
 
-  auto next = lease::LeaseHandle::reserve_for_publish(shm_name, 0);
+  auto wrong = lease::LeaseHandle::acquire(
+      shm_name, other_id, reservation->slot_id, reservation->generation);
+  EXPECT_FALSE(wrong.valid());
+  auto pending = lease::LeaseHandle::current_pending(shm_name, owner_id, 0);
+  ASSERT_TRUE(pending.has_value());
+  EXPECT_EQ(*pending, 1u);
+  ::shm_unlink(shm_name.c_str());
+}
+
+TEST(LeaseHandleTest, HeaderPublisherInstanceMismatchReturnsInvalid) {
+  const std::string shm_name =
+      make_unique_shm_name("lease_header_instance_mismatch");
+  const auto owner_id = test::publisher_instance_id(shm_name + "_owner");
+  const auto other_id = test::publisher_instance_id(shm_name + "_other");
+  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, owner_id, 1));
+
+  // Generation zero is valid in a newly-created slot. No mapping has been
+  // cached yet, so this exercises validation against the mapped header.
+  EXPECT_FALSE(lease::LeaseHandle::acquire(shm_name, other_id, 0, 0).valid());
+  ::shm_unlink(shm_name.c_str());
+}
+
+TEST(LeaseHandleTest, SameSlotAndGenerationAreSeparatedByInstance) {
+  const std::string first_name = make_unique_shm_name("lease_instance_first");
+  const std::string second_name = make_unique_shm_name("lease_instance_second");
+  const auto first_id = test::publisher_instance_id(first_name);
+  const auto second_id = test::publisher_instance_id(second_name);
+  ASSERT_TRUE(lease::LeaseHandle::init(first_name, first_id, 1));
+  ASSERT_TRUE(lease::LeaseHandle::init(second_name, second_id, 1));
+  auto first = lease::LeaseHandle::reserve_for_publish(first_name, first_id, 1);
+  auto second =
+      lease::LeaseHandle::reserve_for_publish(second_name, second_id, 1);
+  ASSERT_TRUE(first.has_value());
+  ASSERT_TRUE(second.has_value());
+  ASSERT_EQ(first->slot_id, second->slot_id);
+  ASSERT_EQ(first->generation, second->generation);
+
+  EXPECT_FALSE(lease::LeaseHandle::acquire(first_name, second_id,
+                                           first->slot_id, first->generation)
+                   .valid());
+  EXPECT_TRUE(lease::LeaseHandle::acquire(first_name, first_id, first->slot_id,
+                                          first->generation)
+                  .valid());
+  ::shm_unlink(first_name.c_str());
+  ::shm_unlink(second_name.c_str());
+}
+
+TEST(LeaseHandleTest, CachedMappingRejectsReusedNameWithNewInstance) {
+  const std::string shm_name = make_unique_shm_name("lease_cached_instance");
+  const auto old_id = test::publisher_instance_id(shm_name + "_old");
+  const auto new_id = test::publisher_instance_id(shm_name + "_new");
+  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, old_id, 1));
+  ASSERT_TRUE(
+      lease::LeaseHandle::current_generation(shm_name, old_id, 0).has_value());
+  ASSERT_EQ(::shm_unlink(shm_name.c_str()), 0);
+  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, new_id, 1));
+
+  // Slot zero and generation zero are valid in the new layout, but the cache
+  // still owns the old mapping for this locator.
+  EXPECT_FALSE(lease::LeaseHandle::acquire(shm_name, new_id, 0, 0).valid());
+  ::shm_unlink(shm_name.c_str());
+}
+
+TEST(LeaseHandleTest, PendingPreventsSlotReuse) {
+  const std::string shm_name = make_unique_shm_name("lease_pending");
+  ASSERT_TRUE(lease::LeaseHandle::init(
+      shm_name, test::publisher_instance_id(shm_name), 1));
+
+  auto reservation = lease::LeaseHandle::reserve_for_publish(
+      shm_name, test::publisher_instance_id(shm_name), 2);
+  ASSERT_TRUE(reservation.has_value());
+
+  auto next = lease::LeaseHandle::reserve_for_publish(
+      shm_name, test::publisher_instance_id(shm_name), 0);
   EXPECT_FALSE(next.has_value());
 
-  EXPECT_TRUE(lease::LeaseHandle::force_clear_pending(shm_name, 0));
+  EXPECT_TRUE(lease::LeaseHandle::force_clear_pending(
+      shm_name, test::publisher_instance_id(shm_name), 0));
 
-  next = lease::LeaseHandle::reserve_for_publish(shm_name, 0);
+  next = lease::LeaseHandle::reserve_for_publish(
+      shm_name, test::publisher_instance_id(shm_name), 0);
   ASSERT_TRUE(next.has_value());
   EXPECT_EQ(next->slot_id, reservation->slot_id);
 
@@ -94,37 +180,42 @@ TEST(LeaseHandleTest, PendingPreventsSlotReuse) {
 
 TEST(LeaseHandleTest, PendingDecrementedOnAcquire) {
   const std::string shm_name = make_unique_shm_name("lease_pending_dec");
-  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, 1));
+  ASSERT_TRUE(lease::LeaseHandle::init(
+      shm_name, test::publisher_instance_id(shm_name), 1));
 
-  auto reservation = lease::LeaseHandle::reserve_for_publish(shm_name, 2);
+  auto reservation = lease::LeaseHandle::reserve_for_publish(
+      shm_name, test::publisher_instance_id(shm_name), 2);
   ASSERT_TRUE(reservation.has_value());
 
   {
-    auto lease = lease::LeaseHandle::acquire(shm_name, reservation->slot_id,
-                                             reservation->generation);
+    auto lease = lease::LeaseHandle::acquire(
+        shm_name, test::publisher_instance_id(shm_name), reservation->slot_id,
+        reservation->generation);
     ASSERT_TRUE(lease.valid());
-    auto pending =
-        lease::LeaseHandle::current_pending(shm_name, reservation->slot_id);
+    auto pending = lease::LeaseHandle::current_pending(
+        shm_name, test::publisher_instance_id(shm_name), reservation->slot_id);
     ASSERT_TRUE(pending.has_value());
     EXPECT_EQ(pending.value(), 1u);
   }
 
   {
-    auto lease = lease::LeaseHandle::acquire(shm_name, reservation->slot_id,
-                                             reservation->generation);
+    auto lease = lease::LeaseHandle::acquire(
+        shm_name, test::publisher_instance_id(shm_name), reservation->slot_id,
+        reservation->generation);
     ASSERT_TRUE(lease.valid());
-    auto pending =
-        lease::LeaseHandle::current_pending(shm_name, reservation->slot_id);
+    auto pending = lease::LeaseHandle::current_pending(
+        shm_name, test::publisher_instance_id(shm_name), reservation->slot_id);
     ASSERT_TRUE(pending.has_value());
     EXPECT_EQ(pending.value(), 0u);
   }
 
   {
-    auto lease = lease::LeaseHandle::acquire(shm_name, reservation->slot_id,
-                                             reservation->generation);
+    auto lease = lease::LeaseHandle::acquire(
+        shm_name, test::publisher_instance_id(shm_name), reservation->slot_id,
+        reservation->generation);
     ASSERT_TRUE(lease.valid());
-    auto pending =
-        lease::LeaseHandle::current_pending(shm_name, reservation->slot_id);
+    auto pending = lease::LeaseHandle::current_pending(
+        shm_name, test::publisher_instance_id(shm_name), reservation->slot_id);
     ASSERT_TRUE(pending.has_value());
     EXPECT_EQ(pending.value(), 0u);
   }
@@ -134,18 +225,23 @@ TEST(LeaseHandleTest, PendingDecrementedOnAcquire) {
 
 TEST(LeaseHandleTest, ForceClearPendingResetsCounterWhenIdle) {
   const std::string shm_name = make_unique_shm_name("lease_force_clear");
-  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, 1));
+  ASSERT_TRUE(lease::LeaseHandle::init(
+      shm_name, test::publisher_instance_id(shm_name), 1));
 
-  auto reservation = lease::LeaseHandle::reserve_for_publish(shm_name, 2);
+  auto reservation = lease::LeaseHandle::reserve_for_publish(
+      shm_name, test::publisher_instance_id(shm_name), 2);
   ASSERT_TRUE(reservation.has_value());
 
-  auto pending = lease::LeaseHandle::current_pending(shm_name, 0);
+  auto pending = lease::LeaseHandle::current_pending(
+      shm_name, test::publisher_instance_id(shm_name), 0);
   ASSERT_TRUE(pending.has_value());
   EXPECT_EQ(pending.value(), 2u);
 
-  EXPECT_TRUE(lease::LeaseHandle::force_clear_pending(shm_name, 0));
+  EXPECT_TRUE(lease::LeaseHandle::force_clear_pending(
+      shm_name, test::publisher_instance_id(shm_name), 0));
 
-  pending = lease::LeaseHandle::current_pending(shm_name, 0);
+  pending = lease::LeaseHandle::current_pending(
+      shm_name, test::publisher_instance_id(shm_name), 0);
   ASSERT_TRUE(pending.has_value());
   EXPECT_EQ(pending.value(), 0u);
 
@@ -154,10 +250,12 @@ TEST(LeaseHandleTest, ForceClearPendingResetsCounterWhenIdle) {
 
 TEST(LeaseHandleTest, AtomicPublisherReservationExcludesSubscriberAcquire) {
   const std::string shm_name = make_unique_shm_name("lease_reserve_race");
-  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, 1));
+  ASSERT_TRUE(lease::LeaseHandle::init(
+      shm_name, test::publisher_instance_id(shm_name), 1));
 
   for (int iteration = 0; iteration < 1000; ++iteration) {
-    auto initial = lease::LeaseHandle::reserve_for_publish(shm_name, 0);
+    auto initial = lease::LeaseHandle::reserve_for_publish(
+        shm_name, test::publisher_instance_id(shm_name), 0);
     ASSERT_TRUE(initial.has_value());
 
     std::atomic<bool> start{false};
@@ -167,14 +265,16 @@ TEST(LeaseHandleTest, AtomicPublisherReservationExcludesSubscriberAcquire) {
       while (!start.load(std::memory_order_acquire)) {
         std::this_thread::yield();
       }
-      publisher = lease::LeaseHandle::reserve_for_publish(shm_name, 0);
+      publisher = lease::LeaseHandle::reserve_for_publish(
+          shm_name, test::publisher_instance_id(shm_name), 0);
     });
     std::thread subscriber_thread([&]() {
       while (!start.load(std::memory_order_acquire)) {
         std::this_thread::yield();
       }
-      subscriber.emplace(lease::LeaseHandle::acquire(shm_name, initial->slot_id,
-                                                     initial->generation));
+      subscriber.emplace(lease::LeaseHandle::acquire(
+          shm_name, test::publisher_instance_id(shm_name), initial->slot_id,
+          initial->generation));
     });
     start.store(true, std::memory_order_release);
     publisher_thread.join();
@@ -187,7 +287,8 @@ TEST(LeaseHandleTest, AtomicPublisherReservationExcludesSubscriberAcquire) {
 
 TEST(LeaseHandleTest, OnlyOnePublisherCanReserveSingleSlot) {
   const std::string shm_name = make_unique_shm_name("lease_pub_race");
-  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, 1));
+  ASSERT_TRUE(lease::LeaseHandle::init(
+      shm_name, test::publisher_instance_id(shm_name), 1));
   std::atomic<bool> start{false};
   std::optional<lease::LeaseHandle::PublisherReservation> first;
   std::optional<lease::LeaseHandle::PublisherReservation> second;
@@ -195,13 +296,15 @@ TEST(LeaseHandleTest, OnlyOnePublisherCanReserveSingleSlot) {
     while (!start.load(std::memory_order_acquire)) {
       std::this_thread::yield();
     }
-    first = lease::LeaseHandle::reserve_for_publish(shm_name, 1);
+    first = lease::LeaseHandle::reserve_for_publish(
+        shm_name, test::publisher_instance_id(shm_name), 1);
   });
   std::thread b([&]() {
     while (!start.load(std::memory_order_acquire)) {
       std::this_thread::yield();
     }
-    second = lease::LeaseHandle::reserve_for_publish(shm_name, 1);
+    second = lease::LeaseHandle::reserve_for_publish(
+        shm_name, test::publisher_instance_id(shm_name), 1);
   });
   start.store(true, std::memory_order_release);
   a.join();
@@ -212,15 +315,20 @@ TEST(LeaseHandleTest, OnlyOnePublisherCanReserveSingleSlot) {
 
 TEST(LeaseHandleTest, CancelDoesNotClearNewerGeneration) {
   const std::string shm_name = make_unique_shm_name("lease_cancel_generation");
-  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, 1));
-  auto old = lease::LeaseHandle::reserve_for_publish(shm_name, 0);
+  ASSERT_TRUE(lease::LeaseHandle::init(
+      shm_name, test::publisher_instance_id(shm_name), 1));
+  auto old = lease::LeaseHandle::reserve_for_publish(
+      shm_name, test::publisher_instance_id(shm_name), 0);
   ASSERT_TRUE(old.has_value());
-  auto current = lease::LeaseHandle::reserve_for_publish(shm_name, 1);
+  auto current = lease::LeaseHandle::reserve_for_publish(
+      shm_name, test::publisher_instance_id(shm_name), 1);
   ASSERT_TRUE(current.has_value());
 
-  EXPECT_FALSE(lease::LeaseHandle::cancel_pending(shm_name, old->slot_id,
-                                                  old->generation));
-  auto pending = lease::LeaseHandle::current_pending(shm_name, 0);
+  EXPECT_FALSE(lease::LeaseHandle::cancel_pending(
+      shm_name, old->slot_id, old->generation,
+      test::publisher_instance_id(shm_name)));
+  auto pending = lease::LeaseHandle::current_pending(
+      shm_name, test::publisher_instance_id(shm_name), 0);
   ASSERT_TRUE(pending.has_value());
   EXPECT_EQ(*pending, 1u);
   ::shm_unlink(shm_name.c_str());
@@ -228,10 +336,12 @@ TEST(LeaseHandleTest, CancelDoesNotClearNewerGeneration) {
 
 TEST(LeaseHandleTest, CancelRetriesTransientReservationContention) {
   const std::string shm_name = make_unique_shm_name("lease_cancel_contention");
-  ASSERT_TRUE(lease::LeaseHandle::init(shm_name, 1));
+  ASSERT_TRUE(lease::LeaseHandle::init(
+      shm_name, test::publisher_instance_id(shm_name), 1));
 
   for (int iteration = 0; iteration < 1000; ++iteration) {
-    auto reservation = lease::LeaseHandle::reserve_for_publish(shm_name, 1);
+    auto reservation = lease::LeaseHandle::reserve_for_publish(
+        shm_name, test::publisher_instance_id(shm_name), 1);
     ASSERT_TRUE(reservation.has_value());
 
     std::atomic<bool> start{false};
@@ -241,13 +351,16 @@ TEST(LeaseHandleTest, CancelRetriesTransientReservationContention) {
         std::this_thread::yield();
       }
       cancelled = lease::LeaseHandle::cancel_pending(
-          shm_name, reservation->slot_id, reservation->generation);
+          shm_name, reservation->slot_id, reservation->generation,
+          test::publisher_instance_id(shm_name));
     });
     std::thread reclaim_thread([&]() {
       while (!start.load(std::memory_order_acquire)) {
         std::this_thread::yield();
       }
-      lease::LeaseHandle::force_clear_pending(shm_name, reservation->slot_id);
+      lease::LeaseHandle::force_clear_pending(
+          shm_name, test::publisher_instance_id(shm_name),
+          reservation->slot_id);
     });
 
     start.store(true, std::memory_order_release);
@@ -255,8 +368,8 @@ TEST(LeaseHandleTest, CancelRetriesTransientReservationContention) {
     reclaim_thread.join();
     EXPECT_TRUE(cancelled);
 
-    const auto pending =
-        lease::LeaseHandle::current_pending(shm_name, reservation->slot_id);
+    const auto pending = lease::LeaseHandle::current_pending(
+        shm_name, test::publisher_instance_id(shm_name), reservation->slot_id);
     ASSERT_TRUE(pending.has_value());
     EXPECT_EQ(*pending, 0u);
   }

--- a/ros2_cuda_ipc_core/test/test_lease_manager.cpp
+++ b/ros2_cuda_ipc_core/test/test_lease_manager.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2026 Daisuke Kato
 // SPDX-License-Identifier: MIT
 
+#include <fcntl.h>
 #include <gtest/gtest.h>
 #include <sys/mman.h>
 #include <unistd.h>
@@ -11,7 +12,6 @@
 #include <sstream>
 #include <string>
 #include <thread>
-#include <utility>
 
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_cuda_ipc_core/lease/lease_handle.hpp"
@@ -26,28 +26,17 @@ std::string make_unique_shm_name() {
   return out.str();
 }
 
-class ShmUnlinkGuard {
- public:
-  explicit ShmUnlinkGuard(std::string name) : name_(std::move(name)) {}
-  ~ShmUnlinkGuard() { ::shm_unlink(name_.c_str()); }
-
-  ShmUnlinkGuard(const ShmUnlinkGuard&) = delete;
-  ShmUnlinkGuard& operator=(const ShmUnlinkGuard&) = delete;
-
- private:
-  std::string name_;
-};
-
 }  // namespace
 
 TEST(LeaseManagerTest, ResetRacingWithReserveDoesNotLeavePending) {
   for (int iteration = 0; iteration < 1000; ++iteration) {
-    const std::string shm_name = make_unique_shm_name();
-    const ShmUnlinkGuard shm_guard(shm_name);
+    const std::string prefix = make_unique_shm_name();
     ros2_cuda_ipc_core::publisher::LeaseManager manager(
-        shm_name, 1, std::chrono::milliseconds(100),
+        prefix, 1, std::chrono::milliseconds(100),
         rclcpp::get_logger("LeaseManagerTest"));
     ASSERT_TRUE(manager.initialise());
+    const std::string shm_name = manager.shm_name();
+    const auto instance_id = manager.publisher_instance_id();
 
     std::atomic<bool> start{false};
     std::optional<ros2_cuda_ipc_core::publisher::LeaseManager::Reservation>
@@ -71,37 +60,51 @@ TEST(LeaseManagerTest, ResetRacingWithReserveDoesNotLeavePending) {
 
     if (reservation) {
       manager.cancel(*reservation);
+      const auto pending =
+          ros2_cuda_ipc_core::lease::LeaseHandle::current_pending(
+              shm_name, instance_id, 0);
+      ASSERT_TRUE(pending.has_value());
+      EXPECT_EQ(*pending, 0u);
     }
-    const auto pending =
-        ros2_cuda_ipc_core::lease::LeaseHandle::current_pending(shm_name, 0);
-    ASSERT_TRUE(pending.has_value());
-    EXPECT_EQ(*pending, 0u);
   }
 }
 
-TEST(LeaseManagerTest, CapacityMismatchRollsBackOutOfRangeReservation) {
-  const std::string shm_name = make_unique_shm_name();
-  const ShmUnlinkGuard shm_guard(shm_name);
+TEST(LeaseManagerTest, SamePrefixProducesDistinctInstances) {
+  const std::string prefix = make_unique_shm_name();
+  ros2_cuda_ipc_core::publisher::LeaseManager first(
+      prefix, 1, std::chrono::milliseconds(100),
+      rclcpp::get_logger("LeaseManagerTest"));
+  ros2_cuda_ipc_core::publisher::LeaseManager second(
+      prefix, 2, std::chrono::milliseconds(100),
+      rclcpp::get_logger("LeaseManagerTest"));
+  ASSERT_TRUE(first.initialise());
+  ASSERT_TRUE(second.initialise());
+  EXPECT_NE(first.shm_name(), second.shm_name());
+  EXPECT_NE(first.publisher_instance_id(), second.publisher_instance_id());
+}
+
+TEST(LeaseManagerTest, ResetUnlinksAndReinitialiseChangesIdentity) {
   ros2_cuda_ipc_core::publisher::LeaseManager manager(
-      shm_name, 1, std::chrono::milliseconds(100),
+      make_unique_shm_name(), 1, std::chrono::milliseconds(100),
       rclcpp::get_logger("LeaseManagerTest"));
   ASSERT_TRUE(manager.initialise());
+  const std::string old_name = manager.shm_name();
+  const auto old_id = manager.publisher_instance_id();
+  manager.reset();
+  EXPECT_TRUE(manager.shm_name().empty());
+  EXPECT_TRUE(ros2_cuda_ipc_core::is_nil(manager.publisher_instance_id()));
+  EXPECT_EQ(::shm_open(old_name.c_str(), O_RDWR, 0660), -1);
 
-  // Simulate an unsupported second Publisher reinitialising the same name
-  // with a different capacity, then occupy slot 0 so the local manager
-  // observes an out-of-range reservation for slot 1.
-  ASSERT_TRUE(ros2_cuda_ipc_core::lease::LeaseHandle::init(shm_name, 2));
-  const auto occupied =
-      ros2_cuda_ipc_core::lease::LeaseHandle::reserve_for_publish(shm_name, 1);
-  ASSERT_TRUE(occupied.has_value());
-  ASSERT_EQ(occupied->slot_id, 0u);
+  ASSERT_TRUE(manager.initialise());
+  EXPECT_NE(manager.shm_name(), old_name);
+  EXPECT_NE(manager.publisher_instance_id(), old_id);
+}
 
-  EXPECT_FALSE(manager.reserve_for_publish(1).has_value());
-  const auto out_of_range_pending =
-      ros2_cuda_ipc_core::lease::LeaseHandle::current_pending(shm_name, 1);
-  ASSERT_TRUE(out_of_range_pending.has_value());
-  EXPECT_EQ(*out_of_range_pending, 0u);
-
-  EXPECT_TRUE(ros2_cuda_ipc_core::lease::LeaseHandle::cancel_pending(
-      shm_name, occupied->slot_id, occupied->generation));
+TEST(LeaseManagerTest, InvalidPrefixFailsClosed) {
+  ros2_cuda_ipc_core::publisher::LeaseManager manager(
+      "/invalid/prefix", 1, std::chrono::milliseconds(100),
+      rclcpp::get_logger("LeaseManagerTest"));
+  EXPECT_FALSE(manager.initialise());
+  EXPECT_TRUE(manager.shm_name().empty());
+  EXPECT_TRUE(ros2_cuda_ipc_core::is_nil(manager.publisher_instance_id()));
 }

--- a/ros2_cuda_ipc_core/test/test_lease_manager.cpp
+++ b/ros2_cuda_ipc_core/test/test_lease_manager.cpp
@@ -93,7 +93,11 @@ TEST(LeaseManagerTest, ResetUnlinksAndReinitialiseChangesIdentity) {
   manager.reset();
   EXPECT_TRUE(manager.shm_name().empty());
   EXPECT_TRUE(ros2_cuda_ipc_core::is_nil(manager.publisher_instance_id()));
-  EXPECT_EQ(::shm_open(old_name.c_str(), O_RDWR, 0660), -1);
+  const int fd = ::shm_open(old_name.c_str(), O_RDWR, 0660);
+  if (fd != -1) {
+    ::close(fd);
+  }
+  EXPECT_EQ(fd, -1);
 
   ASSERT_TRUE(manager.initialise());
   EXPECT_NE(manager.shm_name(), old_name);

--- a/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
+++ b/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
@@ -16,6 +16,7 @@
 #include "ros2_cuda_ipc_core/lease/lease_handle.hpp"
 #include "ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp"
 #include "ros2_cuda_ipc_msgs/msg/buffer_core.hpp"
+#include "test_instance_id.hpp"
 
 namespace ros2_cuda_ipc_core::test {
 
@@ -46,6 +47,7 @@ class RclcppScope {
 inline subscriber::IpcHandleKey make_key(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg) {
   subscriber::IpcHandleKey key{};
+  key.publisher_instance_id = msg.publisher_instance_id;
   key.backend = static_cast<uint8_t>(msg.backend);
   key.mem = msg.mem_handle;
   std::memcpy(key.event.data(), msg.event_handle.data(),
@@ -60,6 +62,7 @@ inline ros2_cuda_ipc_msgs::msg::BufferCore make_cached_buffer_core_message(
         transport::MemoryBackendKind::CUDA_IPC) {
   ros2_cuda_ipc_msgs::msg::BufferCore msg;
   msg.shm_name = shm_name;
+  msg.publisher_instance_id = publisher_instance_id(shm_name);
   msg.device_id = 0;
   msg.slot_id = slot_id;
   msg.generation = generation;
@@ -84,11 +87,13 @@ inline void seed_cache_for_message(
 inline ros2_cuda_ipc_msgs::msg::BufferCore make_seeded_buffer_core_message(
     const std::string& prefix, uint8_t key_seed) {
   const std::string shm_name = make_unique_shm_name(prefix);
-  if (!lease::LeaseHandle::init(shm_name, 1)) {
+  const auto instance_id = publisher_instance_id(shm_name);
+  if (!lease::LeaseHandle::init(shm_name, instance_id, 1)) {
     ADD_FAILURE() << "LeaseHandle::init failed for " << shm_name;
     return ros2_cuda_ipc_msgs::msg::BufferCore{};
   }
-  auto reservation = lease::LeaseHandle::reserve_for_publish(shm_name, 1);
+  auto reservation =
+      lease::LeaseHandle::reserve_for_publish(shm_name, instance_id, 1);
   if (!reservation.has_value()) {
     ADD_FAILURE() << "LeaseHandle::reserve_for_publish failed for " << shm_name;
     return ros2_cuda_ipc_msgs::msg::BufferCore{};

--- a/ros2_cuda_ipc_core/test/test_publisher_messages.cpp
+++ b/ros2_cuda_ipc_core/test/test_publisher_messages.cpp
@@ -20,6 +20,7 @@ namespace {
 ros2_cuda_ipc_core::transport::BufferDescriptor make_descriptor() {
   ros2_cuda_ipc_core::transport::BufferDescriptor descriptor;
   descriptor.lease_shm_name = "/publisher_messages";
+  descriptor.publisher_instance_id[0] = 42;
   descriptor.slot_id = 7;
   descriptor.generation = 11;
   descriptor.device_id = 2;
@@ -41,6 +42,7 @@ TEST(PublisherMessagesTest,
   ros2_cuda_ipc_core::transport::fill_buffer_core_message(descriptor, message);
 
   EXPECT_EQ(message.shm_name, descriptor.lease_shm_name);
+  EXPECT_EQ(message.publisher_instance_id, descriptor.publisher_instance_id);
   EXPECT_EQ(message.slot_id, descriptor.slot_id);
   EXPECT_EQ(message.generation, descriptor.generation);
   EXPECT_EQ(message.device_id, 2u);

--- a/ros2_cuda_ipc_msgs/msg/BufferCore.msg
+++ b/ros2_cuda_ipc_msgs/msg/BufferCore.msg
@@ -10,6 +10,9 @@ uint8[64] event_handle
 # Shared memory name for lease/refcount management
 string shm_name
 
+# Identity of the publisher initialisation that owns this buffer
+uint8[16] publisher_instance_id
+
 # Identification of the GPU buffer slot
 uint32 device_id
 uint32 slot_id


### PR DESCRIPTION
- Added publisher_instance_id to BufferCore message for tracking ownership.
- Updated fill_buffer_core_message to populate publisher_instance_id from BufferDescriptor.
- Enhanced IpcHandleKey hashing to include publisher_instance_id for better key uniqueness.
- Modified tests across various mappers and lease handles to incorporate publisher_instance_id.
- Ensured that publisher_instance_id is utilized in lease management and message mapping logic.
- Created utility functions for generating consistent publisher_instance_id based on unique names.