### PR TITLE
Prepare v0.2.0 release

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -79,7 +79,7 @@ colcon build --symlink-install --packages-up-to cuda_ipc_poc
 source install/setup.bash
 
 ros2 launch cuda_ipc_poc cuda_ipc.launch.py
-ros2 launch cuda_ipc_poc vmm.launch.py
+ros2 launch cuda_ipc_poc vmm_fd.launch.py
 ```
 
 See [utils/cuda_ipc_poc/README.md](utils/cuda_ipc_poc/README.md).

--- a/examples/multi_process_image_fanout/CMakeLists.txt
+++ b/examples/multi_process_image_fanout/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.16)
 project(multi_process_image_fanout)
 
+# Leave architecture selection to the CUDA toolchain unless a build or release
+# configuration explicitly supplies CMAKE_CUDA_ARCHITECTURES.
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+  set(CMAKE_CUDA_ARCHITECTURES OFF)
+endif()
+
 enable_language(CUDA)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/examples/multi_process_image_fanout/package.xml
+++ b/examples/multi_process_image_fanout/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>multi_process_image_fanout</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>Primary ros2_cuda_ipc demo for one GPU image publisher fanning out to multiple processes.</description>
   <maintainer email="dskkato@example.com">dskkato</maintainer>
   <license>MIT</license>

--- a/examples/multi_process_image_fanout/test/test_kernels.cpp
+++ b/examples/multi_process_image_fanout/test/test_kernels.cpp
@@ -191,7 +191,9 @@ TEST(KernelSmokeTest, ProducesExpectedOutputs) {
   }
 
   const InferenceStats cpu_stats = cpu_inference_stats(cpu_gray);
-  EXPECT_NEAR(host_stats.mean, cpu_stats.mean, 1e-6f);
+  // The GPU uses unordered float atomic additions while the reference uses a
+  // deterministic double-precision accumulation.
+  EXPECT_NEAR(host_stats.mean, cpu_stats.mean, 5e-6f);
   EXPECT_NEAR(host_stats.min, cpu_stats.min, 1e-6f);
   EXPECT_NEAR(host_stats.max, cpu_stats.max, 1e-6f);
   EXPECT_EQ(host_stats.checksum, cpu_stats.checksum);

--- a/ros2_cuda_ipc_core/CMakeLists.txt
+++ b/ros2_cuda_ipc_core/CMakeLists.txt
@@ -101,5 +101,5 @@ endif()
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_include_directories(include)
-ament_export_dependencies(rclcpp rcpputils ros2_cuda_ipc_msgs rosidl_default_runtime sensor_msgs std_msgs)
+ament_export_dependencies(CUDAToolkit rclcpp rcpputils ros2_cuda_ipc_msgs rosidl_default_runtime sensor_msgs std_msgs)
 ament_package()

--- a/ros2_cuda_ipc_core/package.xml
+++ b/ros2_cuda_ipc_core/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ros2_cuda_ipc_core</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>Core C++ utilities for ROS 2 GPU zero-copy transport using CUDA IPC.</description>
   <maintainer email="dskkato@example.com">dskkato</maintainer>
   <license>MIT</license>

--- a/ros2_cuda_ipc_msgs/package.xml
+++ b/ros2_cuda_ipc_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ros2_cuda_ipc_msgs</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>Message definitions for ROS 2 GPU zero-copy transport using CUDA IPC.</description>
   <maintainer email="dskkato@example.com">dskkato</maintainer>
   <license>MIT</license>

--- a/utils/cuda_ipc_poc/package.xml
+++ b/utils/cuda_ipc_poc/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>cuda_ipc_poc</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>Test applications for CUDA IPC mechanisms (both cudaIpc and VMM-FD)</description>
   <maintainer email="dskkato@users.noreply.github.com">dskkato</maintainer>
   <license>Apache-2.0</license>

--- a/utils/gpu_image_transport/package.xml
+++ b/utils/gpu_image_transport/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>gpu_image_transport</name>
-  <version>0.0.0</version>
+  <version>0.2.0</version>
   <description>Utility nodes that map ros2_cuda_ipc GpuImage messages to CPU sensor_msgs image topics.</description>
   <maintainer email="dskkato@example.com">dskkato</maintainer>
   <license>MIT</license>


### PR DESCRIPTION
## Summary

- Prepare all ROS packages for the PoC v0.2.0 release.
- Export CUDAToolkit from the core package for downstream consumers.
- Correct the VMM-FD launch command and make CUDA architecture selection explicit.
- Stabilize the GPU kernel smoke test for unordered floating-point atomic accumulation.

## Validation

- Clean colcon build (RelWithDebInfo).
- colcon test and test-result: 51 tests, 0 failures.
- test_kernels passed 10 consecutive repetitions.
- CUDA IPC and VMM-FD multi-process fanout smoke tests on an RTX 4060.