### PR TITLE
Release cached IPC handles safely

### DIFF
--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view.hpp
@@ -11,6 +11,7 @@
 
 #include "ros2_cuda_ipc_core/lease/lease_handle.hpp"
 #include "ros2_cuda_ipc_core/publisher_instance_id.hpp"
+#include "ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 
 namespace ros2_cuda_ipc_core::subscriber {
@@ -25,6 +26,8 @@ struct BufferView {
   std::string shm_name;
   PublisherInstanceId publisher_instance_id{};
   std::shared_ptr<lease::LeaseHandle> lease;
+  // Shares imported IPC/VMM memory lifetime with IpcHandleCache.
+  IpcHandleCache::ImportedMemoryResource imported_memory;
 
   BufferView() = default;
   ~BufferView();

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp
@@ -9,6 +9,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <unordered_map>
@@ -38,23 +39,32 @@ struct IpcHandleKeyHash {
 class IpcHandleCache {
  public:
   using ReleaseFn = std::function<void(const backend::ImportedMemory&)>;
+  // Cache entries and BufferViews share this object.  Releasing a cache entry
+  // therefore cannot close an IPC handle while a view still references it.
+  using ImportedMemoryResource = std::shared_ptr<const backend::ImportedMemory>;
 
   explicit IpcHandleCache(
       ReleaseFn release_fn = backend::release_imported_memory);
 
   static IpcHandleCache& instance();
 
-  std::optional<backend::ImportedMemory> find(const IpcHandleKey& key) const;
+  ~IpcHandleCache();
 
-  backend::ImportedMemory insert_or_discard_duplicate(
+  std::optional<ImportedMemoryResource> find(const IpcHandleKey& key) const;
+
+  ImportedMemoryResource insert_or_discard_duplicate(
       const IpcHandleKey& key, backend::ImportedMemory imported);
+
+  // Removes cached ownership. Resources retained by BufferViews are released
+  // only after their leases have been released.
+  void clear();
 
   std::size_t size() const;
 
  private:
   ReleaseFn release_fn_;
   mutable std::mutex mutex_;
-  std::unordered_map<IpcHandleKey, backend::ImportedMemory, IpcHandleKeyHash>
+  std::unordered_map<IpcHandleKey, ImportedMemoryResource, IpcHandleKeyHash>
       cache_;
 };
 

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp
@@ -28,6 +28,7 @@ BufferView& BufferView::operator=(const BufferView& other) {
   shm_name = other.shm_name;
   publisher_instance_id = other.publisher_instance_id;
   lease = other.lease;
+  imported_memory = other.imported_memory;
   mem_payload_ = other.mem_payload_;
   event_handle_ = other.event_handle_;
   backend_ = other.backend_;
@@ -56,6 +57,7 @@ BufferView& BufferView::operator=(BufferView&& other) noexcept {
   shm_name = std::move(other.shm_name);
   publisher_instance_id = other.publisher_instance_id;
   lease = std::move(other.lease);
+  imported_memory = std::move(other.imported_memory);
   mem_payload_ = other.mem_payload_;
   event_handle_ = other.event_handle_;
   backend_ = other.backend_;
@@ -90,7 +92,10 @@ void BufferView::reset() noexcept {
   publisher_instance_id = {};
   handles_ready_ = false;
   backend_ = transport::MemoryBackendKind::CUDA_IPC;
+  // The publisher observes the lease release before an imported IPC/VMM
+  // resource can be closed.
   lease.reset();
+  imported_memory.reset();
 }
 
 void BufferView::set_ipc_handles(transport::MemoryBackendKind backend,

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
@@ -116,7 +116,7 @@ BufferView BufferViewMapper::map(
   key.mem = msg.mem_handle;
   std::memcpy(key.event.data(), &event_handle, sizeof(event_handle));
 
-  backend::ImportedMemory imported;
+  IpcHandleCache::ImportedMemoryResource imported;
   auto cached = IpcHandleCache::instance().find(key);
   if (cached.has_value()) {
     imported = *cached;
@@ -132,8 +132,8 @@ BufferView BufferViewMapper::map(
   }
 
   BufferView view;
-  view.dev_ptr = imported.dev_ptr;
-  view.ready_evt = imported.event;
+  view.dev_ptr = imported->dev_ptr;
+  view.ready_evt = imported->event;
   view.device_id = static_cast<int>(msg.device_id);
   view.byte_size = msg.byte_size;
   view.slot_id = msg.slot_id;
@@ -141,6 +141,7 @@ BufferView BufferViewMapper::map(
   view.shm_name = msg.shm_name;
   view.publisher_instance_id = instance_id;
   view.lease = std::move(lease_ptr);
+  view.imported_memory = std::move(imported);
   view.set_ipc_handles(
       transport::backend_from_byte(static_cast<uint8_t>(msg.backend)),
       msg.mem_handle.data(), msg.mem_handle.size(), event_handle);

--- a/ros2_cuda_ipc_core/src/subscriber/ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/ipc_handle_cache.cpp
@@ -24,12 +24,14 @@ std::size_t IpcHandleKeyHash::operator()(
 IpcHandleCache::IpcHandleCache(ReleaseFn release_fn)
     : release_fn_(std::move(release_fn)) {}
 
+IpcHandleCache::~IpcHandleCache() { clear(); }
+
 IpcHandleCache& IpcHandleCache::instance() {
   static IpcHandleCache cache;
   return cache;
 }
 
-std::optional<backend::ImportedMemory> IpcHandleCache::find(
+std::optional<IpcHandleCache::ImportedMemoryResource> IpcHandleCache::find(
     const IpcHandleKey& key) const {
   std::lock_guard<std::mutex> lock(mutex_);
   auto it = cache_.find(key);
@@ -39,15 +41,41 @@ std::optional<backend::ImportedMemory> IpcHandleCache::find(
   return it->second;
 }
 
-backend::ImportedMemory IpcHandleCache::insert_or_discard_duplicate(
-    const IpcHandleKey& key, backend::ImportedMemory imported) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  auto [it, inserted] = cache_.emplace(key, imported);
-  if (!inserted) {
-    release_fn_(imported);
-    return it->second;
+IpcHandleCache::ImportedMemoryResource
+IpcHandleCache::insert_or_discard_duplicate(const IpcHandleKey& key,
+                                            backend::ImportedMemory imported) {
+  ImportedMemoryResource existing;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = cache_.find(key);
+    if (it != cache_.end()) {
+      existing = it->second;
+    } else {
+      auto resource = ImportedMemoryResource(
+          new backend::ImportedMemory(std::move(imported)),
+          [release_fn = release_fn_](const backend::ImportedMemory* memory) {
+            release_fn(*memory);
+            delete memory;
+          });
+      cache_.emplace(key, resource);
+      return resource;
+    }
   }
-  return imported;
+
+  // A duplicate is never shared with a view, so it can be released promptly.
+  // This is intentionally outside mutex_ because the callback may enter cache.
+  release_fn_(imported);
+  return existing;
+}
+
+void IpcHandleCache::clear() {
+  decltype(cache_) entries;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    entries.swap(cache_);
+  }
+  // Resource deleters may invoke CUDA/Driver API calls, so destroy entries only
+  // after releasing mutex_. Views can retain resources past this point.
 }
 
 std::size_t IpcHandleCache::size() const {

--- a/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
@@ -5,6 +5,7 @@
 
 #include <atomic>
 
+#include "ros2_cuda_ipc_core/subscriber/buffer_view.hpp"
 #include "ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp"
 #include "test_instance_id.hpp"
 
@@ -56,33 +57,110 @@ TEST(IpcHandleCacheTest, DuplicateInsertReturnsExistingEntry) {
   auto inserted = cache.insert_or_discard_duplicate(key, first);
   auto second = cache.insert_or_discard_duplicate(key, duplicate);
 
-  EXPECT_EQ(inserted.dev_ptr, first.dev_ptr);
-  EXPECT_EQ(second.dev_ptr, first.dev_ptr);
-  EXPECT_EQ(second.event, first.event);
+  EXPECT_EQ(inserted->dev_ptr, first.dev_ptr);
+  EXPECT_EQ(second->dev_ptr, first.dev_ptr);
+  EXPECT_EQ(second->event, first.event);
   EXPECT_EQ(cache.size(), 1u);
 }
 
-TEST(IpcHandleCacheTest, DuplicateInsertInvokesReleaseHook) {
+TEST(IpcHandleCacheTest, DuplicateInsertInvokesReleaseHookOnce) {
+  std::atomic<int> released{0};
+  {
+    subscriber::IpcHandleCache cache(
+        [&released](const backend::ImportedMemory&) { released.fetch_add(1); });
+    subscriber::IpcHandleKey key{};
+    key.backend = 1;
+    key.mem[0] = 17;
+    key.event[0] = 19;
+
+    backend::ImportedMemory first;
+    first.dev_ptr = reinterpret_cast<void*>(0x5050);
+    backend::ImportedMemory duplicate;
+    duplicate.dev_ptr = reinterpret_cast<void*>(0x7070);
+
+    auto resource = cache.insert_or_discard_duplicate(key, first);
+    cache.insert_or_discard_duplicate(key, duplicate);
+    EXPECT_EQ(released.load(), 1);
+    resource.reset();
+  }
+  EXPECT_EQ(released.load(), 2);
+}
+
+TEST(IpcHandleCacheTest, ClearReleasesUnreferencedEntriesExactlyOnce) {
   std::atomic<int> released{0};
   subscriber::IpcHandleCache cache(
       [&released](const backend::ImportedMemory&) { released.fetch_add(1); });
   subscriber::IpcHandleKey key{};
-  key.backend = 1;
-  key.mem[0] = 17;
-  key.event[0] = 19;
+  key.mem[0] = 1;
 
-  backend::ImportedMemory first;
-  first.dev_ptr = reinterpret_cast<void*>(0x5050);
-  first.event = reinterpret_cast<cudaEvent_t>(0x6060);
+  cache.insert_or_discard_duplicate(key, {});
+  cache.clear();
 
-  backend::ImportedMemory duplicate;
-  duplicate.dev_ptr = reinterpret_cast<void*>(0x7070);
-  duplicate.event = reinterpret_cast<cudaEvent_t>(0x8080);
-
-  cache.insert_or_discard_duplicate(key, first);
-  cache.insert_or_discard_duplicate(key, duplicate);
-
+  EXPECT_EQ(cache.size(), 0u);
   EXPECT_EQ(released.load(), 1);
+}
+
+TEST(IpcHandleCacheTest, DestructorReleasesEntriesExactlyOnce) {
+  std::atomic<int> released{0};
+  {
+    subscriber::IpcHandleCache cache(
+        [&released](const backend::ImportedMemory&) { released.fetch_add(1); });
+    subscriber::IpcHandleKey key{};
+    key.mem[0] = 2;
+    cache.insert_or_discard_duplicate(key, {});
+  }
+  EXPECT_EQ(released.load(), 1);
+}
+
+TEST(IpcHandleCacheTest, ClearDefersVmmResourceReleaseUntilViewReleasesIt) {
+  std::atomic<int> released{0};
+  subscriber::IpcHandleCache cache(
+      [&released](const backend::ImportedMemory& imported) {
+        EXPECT_EQ(imported.vmm_address, 0x1234u);
+        EXPECT_EQ(imported.vmm_allocation, 0x5678u);
+        released.fetch_add(1);
+      });
+  subscriber::IpcHandleKey key{};
+  key.backend = 2;
+  key.mem[0] = 3;
+
+  backend::ImportedMemory vmm;
+  vmm.vmm_address = 0x1234;
+  vmm.vmm_allocation = 0x5678;
+  subscriber::BufferView view;
+  view.imported_memory = cache.insert_or_discard_duplicate(key, vmm);
+
+  cache.clear();
+  EXPECT_EQ(released.load(), 0);
+  view.reset();
+  EXPECT_EQ(released.load(), 1);
+}
+
+TEST(IpcHandleCacheTest, ReleaseCallbacksCanReenterCache) {
+  std::atomic<int> released{0};
+  std::atomic<std::size_t> expected_size{0};
+  subscriber::IpcHandleCache* cache_ptr = nullptr;
+  subscriber::IpcHandleCache cache(
+      [&released, &expected_size, &cache_ptr](const backend::ImportedMemory&) {
+        EXPECT_EQ(cache_ptr->size(), expected_size.load());
+        released.fetch_add(1);
+      });
+  cache_ptr = &cache;
+  subscriber::IpcHandleKey key{};
+  key.mem[0] = 4;
+
+  cache.insert_or_discard_duplicate(key, {});
+  cache.clear();
+  EXPECT_EQ(released.load(), 1);
+
+  cache.insert_or_discard_duplicate(key, {});
+  expected_size.store(1);
+  cache.insert_or_discard_duplicate(key, {});
+  EXPECT_EQ(released.load(), 2);
+
+  expected_size.store(0);
+  cache.clear();
+  EXPECT_EQ(released.load(), 3);
 }
 
 }  // namespace ros2_cuda_ipc_core


### PR DESCRIPTION
### Motivation
- Prevent releasing imported IPC/VMM memory while a `BufferView` still references it and avoid calling CUDA/Driver cleanup while holding the cache mutex. 
- Make the ownership model explicit so cache entries and views can share resource lifetimes and preserve the protocol where leases are released before IPC/VMM resources are closed. 
- Provide deterministic cleanup paths for cache clear and destructor while keeping release callbacks safe to re-enter the cache. 

### Description
- Introduce a shared resource type `IpcHandleCache::ImportedMemoryResource` (`std::shared_ptr<const backend::ImportedMemory>`) and change the cache map to store these shared resources. (`ipc_handle_cache.hpp`, `ipc_handle_cache.cpp`).
- Add `IpcHandleCache::clear()` and a destructor that move-out cached entries while holding the mutex and perform resource destruction / release callbacks after the mutex is released, avoiding CUDA/Driver API calls under lock. (`ipc_handle_cache.hpp`, `ipc_handle_cache.cpp`).
- Change `insert_or_discard_duplicate()` to create a shared resource with a custom deleter that invokes the configured `release_fn_`, return an existing shared resource for duplicates, and call the immediate-release callback for duplicate imports outside the mutex. (`ipc_handle_cache.cpp`).
- Make `find()` return an optional `ImportedMemoryResource`, and update the `BufferView` and mapper to store and use the shared `imported_memory` so views retain resource ownership until `BufferView::reset()` releases it after releasing the lease. (`buffer_view.hpp`, `buffer_view.cpp`, `buffer_view_mapper.cpp`).
- Add and update unit tests in `test/test_ipc_handle_cache.cpp` to assert: duplicates invoke release hook exactly once, `clear()` and destructor release unreferenced entries exactly once, `clear()` defers VMM resource release while a view retains it, and release callbacks can re-enter the cache (including checking size expectations during reentrant calls). (`test/test_ipc_handle_cache.cpp`).

### Testing
- `git diff --check` succeeded to validate whitespace and simple issues. (`git diff --check`) — passed. 
- Pre-commit `clang-format` hook ran and passed as part of the commit, so formatting checks succeeded. (`git commit` triggered hook) — passed. 
- Attempted to run unit tests with `colcon test --packages-select ros2_cuda_ipc_core --event-handlers console_direct+`, but `colcon` is not available in the environment so tests were not executed here. (`colcon test`) — not run due to missing tool.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5fdd9f2490832883e4585a38e580b9)