### PR TITLE
Use CUDA Driver API for subscriber IPC imports

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -111,6 +111,22 @@ colcon test-result --verbose
 CUDA-dependent tests may skip when no CUDA device is available or when the
 platform does not support the selected CUDA memory sharing feature.
 
+### CUDA API and Runtime Interoperability
+
+Subscriber-side IPC imports use the CUDA **Driver API** (`CUipcMemHandle`,
+`CUipcEventHandle`, `cuIpcCloseMemHandle`, and `cuEventDestroy`).  Before an
+import or release, the subscriber makes the target device's primary context
+current with a guard that restores the calling thread's previous context.
+Consequently the core library does not link `libcudart`; the CTest suite checks
+its ELF dependencies with `ldd`.
+
+This is intentional for embedding in processes that already use the Runtime
+API, including PyTorch.  CUDA Runtime and Driver API objects on a device share
+the primary context. `BufferView::enqueue_ready_event(cudaStream_t)` accepts a
+Runtime-created or Runtime-obtained stream and submits `cuStreamWaitEvent` for
+the imported publisher event. The caller remains responsible for placing that
+wait before consuming the buffer.
+
 ## Profiling
 
 The fanout launch file can wrap each process with Nsight Systems:

--- a/doc/design.md
+++ b/doc/design.md
@@ -507,3 +507,21 @@ void on_message(const ros2_cuda_ipc_msgs::msg::GpuImage& message) {
    * ROS msg を受信 → Mapper が View を返す
    * `cudaStreamWaitEvent(my_stream, view.ready_evt, 0)`
    * カーネル呼び出しで view.dev_ptr を利用
+
+## Subscriber CUDA API policy
+
+Subscriber の import と解放は CUDA Driver API で実装する。具体的には
+`CUipcMemHandle` / `CUipcEventHandle` を message bytes から復元し、
+`cuIpcOpenMemHandle`、`cuIpcOpenEventHandle`、`cuIpcCloseMemHandle`、
+`cuEventDestroy` を使用する。失敗後に event または memory が部分的に open された場合は、
+その場で rollback する。
+
+各操作は device の primary context を current にする guard の中で行い、guard は呼出し元
+thread の current context を必ず復元する。このため Runtime API を使う PyTorch 等と同じ
+プロセスに置いても、Runtime と Driver は同一 primary context を共有できる。core library 自体は
+`libcudart` に link しない（CTest の `ldd` check で検証する）。
+
+公開 `BufferView::enqueue_ready_event(cudaStream_t)` は Runtime API で作成または取得した
+stream を受け取れる。実装はその stream を `CUstream` として Driver API の
+`cuStreamWaitEvent` に渡し、Publisher が IPC で export した ready event への wait を enqueue
+する。Runtime stream を使う側は、buffer の消費より前にこの API を呼ぶ。

--- a/ros2_cuda_ipc_core/CMakeLists.txt
+++ b/ros2_cuda_ipc_core/CMakeLists.txt
@@ -25,6 +25,7 @@ endif()
 
 add_library(${PROJECT_NAME}
   src/detail/cuda_util.cpp
+  src/detail/primary_context_guard.cpp
   src/publisher/gpu_buffer_manager.cpp
   src/publisher/gpu_buffer_pool.cpp
   src/backend/memory_importer.cpp
@@ -58,7 +59,6 @@ target_link_libraries(${PROJECT_NAME}
     ${ros2_cuda_ipc_msgs_TARGETS}
     ${sensor_msgs_TARGETS}
     ${std_msgs_TARGETS}
-    CUDA::cudart
     CUDA::cuda_driver
     ${UUID_LIB}
 )
@@ -97,6 +97,14 @@ if(BUILD_TESTING)
   target_link_libraries(test_gpu_buffer_pool ${PROJECT_NAME})
   ament_add_gtest(test_lease_manager test/test_lease_manager.cpp)
   target_link_libraries(test_lease_manager ${PROJECT_NAME})
+  ament_add_gtest(test_driver_ipc_interop test/test_driver_ipc_interop.cpp)
+  target_link_libraries(test_driver_ipc_interop ${PROJECT_NAME} CUDA::cudart CUDA::cuda_driver)
+  # Keep the core library usable beside applications which choose their own
+  # CUDA Runtime version (e.g. PyTorch): it must not acquire libcudart itself.
+  add_test(NAME test_core_has_no_cudart_dependency
+    COMMAND ${CMAKE_COMMAND}
+      -DLIBRARY=$<TARGET_FILE:${PROJECT_NAME}>
+      -P ${CMAKE_CURRENT_SOURCE_DIR}/test/check_no_cudart_dependency.cmake)
 endif()
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp
@@ -11,7 +11,7 @@ class MemoryImporter final : public backend::MemoryImporter {
  public:
   std::optional<ImportedMemory> import(
       const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-      const cudaIpcEventHandle_t& event_handle,
+      const CUipcEventHandle& event_handle,
       const rclcpp::Logger& logger) const override;
 };
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <cuda.h>
-#include <cuda_runtime_api.h>
 
 #include <cstddef>
 #include <optional>
@@ -17,7 +16,8 @@ namespace ros2_cuda_ipc_core::backend {
 
 struct ImportedMemory {
   void* dev_ptr = nullptr;
-  cudaEvent_t event = nullptr;
+  CUevent event = nullptr;
+  int device_id = 0;
   CUdeviceptr vmm_address = 0;
   CUmemGenericAllocationHandle vmm_allocation = 0;
   std::size_t allocation_size = 0;
@@ -29,7 +29,7 @@ class MemoryImporter {
 
   virtual std::optional<ImportedMemory> import(
       const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-      const cudaIpcEventHandle_t& event_handle,
+      const CUipcEventHandle& event_handle,
       const rclcpp::Logger& logger) const = 0;
 };
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/vmm_fd/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/vmm_fd/memory_importer.hpp
@@ -11,7 +11,7 @@ class MemoryImporter final : public backend::MemoryImporter {
  public:
   std::optional<ImportedMemory> import(
       const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-      const cudaIpcEventHandle_t& event_handle,
+      const CUipcEventHandle& event_handle,
       const rclcpp::Logger& logger) const override;
 };
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/detail/primary_context_guard.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/detail/primary_context_guard.hpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cuda.h>
+
+namespace ros2_cuda_ipc_core::detail {
+
+// Makes a device's primary context current and restores the caller's context
+// when it goes out of scope.  This is deliberately a Driver API utility: a
+// subscriber may be used in a process which already owns the primary context
+// through cudart (for example PyTorch).
+class PrimaryContextGuard {
+ public:
+  explicit PrimaryContextGuard(int device_id) noexcept;
+  ~PrimaryContextGuard();
+  PrimaryContextGuard(const PrimaryContextGuard&) = delete;
+  PrimaryContextGuard& operator=(const PrimaryContextGuard&) = delete;
+
+  bool ok() const noexcept { return result_ == CUDA_SUCCESS; }
+  CUresult result() const noexcept { return result_; }
+
+ private:
+  CUcontext previous_ = nullptr;
+  CUdevice device_ = 0;
+  bool retained_ = false;
+  CUresult result_ = CUDA_ERROR_NOT_INITIALIZED;
+};
+
+}  // namespace ros2_cuda_ipc_core::detail

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view.hpp
@@ -3,7 +3,8 @@
 
 #pragma once
 
-#include <cuda_runtime_api.h>
+#include <cuda.h>
+#include <cuda_runtime_api.h>  // cudaStream_t interoperability only
 
 #include <cstdint>
 #include <memory>
@@ -17,7 +18,7 @@ namespace ros2_cuda_ipc_core::subscriber {
 
 struct BufferView {
   void* dev_ptr = nullptr;
-  cudaEvent_t ready_evt = nullptr;
+  CUevent ready_evt = nullptr;
   int device_id = 0;
   uint64_t byte_size = 0;
   uint32_t slot_id = 0;
@@ -46,11 +47,11 @@ struct BufferView {
 
   void set_ipc_handles(transport::MemoryBackendKind backend,
                        const uint8_t* payload_bytes, std::size_t payload_size,
-                       const cudaIpcEventHandle_t& evt) noexcept;
+                       const CUipcEventHandle& evt) noexcept;
   const transport::MemoryHandlePayload& mem_payload() const noexcept {
     return mem_payload_;
   }
-  const cudaIpcEventHandle_t& event_handle() const noexcept {
+  const CUipcEventHandle& event_handle() const noexcept {
     return event_handle_;
   }
   transport::MemoryBackendKind backend() const noexcept { return backend_; }
@@ -58,7 +59,7 @@ struct BufferView {
 
  private:
   transport::MemoryHandlePayload mem_payload_{};
-  cudaIpcEventHandle_t event_handle_{};
+  CUipcEventHandle event_handle_{};
   transport::MemoryBackendKind backend_ =
       transport::MemoryBackendKind::CUDA_IPC;
   bool handles_ready_ = false;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <cuda_runtime_api.h>
+#include <cuda.h>
 
 #include <array>
 #include <cstddef>
@@ -23,7 +23,7 @@ struct IpcHandleKey {
   PublisherInstanceId publisher_instance_id{};
   uint8_t backend = 0;
   transport::MemoryHandlePayload mem{};
-  std::array<uint8_t, sizeof(cudaIpcEventHandle_t)> event{};
+  std::array<uint8_t, sizeof(CUipcEventHandle)> event{};
 
   bool operator==(const IpcHandleKey& other) const noexcept {
     return publisher_instance_id == other.publisher_instance_id &&

--- a/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_importer.cpp
@@ -6,15 +6,17 @@
 #include <cstring>
 
 #include "rclcpp/logging.hpp"
+#include "ros2_cuda_ipc_core/detail/cuda_util.hpp"
+#include "ros2_cuda_ipc_core/detail/primary_context_guard.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 
 namespace ros2_cuda_ipc_core::backend::cuda_ipc {
 
 namespace {
 
-cudaIpcMemHandle_t to_cuda_mem_handle(
+CUipcMemHandle to_cuda_mem_handle(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg) {
-  cudaIpcMemHandle_t handle{};
+  CUipcMemHandle handle{};
   std::memcpy(&handle, msg.mem_handle.data(), sizeof(handle));
   return handle;
 }
@@ -23,26 +25,34 @@ cudaIpcMemHandle_t to_cuda_mem_handle(
 
 std::optional<ImportedMemory> MemoryImporter::import(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-    const cudaIpcEventHandle_t& event_handle,
-    const rclcpp::Logger& logger) const {
+    const CUipcEventHandle& event_handle, const rclcpp::Logger& logger) const {
+  detail::PrimaryContextGuard context(static_cast<int>(msg.device_id));
+  if (!context.ok()) {
+    RCLCPP_WARN(logger, "Unable to make primary context current: %s",
+                detail::cu_result_to_string(context.result()).c_str());
+    return std::nullopt;
+  }
   ImportedMemory imported;
+  imported.device_id = static_cast<int>(msg.device_id);
 
-  auto err = cudaIpcOpenEventHandle(&imported.event, event_handle);
-  if (err != cudaSuccess) {
-    RCLCPP_WARN(logger, "cudaIpcOpenEventHandle failed: %s",
-                cudaGetErrorString(err));
+  auto err = cuIpcOpenEventHandle(&imported.event, event_handle);
+  if (err != CUDA_SUCCESS) {
+    RCLCPP_WARN(logger, "cuIpcOpenEventHandle failed: %s",
+                detail::cu_result_to_string(err).c_str());
     return std::nullopt;
   }
 
-  const cudaIpcMemHandle_t mem_handle = to_cuda_mem_handle(msg);
-  err = cudaIpcOpenMemHandle(&imported.dev_ptr, mem_handle,
-                             cudaIpcMemLazyEnablePeerAccess);
-  if (err != cudaSuccess) {
-    RCLCPP_WARN(logger, "cudaIpcOpenMemHandle failed: %s",
-                cudaGetErrorString(err));
-    cudaEventDestroy(imported.event);
+  const CUipcMemHandle mem_handle = to_cuda_mem_handle(msg);
+  CUdeviceptr ptr = 0;
+  err =
+      cuIpcOpenMemHandle(&ptr, mem_handle, CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS);
+  if (err != CUDA_SUCCESS) {
+    RCLCPP_WARN(logger, "cuIpcOpenMemHandle failed: %s",
+                detail::cu_result_to_string(err).c_str());
+    cuEventDestroy(imported.event);
     return std::nullopt;
   }
+  imported.dev_ptr = reinterpret_cast<void*>(ptr);
 
   return imported;
 }

--- a/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
@@ -5,11 +5,14 @@
 
 #include "ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp"
 #include "ros2_cuda_ipc_core/backend/vmm_fd/memory_importer.hpp"
+#include "ros2_cuda_ipc_core/detail/primary_context_guard.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 
 namespace ros2_cuda_ipc_core::backend {
 
 void release_imported_memory(const ImportedMemory& imported) noexcept {
+  detail::PrimaryContextGuard context(imported.device_id);
+  if (!context.ok()) return;
   if (imported.vmm_address != 0 && imported.allocation_size != 0) {
     cuMemUnmap(imported.vmm_address, imported.allocation_size);
     cuMemAddressFree(imported.vmm_address, imported.allocation_size);
@@ -18,10 +21,10 @@ void release_imported_memory(const ImportedMemory& imported) noexcept {
     cuMemRelease(imported.vmm_allocation);
   }
   if (imported.vmm_address == 0 && imported.dev_ptr != nullptr) {
-    cudaIpcCloseMemHandle(imported.dev_ptr);
+    cuIpcCloseMemHandle(reinterpret_cast<CUdeviceptr>(imported.dev_ptr));
   }
   if (imported.event != nullptr) {
-    cudaEventDestroy(imported.event);
+    cuEventDestroy(imported.event);
   }
 }
 

--- a/ros2_cuda_ipc_core/src/backend/vmm_fd/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/vmm_fd/memory_importer.cpp
@@ -18,6 +18,7 @@
 #include "ros2_cuda_ipc_core/backend/vmm_fd/payload.hpp"
 #include "ros2_cuda_ipc_core/detail/cuda_util.hpp"
 #include "ros2_cuda_ipc_core/detail/posix_error.hpp"
+#include "ros2_cuda_ipc_core/detail/primary_context_guard.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 
 namespace ros2_cuda_ipc_core::backend::vmm_fd {
@@ -130,8 +131,7 @@ std::optional<int> request_fd_from_publisher(const std::string& path,
 
 std::optional<ImportedMemory> MemoryImporter::import(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-    const cudaIpcEventHandle_t& event_handle,
-    const rclcpp::Logger& logger) const {
+    const CUipcEventHandle& event_handle, const rclcpp::Logger& logger) const {
   const auto meta = parse_vmm_payload(msg.mem_handle, logger);
   if (!meta.has_value()) {
     return std::nullopt;
@@ -154,7 +154,16 @@ std::optional<ImportedMemory> MemoryImporter::import(
     return std::nullopt;
   }
 
+  detail::PrimaryContextGuard context(static_cast<int>(msg.device_id));
+  if (!context.ok()) {
+    RCLCPP_WARN(logger, "Unable to make primary context current: %s",
+                detail::cu_result_to_string(context.result()).c_str());
+    ::close(fd_opt.value());
+    return std::nullopt;
+  }
+
   ImportedMemory imported;
+  imported.device_id = static_cast<int>(msg.device_id);
 
   void* os_handle =
       reinterpret_cast<void*>(static_cast<intptr_t>(fd_opt.value()));
@@ -227,10 +236,10 @@ std::optional<ImportedMemory> MemoryImporter::import(
     return std::nullopt;
   }
 
-  auto err = cudaIpcOpenEventHandle(&imported.event, event_handle);
-  if (err != cudaSuccess) {
-    RCLCPP_WARN(logger, "cudaIpcOpenEventHandle failed: %s",
-                cudaGetErrorString(err));
+  auto err = cuIpcOpenEventHandle(&imported.event, event_handle);
+  if (err != CUDA_SUCCESS) {
+    RCLCPP_WARN(logger, "cuIpcOpenEventHandle failed: %s",
+                ros2_cuda_ipc_core::detail::cu_result_to_string(err).c_str());
     cuMemUnmap(imported.vmm_address, imported.allocation_size);
     cuMemAddressFree(imported.vmm_address, imported.allocation_size);
     cuMemRelease(imported.vmm_allocation);

--- a/ros2_cuda_ipc_core/src/detail/primary_context_guard.cpp
+++ b/ros2_cuda_ipc_core/src/detail/primary_context_guard.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#include "ros2_cuda_ipc_core/detail/primary_context_guard.hpp"
+
+namespace ros2_cuda_ipc_core::detail {
+
+PrimaryContextGuard::PrimaryContextGuard(int device_id) noexcept {
+  result_ = cuInit(0);
+  if (result_ != CUDA_SUCCESS) return;
+  result_ = cuCtxGetCurrent(&previous_);
+  if (result_ != CUDA_SUCCESS) return;
+  result_ = cuDeviceGet(&device_, device_id);
+  if (result_ != CUDA_SUCCESS) return;
+  CUcontext primary = nullptr;
+  result_ = cuDevicePrimaryCtxRetain(&primary, device_);
+  if (result_ != CUDA_SUCCESS) return;
+  retained_ = true;
+  result_ = cuCtxSetCurrent(primary);
+}
+
+PrimaryContextGuard::~PrimaryContextGuard() {
+  if (!retained_) return;
+  cuCtxSetCurrent(previous_);
+  cuDevicePrimaryCtxRelease(device_);
+}
+
+}  // namespace ros2_cuda_ipc_core::detail

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp
@@ -77,7 +77,9 @@ cudaError_t BufferView::enqueue_ready_event(
   if (!ready_evt) {
     return cudaSuccess;
   }
-  return cudaStreamWaitEvent(stream, ready_evt, 0);
+  const CUresult result =
+      cuStreamWaitEvent(reinterpret_cast<CUstream>(stream), ready_evt, 0);
+  return result == CUDA_SUCCESS ? cudaSuccess : cudaErrorUnknown;
 }
 
 void BufferView::reset() noexcept {
@@ -96,7 +98,7 @@ void BufferView::reset() noexcept {
 void BufferView::set_ipc_handles(transport::MemoryBackendKind backend,
                                  const uint8_t* payload_bytes,
                                  std::size_t payload_size,
-                                 const cudaIpcEventHandle_t& evt) noexcept {
+                                 const CUipcEventHandle& evt) noexcept {
   backend_ = backend;
   std::memset(mem_payload_.data(), 0, mem_payload_.size());
   if (payload_bytes != nullptr && payload_size > 0) {

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
@@ -16,9 +16,9 @@ namespace ros2_cuda_ipc_core::subscriber {
 
 namespace {
 
-cudaIpcEventHandle_t to_cuda_event_handle(
+CUipcEventHandle to_cuda_event_handle(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg) {
-  cudaIpcEventHandle_t handle{};
+  CUipcEventHandle handle{};
   std::memcpy(&handle, msg.event_handle.data(), sizeof(handle));
   return handle;
 }
@@ -108,7 +108,7 @@ BufferView BufferViewMapper::map(
   }
 
   auto lease_ptr = std::make_shared<lease::LeaseHandle>(std::move(lease));
-  const cudaIpcEventHandle_t event_handle = to_cuda_event_handle(msg);
+  const CUipcEventHandle event_handle = to_cuda_event_handle(msg);
 
   IpcHandleKey key{};
   key.publisher_instance_id = instance_id;

--- a/ros2_cuda_ipc_core/src/transport/message_utils.cpp
+++ b/ros2_cuda_ipc_core/src/transport/message_utils.cpp
@@ -15,8 +15,8 @@ static_assert(sizeof(BufferCoreMessage::_mem_handle_type) ==
                   sizeof(MemoryHandlePayload),
               "BufferCore.mem_handle must match MemoryHandlePayload");
 static_assert(sizeof(BufferCoreMessage::_event_handle_type) ==
-                  sizeof(cudaIpcEventHandle_t),
-              "BufferCore.event_handle must match cudaIpcEventHandle_t");
+                  sizeof(CUipcEventHandle),
+              "BufferCore.event_handle must match CUipcEventHandle");
 
 }  // namespace
 

--- a/ros2_cuda_ipc_core/test/check_no_cudart_dependency.cmake
+++ b/ros2_cuda_ipc_core/test/check_no_cudart_dependency.cmake
@@ -1,0 +1,14 @@
+# Verify the ELF dependency list rather than relying on link-line inspection:
+# transitive dependencies are what matter to downstream Runtime API users.
+find_program(LDD_EXECUTABLE ldd)
+if(NOT LDD_EXECUTABLE)
+  message(FATAL_ERROR "ldd is required for the libcudart dependency check")
+endif()
+execute_process(COMMAND "${LDD_EXECUTABLE}" "${LIBRARY}"
+  RESULT_VARIABLE status OUTPUT_VARIABLE dependencies ERROR_VARIABLE errors)
+if(NOT status EQUAL 0)
+  message(FATAL_ERROR "ldd failed for ${LIBRARY}: ${errors}")
+endif()
+if(dependencies MATCHES "libcudart\\.so")
+  message(FATAL_ERROR "${LIBRARY} must not depend on libcudart:\n${dependencies}")
+endif()

--- a/ros2_cuda_ipc_core/test/test_driver_ipc_interop.cpp
+++ b/ros2_cuda_ipc_core/test/test_driver_ipc_interop.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+#include "ros2_cuda_ipc_core/detail/primary_context_guard.hpp"
+#include "ros2_cuda_ipc_core/subscriber/buffer_view.hpp"
+
+namespace ros2_cuda_ipc_core {
+namespace {
+
+class DriverIpcInteropTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    if (cuInit(0) != CUDA_SUCCESS) GTEST_SKIP() << "CUDA driver is unavailable";
+    int count = 0;
+    if (cuDeviceGetCount(&count) != CUDA_SUCCESS || count == 0)
+      GTEST_SKIP() << "No CUDA device is available";
+    if (cudaSetDevice(0) != cudaSuccess)
+      GTEST_SKIP() << "CUDA Runtime cannot select device 0";
+  }
+};
+
+TEST_F(DriverIpcInteropTest, PrimaryContextGuardRestoresCurrentContext) {
+  CUcontext before = nullptr;
+  ASSERT_EQ(cuCtxGetCurrent(&before), CUDA_SUCCESS);
+  {
+    detail::PrimaryContextGuard guard(0);
+    ASSERT_TRUE(guard.ok());
+  }
+  CUcontext after = nullptr;
+  ASSERT_EQ(cuCtxGetCurrent(&after), CUDA_SUCCESS);
+  EXPECT_EQ(after, before);
+}
+
+TEST_F(DriverIpcInteropTest, RuntimeAndDriverShareThePrimaryContext) {
+  // cudaFree(0) creates/attaches the Runtime API context without allocating.
+  ASSERT_EQ(cudaFree(nullptr), cudaSuccess);
+  CUcontext runtime_context = nullptr;
+  ASSERT_EQ(cuCtxGetCurrent(&runtime_context), CUDA_SUCCESS);
+  CUdevice device = 0;
+  ASSERT_EQ(cuDeviceGet(&device, 0), CUDA_SUCCESS);
+  CUcontext primary = nullptr;
+  ASSERT_EQ(cuDevicePrimaryCtxRetain(&primary, device), CUDA_SUCCESS);
+  EXPECT_EQ(runtime_context, primary);
+  EXPECT_EQ(cuDevicePrimaryCtxRelease(device), CUDA_SUCCESS);
+}
+
+TEST_F(DriverIpcInteropTest, DriverImportsAndClosesIpcHandles) {
+  void* allocation = nullptr;
+  ASSERT_EQ(cudaMalloc(&allocation, 64), cudaSuccess);
+  CUipcMemHandle memory_handle{};
+  cudaIpcMemHandle_t runtime_memory_handle{};
+  ASSERT_EQ(cudaIpcGetMemHandle(&runtime_memory_handle, allocation),
+            cudaSuccess);
+  std::memcpy(&memory_handle, &runtime_memory_handle, sizeof(memory_handle));
+  cudaEvent_t runtime_event = nullptr;
+  ASSERT_EQ(cudaEventCreateWithFlags(&runtime_event, cudaEventInterprocess),
+            cudaSuccess);
+  cudaIpcEventHandle_t runtime_event_handle{};
+  ASSERT_EQ(cudaIpcGetEventHandle(&runtime_event_handle, runtime_event),
+            cudaSuccess);
+  CUipcEventHandle event_handle{};
+  std::memcpy(&event_handle, &runtime_event_handle, sizeof(event_handle));
+
+  detail::PrimaryContextGuard context(0);
+  ASSERT_TRUE(context.ok());
+  CUevent imported_event = nullptr;
+  ASSERT_EQ(cuIpcOpenEventHandle(&imported_event, event_handle), CUDA_SUCCESS);
+  CUdeviceptr imported_memory = 0;
+  ASSERT_EQ(cuIpcOpenMemHandle(&imported_memory, memory_handle,
+                               CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS),
+            CUDA_SUCCESS);
+  EXPECT_EQ(cuIpcCloseMemHandle(imported_memory), CUDA_SUCCESS);
+  EXPECT_EQ(cuEventDestroy(imported_event), CUDA_SUCCESS);
+  ASSERT_EQ(cudaEventDestroy(runtime_event), cudaSuccess);
+  ASSERT_EQ(cudaFree(allocation), cudaSuccess);
+}
+
+TEST_F(DriverIpcInteropTest,
+       RuntimeStreamWaitsForDriverImportedPublisherEvent) {
+  cudaEvent_t publisher_event = nullptr;
+  ASSERT_EQ(cudaEventCreateWithFlags(&publisher_event, cudaEventInterprocess),
+            cudaSuccess);
+  ASSERT_EQ(cudaEventRecord(publisher_event, nullptr), cudaSuccess);
+  cudaIpcEventHandle_t runtime_handle{};
+  ASSERT_EQ(cudaIpcGetEventHandle(&runtime_handle, publisher_event),
+            cudaSuccess);
+  CUipcEventHandle handle{};
+  std::memcpy(&handle, &runtime_handle, sizeof(handle));
+  detail::PrimaryContextGuard context(0);
+  ASSERT_TRUE(context.ok());
+  CUevent imported = nullptr;
+  ASSERT_EQ(cuIpcOpenEventHandle(&imported, handle), CUDA_SUCCESS);
+  subscriber::BufferView view;
+  view.ready_evt = imported;
+  cudaStream_t stream = nullptr;
+  ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
+  EXPECT_EQ(view.enqueue_ready_event(stream), cudaSuccess);
+  EXPECT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
+  EXPECT_EQ(cuEventDestroy(imported), CUDA_SUCCESS);
+  EXPECT_EQ(cudaStreamDestroy(stream), cudaSuccess);
+  EXPECT_EQ(cudaEventDestroy(publisher_event), cudaSuccess);
+}
+
+}  // namespace
+}  // namespace ros2_cuda_ipc_core

--- a/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
@@ -47,11 +47,11 @@ TEST(IpcHandleCacheTest, DuplicateInsertReturnsExistingEntry) {
 
   backend::ImportedMemory first;
   first.dev_ptr = reinterpret_cast<void*>(0x1010);
-  first.event = reinterpret_cast<cudaEvent_t>(0x2020);
+  first.event = reinterpret_cast<CUevent>(0x2020);
 
   backend::ImportedMemory duplicate;
   duplicate.dev_ptr = reinterpret_cast<void*>(0x3030);
-  duplicate.event = reinterpret_cast<cudaEvent_t>(0x4040);
+  duplicate.event = reinterpret_cast<CUevent>(0x4040);
 
   auto inserted = cache.insert_or_discard_duplicate(key, first);
   auto second = cache.insert_or_discard_duplicate(key, duplicate);
@@ -73,11 +73,11 @@ TEST(IpcHandleCacheTest, DuplicateInsertInvokesReleaseHook) {
 
   backend::ImportedMemory first;
   first.dev_ptr = reinterpret_cast<void*>(0x5050);
-  first.event = reinterpret_cast<cudaEvent_t>(0x6060);
+  first.event = reinterpret_cast<CUevent>(0x6060);
 
   backend::ImportedMemory duplicate;
   duplicate.dev_ptr = reinterpret_cast<void*>(0x7070);
-  duplicate.event = reinterpret_cast<cudaEvent_t>(0x8080);
+  duplicate.event = reinterpret_cast<CUevent>(0x8080);
 
   cache.insert_or_discard_duplicate(key, first);
   cache.insert_or_discard_duplicate(key, duplicate);

--- a/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
+++ b/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
@@ -79,7 +79,7 @@ inline void seed_cache_for_message(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg, uintptr_t ptr_seed) {
   backend::ImportedMemory imported;
   imported.dev_ptr = reinterpret_cast<void*>(ptr_seed);
-  imported.event = reinterpret_cast<cudaEvent_t>(ptr_seed + 1U);
+  imported.event = reinterpret_cast<CUevent>(ptr_seed + 1U);
   subscriber::IpcHandleCache::instance().insert_or_discard_duplicate(
       make_key(msg), imported);
 }


### PR DESCRIPTION
### Motivation
- Ensure subscriber-side IPC import/release uses the CUDA Driver API so imports/releases can be performed without pulling in the CUDA Runtime and so the library can be embedded in Runtime-using processes (e.g. PyTorch). 
- Make imports/releases resilient by restoring the caller's current context (primary-context guard) and rolling back partial opens on failure. 
- Provide Runtime/Driver interop for synchronization so a Runtime-created `cudaStream_t` can wait on a Driver-imported IPC event.

### Description
- Replace Runtime IPC handle types/usages with Driver API types and calls for imports/releases: use `CUipcMemHandle`/`CUipcEventHandle`, `cuIpcOpenMemHandle`/`cuIpcOpenEventHandle`, `cuIpcCloseMemHandle`, and `cuEventDestroy` across the CUDA IPC and VMM-FD import code paths. 
- Add `detail::PrimaryContextGuard` RAII utility to make the device primary context current for the import/release and restore the caller's context on destruction, and use it around all import/release flows. 
- Change `BufferView` to store `CUevent` and `CUipcEventHandle` and make `enqueue_ready_event(cudaStream_t)` accept a Runtime `cudaStream_t` and call `cuStreamWaitEvent` by casting the stream to `CUstream` so Runtime streams can wait on Driver-imported events. 
- Update `release_imported_memory` to use Driver API closes/destroys under the primary-context guard and to track `device_id` for correct restoration. 
- Add integration unit tests `test_driver_ipc_interop` that skip when CUDA/driver/runtime are unavailable and verify primary-context restoration, Runtime/Driver primary-context sharing, Driver import/close lifecycle, and that a Runtime stream properly waits on a Driver-imported IPC event. 
- Remove `CUDA::cudart` from the core library link line and add a CTest `ldd`-based check `check_no_cudart_dependency.cmake` to assert the core shared library does not depend on `libcudart`. 
- Update `DEVELOPING.md` and `doc/design.md` to document the subscriber policy (Driver API imports, primary-context guard, Runtime-stream interop) and explain the rationale for not linking `libcudart` in the core library.

### Testing
- Added gtest `test_driver_ipc_interop` (skips when CUDA driver/runtime or device is unavailable) and CTest `test_core_has_no_cudart_dependency` to detect `libcudart` ELF dependencies; these tests are wired into `CMakeLists.txt`. 
- Ran repository checks: `git diff --check` and pre-commit `clang-format` hook (both succeeded) and committed the change. 
- Full build/test (`colcon`/CTest) was not executed in this environment because the ROS/CUDA build toolchain was not available, but the new tests are written to explicitly skip when CUDA/driver/device support is missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5fdda90d70832881854a9492753831)