### PR TITLE
refactor: use CUDA driver IPC imports

### DIFF
--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp
@@ -11,7 +11,6 @@ class MemoryImporter final : public backend::MemoryImporter {
  public:
   std::optional<ImportedMemory> import(
       const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-      const cudaIpcEventHandle_t& event_handle,
       const rclcpp::Logger& logger) const override;
 };
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <cuda.h>
-#include <cuda_runtime_api.h>
 
 #include <cstddef>
 #include <optional>
@@ -16,8 +15,8 @@
 namespace ros2_cuda_ipc_core::backend {
 
 struct ImportedMemory {
-  void* dev_ptr = nullptr;
-  cudaEvent_t event = nullptr;
+  CUdeviceptr dev_ptr = 0;
+  CUevent event = nullptr;
   CUdeviceptr vmm_address = 0;
   CUmemGenericAllocationHandle vmm_allocation = 0;
   std::size_t allocation_size = 0;
@@ -29,7 +28,6 @@ class MemoryImporter {
 
   virtual std::optional<ImportedMemory> import(
       const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-      const cudaIpcEventHandle_t& event_handle,
       const rclcpp::Logger& logger) const = 0;
 };
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/vmm_fd/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/vmm_fd/memory_importer.hpp
@@ -11,7 +11,6 @@ class MemoryImporter final : public backend::MemoryImporter {
  public:
   std::optional<ImportedMemory> import(
       const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-      const cudaIpcEventHandle_t& event_handle,
       const rclcpp::Logger& logger) const override;
 };
 

--- a/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_importer.cpp
@@ -6,16 +6,33 @@
 #include <cstring>
 
 #include "rclcpp/logging.hpp"
+#include "ros2_cuda_ipc_core/detail/cuda_util.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 
 namespace ros2_cuda_ipc_core::backend::cuda_ipc {
 
 namespace {
 
-cudaIpcMemHandle_t to_cuda_mem_handle(
+using BufferCoreMessage = ros2_cuda_ipc_msgs::msg::BufferCore;
+
+static_assert(sizeof(BufferCoreMessage::_mem_handle_type) ==
+                  sizeof(CUipcMemHandle),
+              "BufferCore.mem_handle must match CUipcMemHandle");
+static_assert(sizeof(BufferCoreMessage::_event_handle_type) ==
+                  sizeof(CUipcEventHandle),
+              "BufferCore.event_handle must match CUipcEventHandle");
+
+CUipcMemHandle to_ipc_mem_handle(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg) {
-  cudaIpcMemHandle_t handle{};
+  CUipcMemHandle handle{};
   std::memcpy(&handle, msg.mem_handle.data(), sizeof(handle));
+  return handle;
+}
+
+CUipcEventHandle to_ipc_event_handle(
+    const ros2_cuda_ipc_msgs::msg::BufferCore& msg) {
+  CUipcEventHandle handle{};
+  std::memcpy(&handle, msg.event_handle.data(), sizeof(handle));
   return handle;
 }
 
@@ -23,24 +40,26 @@ cudaIpcMemHandle_t to_cuda_mem_handle(
 
 std::optional<ImportedMemory> MemoryImporter::import(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-    const cudaIpcEventHandle_t& event_handle,
     const rclcpp::Logger& logger) const {
   ImportedMemory imported;
 
-  auto err = cudaIpcOpenEventHandle(&imported.event, event_handle);
-  if (err != cudaSuccess) {
-    RCLCPP_WARN(logger, "cudaIpcOpenEventHandle failed: %s",
-                cudaGetErrorString(err));
+  const CUresult event_result =
+      cuIpcOpenEventHandle(&imported.event, to_ipc_event_handle(msg));
+  if (event_result != CUDA_SUCCESS) {
+    RCLCPP_WARN(
+        logger, "cuIpcOpenEventHandle failed: %s",
+        ros2_cuda_ipc_core::detail::cu_result_to_string(event_result).c_str());
     return std::nullopt;
   }
 
-  const cudaIpcMemHandle_t mem_handle = to_cuda_mem_handle(msg);
-  err = cudaIpcOpenMemHandle(&imported.dev_ptr, mem_handle,
-                             cudaIpcMemLazyEnablePeerAccess);
-  if (err != cudaSuccess) {
-    RCLCPP_WARN(logger, "cudaIpcOpenMemHandle failed: %s",
-                cudaGetErrorString(err));
-    cudaEventDestroy(imported.event);
+  const CUresult memory_result =
+      cuIpcOpenMemHandle(&imported.dev_ptr, to_ipc_mem_handle(msg),
+                         CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS);
+  if (memory_result != CUDA_SUCCESS) {
+    RCLCPP_WARN(
+        logger, "cuIpcOpenMemHandle failed: %s",
+        ros2_cuda_ipc_core::detail::cu_result_to_string(memory_result).c_str());
+    (void)cuEventDestroy(imported.event);
     return std::nullopt;
   }
 

--- a/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
@@ -10,18 +10,20 @@
 namespace ros2_cuda_ipc_core::backend {
 
 void release_imported_memory(const ImportedMemory& imported) noexcept {
+  // VMM imports must be dismantled in mapping dependency order.
   if (imported.vmm_address != 0 && imported.allocation_size != 0) {
-    cuMemUnmap(imported.vmm_address, imported.allocation_size);
-    cuMemAddressFree(imported.vmm_address, imported.allocation_size);
+    (void)cuMemUnmap(imported.vmm_address, imported.allocation_size);
+    (void)cuMemAddressFree(imported.vmm_address, imported.allocation_size);
   }
   if (imported.vmm_allocation != 0) {
-    cuMemRelease(imported.vmm_allocation);
+    (void)cuMemRelease(imported.vmm_allocation);
   }
-  if (imported.vmm_address == 0 && imported.dev_ptr != nullptr) {
-    cudaIpcCloseMemHandle(imported.dev_ptr);
-  }
+  // CUDA IPC imports own an event and memory mapping independently.
   if (imported.event != nullptr) {
-    cudaEventDestroy(imported.event);
+    (void)cuEventDestroy(imported.event);
+  }
+  if (imported.vmm_address == 0 && imported.dev_ptr != 0) {
+    (void)cuIpcCloseMemHandle(imported.dev_ptr);
   }
 }
 

--- a/ros2_cuda_ipc_core/src/backend/vmm_fd/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/vmm_fd/memory_importer.cpp
@@ -24,6 +24,12 @@ namespace ros2_cuda_ipc_core::backend::vmm_fd {
 
 namespace {
 
+using BufferCoreMessage = ros2_cuda_ipc_msgs::msg::BufferCore;
+
+static_assert(sizeof(BufferCoreMessage::_event_handle_type) ==
+                  sizeof(CUipcEventHandle),
+              "BufferCore.event_handle must match CUipcEventHandle");
+
 std::size_t align_up_size(std::size_t value, std::size_t alignment) {
   if (alignment == 0) {
     return value;
@@ -57,6 +63,26 @@ std::optional<std::string> parse_vmm_payload(
     return std::nullopt;
   }
   return uuid;
+}
+
+CUipcEventHandle to_ipc_event_handle(
+    const ros2_cuda_ipc_msgs::msg::BufferCore& msg) {
+  CUipcEventHandle handle{};
+  std::memcpy(&handle, msg.event_handle.data(), sizeof(handle));
+  return handle;
+}
+
+void rollback_vmm_import(const ImportedMemory& imported) noexcept {
+  if (imported.event != nullptr) {
+    (void)cuEventDestroy(imported.event);
+  }
+  if (imported.vmm_address != 0 && imported.allocation_size != 0) {
+    (void)cuMemUnmap(imported.vmm_address, imported.allocation_size);
+    (void)cuMemAddressFree(imported.vmm_address, imported.allocation_size);
+  }
+  if (imported.vmm_allocation != 0) {
+    (void)cuMemRelease(imported.vmm_allocation);
+  }
 }
 
 std::optional<int> request_fd_from_publisher(const std::string& path,
@@ -130,7 +156,6 @@ std::optional<int> request_fd_from_publisher(const std::string& path,
 
 std::optional<ImportedMemory> MemoryImporter::import(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-    const cudaIpcEventHandle_t& event_handle,
     const rclcpp::Logger& logger) const {
   const auto meta = parse_vmm_payload(msg.mem_handle, logger);
   if (!meta.has_value()) {
@@ -156,9 +181,19 @@ std::optional<ImportedMemory> MemoryImporter::import(
 
   ImportedMemory imported;
 
+  CUresult cu_res =
+      cuIpcOpenEventHandle(&imported.event, to_ipc_event_handle(msg));
+  if (cu_res != CUDA_SUCCESS) {
+    RCLCPP_WARN(
+        logger, "cuIpcOpenEventHandle failed: %s",
+        ros2_cuda_ipc_core::detail::cu_result_to_string(cu_res).c_str());
+    ::close(fd_opt.value());
+    return std::nullopt;
+  }
+
   void* os_handle =
       reinterpret_cast<void*>(static_cast<intptr_t>(fd_opt.value()));
-  CUresult cu_res =
+  cu_res =
       cuMemImportFromShareableHandle(&imported.vmm_allocation, os_handle,
                                      CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
   ::close(fd_opt.value());
@@ -166,6 +201,7 @@ std::optional<ImportedMemory> MemoryImporter::import(
     RCLCPP_WARN(
         logger, "cuMemImportFromShareableHandle failed: %s",
         ros2_cuda_ipc_core::detail::cu_result_to_string(cu_res).c_str());
+    rollback_vmm_import(imported);
     return std::nullopt;
   }
 
@@ -181,7 +217,7 @@ std::optional<ImportedMemory> MemoryImporter::import(
     RCLCPP_WARN(
         logger, "cuMemGetAllocationGranularity failed: %s",
         ros2_cuda_ipc_core::detail::cu_result_to_string(cu_res).c_str());
-    cuMemRelease(imported.vmm_allocation);
+    rollback_vmm_import(imported);
     return std::nullopt;
   }
 
@@ -197,7 +233,7 @@ std::optional<ImportedMemory> MemoryImporter::import(
     RCLCPP_WARN(
         logger, "cuMemAddressReserve failed: %s",
         ros2_cuda_ipc_core::detail::cu_result_to_string(cu_res).c_str());
-    cuMemRelease(imported.vmm_allocation);
+    rollback_vmm_import(imported);
     return std::nullopt;
   }
 
@@ -207,8 +243,7 @@ std::optional<ImportedMemory> MemoryImporter::import(
     RCLCPP_WARN(
         logger, "cuMemMap failed: %s",
         ros2_cuda_ipc_core::detail::cu_result_to_string(cu_res).c_str());
-    cuMemAddressFree(imported.vmm_address, imported.allocation_size);
-    cuMemRelease(imported.vmm_allocation);
+    rollback_vmm_import(imported);
     return std::nullopt;
   }
 
@@ -221,23 +256,11 @@ std::optional<ImportedMemory> MemoryImporter::import(
     RCLCPP_WARN(
         logger, "cuMemSetAccess failed: %s",
         ros2_cuda_ipc_core::detail::cu_result_to_string(cu_res).c_str());
-    cuMemUnmap(imported.vmm_address, imported.allocation_size);
-    cuMemAddressFree(imported.vmm_address, imported.allocation_size);
-    cuMemRelease(imported.vmm_allocation);
+    rollback_vmm_import(imported);
     return std::nullopt;
   }
 
-  auto err = cudaIpcOpenEventHandle(&imported.event, event_handle);
-  if (err != cudaSuccess) {
-    RCLCPP_WARN(logger, "cudaIpcOpenEventHandle failed: %s",
-                cudaGetErrorString(err));
-    cuMemUnmap(imported.vmm_address, imported.allocation_size);
-    cuMemAddressFree(imported.vmm_address, imported.allocation_size);
-    cuMemRelease(imported.vmm_allocation);
-    return std::nullopt;
-  }
-
-  imported.dev_ptr = reinterpret_cast<void*>(imported.vmm_address);
+  imported.dev_ptr = imported.vmm_address;
   return imported;
 }
 

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
@@ -123,7 +123,7 @@ BufferView BufferViewMapper::map(
   } else {
     const auto& importer =
         backend::get_memory_importer(static_cast<uint8_t>(msg.backend));
-    auto opened = importer.import(msg, event_handle, options_.logger);
+    auto opened = importer.import(msg, options_.logger);
     if (!opened.has_value()) {
       return {};
     }
@@ -132,8 +132,8 @@ BufferView BufferViewMapper::map(
   }
 
   BufferView view;
-  view.dev_ptr = imported.dev_ptr;
-  view.ready_evt = imported.event;
+  view.dev_ptr = reinterpret_cast<void*>(imported.dev_ptr);
+  view.ready_evt = reinterpret_cast<cudaEvent_t>(imported.event);
   view.device_id = static_cast<int>(msg.device_id);
   view.byte_size = msg.byte_size;
   view.slot_id = msg.slot_id;

--- a/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
@@ -46,12 +46,12 @@ TEST(IpcHandleCacheTest, DuplicateInsertReturnsExistingEntry) {
   key.event[0] = 13;
 
   backend::ImportedMemory first;
-  first.dev_ptr = reinterpret_cast<void*>(0x1010);
-  first.event = reinterpret_cast<cudaEvent_t>(0x2020);
+  first.dev_ptr = static_cast<CUdeviceptr>(0x1010);
+  first.event = reinterpret_cast<CUevent>(0x2020);
 
   backend::ImportedMemory duplicate;
-  duplicate.dev_ptr = reinterpret_cast<void*>(0x3030);
-  duplicate.event = reinterpret_cast<cudaEvent_t>(0x4040);
+  duplicate.dev_ptr = static_cast<CUdeviceptr>(0x3030);
+  duplicate.event = reinterpret_cast<CUevent>(0x4040);
 
   auto inserted = cache.insert_or_discard_duplicate(key, first);
   auto second = cache.insert_or_discard_duplicate(key, duplicate);
@@ -72,12 +72,12 @@ TEST(IpcHandleCacheTest, DuplicateInsertInvokesReleaseHook) {
   key.event[0] = 19;
 
   backend::ImportedMemory first;
-  first.dev_ptr = reinterpret_cast<void*>(0x5050);
-  first.event = reinterpret_cast<cudaEvent_t>(0x6060);
+  first.dev_ptr = static_cast<CUdeviceptr>(0x5050);
+  first.event = reinterpret_cast<CUevent>(0x6060);
 
   backend::ImportedMemory duplicate;
-  duplicate.dev_ptr = reinterpret_cast<void*>(0x7070);
-  duplicate.event = reinterpret_cast<cudaEvent_t>(0x8080);
+  duplicate.dev_ptr = static_cast<CUdeviceptr>(0x7070);
+  duplicate.event = reinterpret_cast<CUevent>(0x8080);
 
   cache.insert_or_discard_duplicate(key, first);
   cache.insert_or_discard_duplicate(key, duplicate);

--- a/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
+++ b/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
@@ -78,8 +78,8 @@ inline ros2_cuda_ipc_msgs::msg::BufferCore make_cached_buffer_core_message(
 inline void seed_cache_for_message(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg, uintptr_t ptr_seed) {
   backend::ImportedMemory imported;
-  imported.dev_ptr = reinterpret_cast<void*>(ptr_seed);
-  imported.event = reinterpret_cast<cudaEvent_t>(ptr_seed + 1U);
+  imported.dev_ptr = static_cast<CUdeviceptr>(ptr_seed);
+  imported.event = reinterpret_cast<CUevent>(ptr_seed + 1U);
   subscriber::IpcHandleCache::instance().insert_or_discard_duplicate(
       make_key(msg), imported);
 }


### PR DESCRIPTION
### Motivation
- Move imported-memory internal representation to CUDA Driver API types to allow direct use of driver IPC primitives and unify cleanup semantics.
- Reconstruct opaque IPC handle bytes from `BufferCore` messages and import them with the CUDA Driver IPC APIs to avoid mixing Runtime and Driver IPC calls.

### Description
- Change `ImportedMemory` to store `CUdeviceptr dev_ptr` and `CUevent event` instead of `void*`/`cudaEvent_t`, and update importer interface to accept only the message and logger.
- Update CUDA IPC importer to reconstruct `CUipcMemHandle`/`CUipcEventHandle` from message bytes, call `cuIpcOpenEventHandle` and `cuIpcOpenMemHandle(..., CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS)`, and destroy the created `CUevent` with `cuEventDestroy` on memory-import failure.
- Update VMM-FD importer to open events with `cuIpcOpenEventHandle`, add `rollback_vmm_import` to destroy event and undo VMM mapping/allocation on any failure, and use `rollback_vmm_import` on all error paths.
- Replace cleanup in `release_imported_memory` to use Driver API `cuEventDestroy` and `cuIpcCloseMemHandle`, explicitly order VMM unmap/address-free/release before freeing IPC event/memory, and keep the function `noexcept` while safely ignoring `CUresult` return values.
- Convert back to Runtime API types at the BufferView boundary using `reinterpret_cast` and update tests/helpers to use `CUdeviceptr`/`CUevent` seeds; add `static_assert`s to validate message payload sizes match expected driver handle sizes; use `detail::cu_result_to_string` for driver error logging.

### Testing
- Ran `git diff --check` and code formatting (`clang-format` / pre-commit) which passed with no check failures.
- Attempted to configure the package with CMake (`cmake -S ros2_cuda_ipc_core -B /tmp/ros2_cuda_ipc_core_build -DBUILD_TESTING=OFF`) but configure failed because `ament_cmake` is not available in this environment, so no build/test binary verification was performed.
- No unit tests were executed because the project could not be configured in this environment due to the missing ROS 2 build tooling dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5fdd42296c83288b8fb63f6ed62285)