### PR TITLE
Add scoped CUDA primary context guard

### DIFF
--- a/ros2_cuda_ipc_core/CMakeLists.txt
+++ b/ros2_cuda_ipc_core/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 
 add_library(${PROJECT_NAME}
   src/detail/cuda_util.cpp
+  src/detail/cuda_context.cpp
   src/publisher/gpu_buffer_manager.cpp
   src/publisher/gpu_buffer_pool.cpp
   src/backend/memory_importer.cpp

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
@@ -21,6 +21,9 @@ struct ImportedMemory {
   CUdeviceptr vmm_address = 0;
   CUmemGenericAllocationHandle vmm_allocation = 0;
   std::size_t allocation_size = 0;
+  // Identity needed to restore the import context during cleanup.
+  CUdevice device = -1;
+  CUcontext context = nullptr;
 };
 
 class MemoryImporter {

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/detail/cuda_context.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/detail/cuda_context.hpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cuda.h>
+
+namespace ros2_cuda_ipc_core::detail {
+
+/// Temporarily makes a device's shared primary context current.
+///
+/// Primary contexts retained by this utility intentionally live until process
+/// exit.  In particular, this class never resets, destroys, or releases a
+/// primary context because it may be shared with CUDA Runtime or PyTorch.
+class CudaContextGuard {
+ public:
+  CudaContextGuard() = default;
+  CudaContextGuard(const CudaContextGuard&) = delete;
+  CudaContextGuard& operator=(const CudaContextGuard&) = delete;
+  CudaContextGuard(CudaContextGuard&& other) noexcept;
+  CudaContextGuard& operator=(CudaContextGuard&& other) noexcept;
+  ~CudaContextGuard();
+
+  /// Retains (once per device) and pushes the device primary context.
+  static CudaContextGuard for_device(int device_id, CUresult* status) noexcept;
+
+  /// Pushes an already retained context.  Used for resource cleanup.
+  static CudaContextGuard for_context(CUcontext context,
+                                      CUresult* status) noexcept;
+
+  explicit operator bool() const noexcept { return pushed_; }
+  CUcontext context() const noexcept { return context_; }
+
+ private:
+  explicit CudaContextGuard(CUcontext context) noexcept : context_(context) {}
+  void reset() noexcept;
+
+  CUcontext context_ = nullptr;
+  bool pushed_ = false;
+};
+
+}  // namespace ros2_cuda_ipc_core::detail

--- a/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_importer.cpp
@@ -6,6 +6,8 @@
 #include <cstring>
 
 #include "rclcpp/logging.hpp"
+#include "ros2_cuda_ipc_core/detail/cuda_context.hpp"
+#include "ros2_cuda_ipc_core/detail/cuda_util.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 
 namespace ros2_cuda_ipc_core::backend::cuda_ipc {
@@ -26,6 +28,17 @@ std::optional<ImportedMemory> MemoryImporter::import(
     const cudaIpcEventHandle_t& event_handle,
     const rclcpp::Logger& logger) const {
   ImportedMemory imported;
+  CUresult context_result = CUDA_SUCCESS;
+  auto context = detail::CudaContextGuard::for_device(
+      static_cast<int>(msg.device_id), &context_result);
+  if (!context) {
+    RCLCPP_WARN(logger, "Unable to make device %u context current: %s",
+                msg.device_id,
+                detail::cu_result_to_string(context_result).c_str());
+    return std::nullopt;
+  }
+  imported.device = static_cast<CUdevice>(msg.device_id);
+  imported.context = context.context();
 
   auto err = cudaIpcOpenEventHandle(&imported.event, event_handle);
   if (err != cudaSuccess) {

--- a/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
@@ -5,11 +5,18 @@
 
 #include "ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp"
 #include "ros2_cuda_ipc_core/backend/vmm_fd/memory_importer.hpp"
+#include "ros2_cuda_ipc_core/detail/cuda_context.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 
 namespace ros2_cuda_ipc_core::backend {
 
 void release_imported_memory(const ImportedMemory& imported) noexcept {
+  CUresult context_result = CUDA_SUCCESS;
+  auto context =
+      detail::CudaContextGuard::for_context(imported.context, &context_result);
+  if (!context) {
+    return;
+  }
   if (imported.vmm_address != 0 && imported.allocation_size != 0) {
     cuMemUnmap(imported.vmm_address, imported.allocation_size);
     cuMemAddressFree(imported.vmm_address, imported.allocation_size);

--- a/ros2_cuda_ipc_core/src/backend/vmm_fd/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/vmm_fd/memory_importer.cpp
@@ -10,12 +10,12 @@
 
 #include <cerrno>
 #include <cstring>
-#include <mutex>
 #include <optional>
 #include <string>
 
 #include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/backend/vmm_fd/payload.hpp"
+#include "ros2_cuda_ipc_core/detail/cuda_context.hpp"
 #include "ros2_cuda_ipc_core/detail/cuda_util.hpp"
 #include "ros2_cuda_ipc_core/detail/posix_error.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
@@ -33,19 +33,6 @@ std::size_t align_up_size(std::size_t value, std::size_t alignment) {
     return value;
   }
   return value + alignment - remainder;
-}
-
-bool ensure_cuda_driver_initialised(const rclcpp::Logger& logger) {
-  static std::once_flag once;
-  static CUresult init_status = CUDA_SUCCESS;
-  std::call_once(once, []() { init_status = cuInit(0); });
-  if (init_status != CUDA_SUCCESS) {
-    RCLCPP_ERROR(
-        logger, "cuInit failed: %s",
-        ros2_cuda_ipc_core::detail::cu_result_to_string(init_status).c_str());
-    return false;
-  }
-  return true;
 }
 
 std::optional<std::string> parse_vmm_payload(
@@ -149,12 +136,20 @@ std::optional<ImportedMemory> MemoryImporter::import(
     return std::nullopt;
   }
 
-  if (!ensure_cuda_driver_initialised(logger)) {
+  CUresult context_result = CUDA_SUCCESS;
+  auto context = detail::CudaContextGuard::for_device(
+      static_cast<int>(msg.device_id), &context_result);
+  if (!context) {
+    RCLCPP_ERROR(logger, "Unable to make device %u context current: %s",
+                 msg.device_id,
+                 detail::cu_result_to_string(context_result).c_str());
     ::close(fd_opt.value());
     return std::nullopt;
   }
 
   ImportedMemory imported;
+  imported.device = static_cast<CUdevice>(msg.device_id);
+  imported.context = context.context();
 
   void* os_handle =
       reinterpret_cast<void*>(static_cast<intptr_t>(fd_opt.value()));

--- a/ros2_cuda_ipc_core/src/detail/cuda_context.cpp
+++ b/ros2_cuda_ipc_core/src/detail/cuda_context.cpp
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#include "ros2_cuda_ipc_core/detail/cuda_context.hpp"
+
+#include <map>
+#include <mutex>
+
+namespace ros2_cuda_ipc_core::detail {
+namespace {
+
+std::once_flag init_once;
+CUresult init_status = CUDA_SUCCESS;
+std::mutex contexts_mutex;
+std::map<int, CUcontext> contexts;
+
+CUresult primary_context_for_device(int device_id, CUcontext* context) {
+  std::call_once(init_once, [] { init_status = cuInit(0); });
+  if (init_status != CUDA_SUCCESS) {
+    return init_status;
+  }
+
+  std::lock_guard<std::mutex> lock(contexts_mutex);
+  const auto existing = contexts.find(device_id);
+  if (existing != contexts.end()) {
+    *context = existing->second;
+    return CUDA_SUCCESS;
+  }
+
+  CUdevice device;
+  CUresult result = cuDeviceGet(&device, device_id);
+  if (result != CUDA_SUCCESS) {
+    return result;
+  }
+  result = cuDevicePrimaryCtxRetain(context, device);
+  if (result == CUDA_SUCCESS) {
+    contexts.emplace(device_id, *context);
+  }
+  return result;
+}
+
+}  // namespace
+
+CudaContextGuard::CudaContextGuard(CudaContextGuard&& other) noexcept
+    : context_(other.context_), pushed_(other.pushed_) {
+  other.context_ = nullptr;
+  other.pushed_ = false;
+}
+
+CudaContextGuard& CudaContextGuard::operator=(
+    CudaContextGuard&& other) noexcept {
+  if (this != &other) {
+    reset();
+    context_ = other.context_;
+    pushed_ = other.pushed_;
+    other.context_ = nullptr;
+    other.pushed_ = false;
+  }
+  return *this;
+}
+
+CudaContextGuard::~CudaContextGuard() { reset(); }
+
+CudaContextGuard CudaContextGuard::for_device(int device_id,
+                                              CUresult* status) noexcept {
+  CUcontext context = nullptr;
+  CUresult result = primary_context_for_device(device_id, &context);
+  if (result != CUDA_SUCCESS) {
+    *status = result;
+    return {};
+  }
+  return for_context(context, status);
+}
+
+CudaContextGuard CudaContextGuard::for_context(CUcontext context,
+                                               CUresult* status) noexcept {
+  CudaContextGuard guard(context);
+  if (context == nullptr) {
+    *status = CUDA_ERROR_INVALID_CONTEXT;
+    return guard;
+  }
+  *status = cuCtxPushCurrent(context);
+  guard.pushed_ = *status == CUDA_SUCCESS;
+  return guard;
+}
+
+void CudaContextGuard::reset() noexcept {
+  if (pushed_) {
+    CUcontext popped = nullptr;
+    (void)cuCtxPopCurrent(&popped);
+    pushed_ = false;
+  }
+}
+
+}  // namespace ros2_cuda_ipc_core::detail

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp
@@ -6,6 +6,8 @@
 #include <algorithm>
 #include <cstring>
 
+#include "ros2_cuda_ipc_core/detail/cuda_context.hpp"
+
 namespace ros2_cuda_ipc_core::subscriber {
 
 BufferView::~BufferView() { reset(); }
@@ -76,6 +78,12 @@ cudaError_t BufferView::enqueue_ready_event(
     cudaStream_t stream) const noexcept {
   if (!ready_evt) {
     return cudaSuccess;
+  }
+  CUresult context_result = CUDA_SUCCESS;
+  auto context =
+      detail::CudaContextGuard::for_device(device_id, &context_result);
+  if (!context) {
+    return cudaErrorUnknown;
   }
   return cudaStreamWaitEvent(stream, ready_evt, 0);
 }


### PR DESCRIPTION
### Motivation
- Ensure Driver API operations (CUDA IPC and VMM FD imports, VMM map/unmap/release, IPC close, and event destroy/wait) run with the correct device primary context and restore nested current contexts safely.
- Persist import context identity so cleanup can be executed under the same device/context that performed the import.
- Avoid resetting/destroying/releasing shared primary contexts (which may be owned by CUDA Runtime or other frameworks such as PyTorch).

### Description
- Add a new RAII utility `detail::CudaContextGuard` in `include/ros2_cuda_ipc_core/detail/cuda_context.hpp` and `src/detail/cuda_context.cpp` that calls `cuInit(0)` once, retains each device primary context once with `cuDevicePrimaryCtxRetain`, and uses `cuCtxPushCurrent`/`cuCtxPopCurrent` to manage nested current contexts without releasing/destroying primary contexts.
- Extend `backend::ImportedMemory` in `include/.../backend/memory_importer.hpp` to store `CUdevice device` and `CUcontext context` for cleanup identity.
- Guard CUDA IPC import in `src/backend/cuda_ipc/memory_importer.cpp` by pushing the device primary context (selected from `msg.device_id`) and store the context/device into `ImportedMemory`.
- Guard VMM FD import in `src/backend/vmm_fd/memory_importer.cpp` similarly and persist context/device before performing `cuMemImportFromShareableHandle`, `cuMemMap`, `cuMemSetAccess`, etc.
- Make `release_imported_memory` in `src/backend/memory_importer.cpp` restore the import context (via `CudaContextGuard::for_context`) before performing VMM unmap/release, CUDA IPC close, and event destroy.
- Make subscriber event waits use the matching device context by pushing the device primary context in `src/subscriber/buffer_view.cpp::enqueue_ready_event`.
- Add the new source file to the library in `CMakeLists.txt`.

### Testing
- Ran `git diff --check` to validate diffs with no whitespace errors and it passed.
- Pre-commit `clang-format` hook ran during commit and passed.
- Attempted to configure the package with `cmake -S ros2_cuda_ipc_core -B /tmp/ros2_cuda_ipc_core_build -DBUILD_TESTING=ON`, but configuration failed because `ament_cmake` is not available in the environment, so full build/tests could not be run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5fdd639b408328a657c6f17acfd80c)