### PR TITLE
Use CUDA Driver API for subscriber imports and isolate runtime libcudart to publisher target

### DIFF
--- a/ros2_cuda_ipc_core/CMakeLists.txt
+++ b/ros2_cuda_ipc_core/CMakeLists.txt
@@ -23,14 +23,10 @@ if(NOT UUID_LIB)
   message(FATAL_ERROR "Failed to find libuuid (uuid)")
 endif()
 
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED
   src/detail/cuda_util.cpp
-  src/publisher/gpu_buffer_manager.cpp
-  src/publisher/gpu_buffer_pool.cpp
   src/backend/memory_importer.cpp
-  src/backend/cuda_ipc/memory_backend.cpp
   src/backend/cuda_ipc/memory_importer.cpp
-  src/backend/vmm_fd/memory_backend.cpp
   src/backend/vmm_fd/memory_importer.cpp
   src/subscriber/buffer_view.cpp
   src/image/image_view.cpp
@@ -58,12 +54,28 @@ target_link_libraries(${PROJECT_NAME}
     ${ros2_cuda_ipc_msgs_TARGETS}
     ${sensor_msgs_TARGETS}
     ${std_msgs_TARGETS}
-    CUDA::cudart
+  PRIVATE
     CUDA::cuda_driver
     ${UUID_LIB}
 )
 
-install(TARGETS ${PROJECT_NAME}
+
+add_library(${PROJECT_NAME}_publisher SHARED
+  src/detail/cuda_runtime_util.cpp
+  src/publisher/gpu_buffer_manager.cpp
+  src/publisher/gpu_buffer_pool.cpp
+  src/backend/cuda_ipc/memory_backend.cpp
+  src/backend/vmm_fd/memory_backend.cpp
+)
+target_link_libraries(${PROJECT_NAME}_publisher
+  PUBLIC
+    ${PROJECT_NAME}
+  PRIVATE
+    CUDA::cudart
+    CUDA::cuda_driver
+)
+
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_publisher
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
@@ -92,11 +104,18 @@ if(BUILD_TESTING)
   target_link_libraries(test_publisher_messages ${PROJECT_NAME})
   ament_add_gtest(test_gpu_buffer_manager
                   test/test_gpu_buffer_manager.cpp)
-  target_link_libraries(test_gpu_buffer_manager ${PROJECT_NAME})
+  target_link_libraries(test_gpu_buffer_manager ${PROJECT_NAME}_publisher)
   ament_add_gtest(test_gpu_buffer_pool test/test_gpu_buffer_pool.cpp)
-  target_link_libraries(test_gpu_buffer_pool ${PROJECT_NAME})
+  target_link_libraries(test_gpu_buffer_pool ${PROJECT_NAME}_publisher)
   ament_add_gtest(test_lease_manager test/test_lease_manager.cpp)
   target_link_libraries(test_lease_manager ${PROJECT_NAME})
+
+  add_test(NAME check_core_cuda_dependencies
+    COMMAND ${CMAKE_COMMAND} -Dbinary=$<TARGET_FILE:${PROJECT_NAME}>
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/check_cuda_dependencies.cmake)
+  add_test(NAME check_subscriber_cuda_dependencies
+    COMMAND ${CMAKE_COMMAND} -Dbinary=$<TARGET_FILE:test_buffer_view_mapper>
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/check_cuda_dependencies.cmake)
 endif()
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)

--- a/ros2_cuda_ipc_core/cmake/check_cuda_dependencies.cmake
+++ b/ros2_cuda_ipc_core/cmake/check_cuda_dependencies.cmake
@@ -1,0 +1,19 @@
+if(NOT DEFINED binary)
+  message(FATAL_ERROR "binary must be set")
+endif()
+
+find_program(LDD_EXECUTABLE ldd REQUIRED)
+execute_process(
+  COMMAND "${LDD_EXECUTABLE}" "${binary}"
+  RESULT_VARIABLE result
+  OUTPUT_VARIABLE dependencies
+  ERROR_VARIABLE error)
+if(NOT result EQUAL 0)
+  message(FATAL_ERROR "Unable to inspect ${binary}: ${error}")
+endif()
+if(dependencies MATCHES "libcudart\\.so")
+  message(FATAL_ERROR "${binary} unexpectedly depends on libcudart.so:\n${dependencies}")
+endif()
+if(NOT dependencies MATCHES "libcuda\\.so")
+  message(FATAL_ERROR "${binary} must depend on libcuda.so:\n${dependencies}")
+endif()

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp
@@ -11,7 +11,7 @@ class MemoryImporter final : public backend::MemoryImporter {
  public:
   std::optional<ImportedMemory> import(
       const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-      const cudaIpcEventHandle_t& event_handle,
+      const CUipcEventHandle& event_handle,
       const rclcpp::Logger& logger) const override;
 };
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <cuda.h>
-#include <cuda_runtime_api.h>
 
 #include <cstddef>
 #include <optional>
@@ -17,7 +16,7 @@ namespace ros2_cuda_ipc_core::backend {
 
 struct ImportedMemory {
   void* dev_ptr = nullptr;
-  cudaEvent_t event = nullptr;
+  CUevent event = nullptr;
   CUdeviceptr vmm_address = 0;
   CUmemGenericAllocationHandle vmm_allocation = 0;
   std::size_t allocation_size = 0;
@@ -29,7 +28,7 @@ class MemoryImporter {
 
   virtual std::optional<ImportedMemory> import(
       const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-      const cudaIpcEventHandle_t& event_handle,
+      const CUipcEventHandle& event_handle,
       const rclcpp::Logger& logger) const = 0;
 };
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/vmm_fd/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/vmm_fd/memory_importer.hpp
@@ -11,7 +11,7 @@ class MemoryImporter final : public backend::MemoryImporter {
  public:
   std::optional<ImportedMemory> import(
       const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-      const cudaIpcEventHandle_t& event_handle,
+      const CUipcEventHandle& event_handle,
       const rclcpp::Logger& logger) const override;
 };
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/detail/cuda_runtime_util.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/detail/cuda_runtime_util.hpp
@@ -3,13 +3,12 @@
 
 #pragma once
 
-#include <cuda.h>
+#include <cuda_runtime_api.h>
 
 #include <string>
 
 namespace ros2_cuda_ipc_core::detail {
 
-/// Convert a CUDA Driver API result into "<name>: <message>".
-std::string cu_result_to_string(CUresult result);
+std::string cuda_error_to_string(cudaError_t error);
 
 }  // namespace ros2_cuda_ipc_core::detail

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/image/image_view.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/image/image_view.hpp
@@ -51,7 +51,7 @@ struct ImageView {
 
   uint32_t elem_size_bytes() const noexcept;
 
-  cudaError_t enqueue_ready_event(cudaStream_t stream) const noexcept {
+  CUresult enqueue_ready_event(CUstream stream) const noexcept {
     return core.enqueue_ready_event(stream);
   }
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/pointcloud2/pointcloud2_view.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/pointcloud2/pointcloud2_view.hpp
@@ -56,7 +56,7 @@ struct PointCloud2View {
   size_t num_points() const noexcept {
     return static_cast<size_t>(width) * height;
   }
-  cudaError_t enqueue_ready_event(cudaStream_t stream) const noexcept {
+  CUresult enqueue_ready_event(CUstream stream) const noexcept {
     return core.enqueue_ready_event(stream);
   }
   bool valid() const noexcept { return core.valid() && point_step > 0; }

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <cuda_runtime_api.h>
+#include <cuda.h>
 
 #include <cstdint>
 #include <memory>
@@ -17,7 +17,7 @@ namespace ros2_cuda_ipc_core::subscriber {
 
 struct BufferView {
   void* dev_ptr = nullptr;
-  cudaEvent_t ready_evt = nullptr;
+  CUevent ready_evt = nullptr;
   int device_id = 0;
   uint64_t byte_size = 0;
   uint32_t slot_id = 0;
@@ -40,17 +40,17 @@ struct BufferView {
 
   bool valid() const noexcept { return dev_ptr != nullptr; }
 
-  cudaError_t enqueue_ready_event(cudaStream_t stream) const noexcept;
+  CUresult enqueue_ready_event(CUstream stream) const noexcept;
 
   void reset() noexcept;
 
   void set_ipc_handles(transport::MemoryBackendKind backend,
                        const uint8_t* payload_bytes, std::size_t payload_size,
-                       const cudaIpcEventHandle_t& evt) noexcept;
+                       const CUipcEventHandle& evt) noexcept;
   const transport::MemoryHandlePayload& mem_payload() const noexcept {
     return mem_payload_;
   }
-  const cudaIpcEventHandle_t& event_handle() const noexcept {
+  const CUipcEventHandle& event_handle() const noexcept {
     return event_handle_;
   }
   transport::MemoryBackendKind backend() const noexcept { return backend_; }
@@ -58,7 +58,7 @@ struct BufferView {
 
  private:
   transport::MemoryHandlePayload mem_payload_{};
-  cudaIpcEventHandle_t event_handle_{};
+  CUipcEventHandle event_handle_{};
   transport::MemoryBackendKind backend_ =
       transport::MemoryBackendKind::CUDA_IPC;
   bool handles_ready_ = false;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include <cuda_runtime_api.h>
+#include <cuda.h>
 
 #include <array>
 #include <cstddef>
@@ -23,7 +23,7 @@ struct IpcHandleKey {
   PublisherInstanceId publisher_instance_id{};
   uint8_t backend = 0;
   transport::MemoryHandlePayload mem{};
-  std::array<uint8_t, sizeof(cudaIpcEventHandle_t)> event{};
+  std::array<uint8_t, sizeof(CUipcEventHandle)> event{};
 
   bool operator==(const IpcHandleKey& other) const noexcept {
     return publisher_instance_id == other.publisher_instance_id &&

--- a/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_backend.cpp
+++ b/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_backend.cpp
@@ -10,7 +10,7 @@
 #include <vector>
 
 #include "rclcpp/logging.hpp"
-#include "ros2_cuda_ipc_core/detail/cuda_util.hpp"
+#include "ros2_cuda_ipc_core/detail/cuda_runtime_util.hpp"
 #include "ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 

--- a/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_importer.cpp
@@ -6,15 +6,20 @@
 #include <cstring>
 
 #include "rclcpp/logging.hpp"
+#include "ros2_cuda_ipc_core/detail/cuda_util.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 
 namespace ros2_cuda_ipc_core::backend::cuda_ipc {
 
 namespace {
 
-cudaIpcMemHandle_t to_cuda_mem_handle(
+static_assert(sizeof(CUipcMemHandle) ==
+                  sizeof(ros2_cuda_ipc_msgs::msg::BufferCore::_mem_handle_type),
+              "BufferCore.mem_handle must match CUipcMemHandle");
+
+CUipcMemHandle to_cuda_mem_handle(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg) {
-  cudaIpcMemHandle_t handle{};
+  CUipcMemHandle handle{};
   std::memcpy(&handle, msg.mem_handle.data(), sizeof(handle));
   return handle;
 }
@@ -23,24 +28,25 @@ cudaIpcMemHandle_t to_cuda_mem_handle(
 
 std::optional<ImportedMemory> MemoryImporter::import(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-    const cudaIpcEventHandle_t& event_handle,
-    const rclcpp::Logger& logger) const {
+    const CUipcEventHandle& event_handle, const rclcpp::Logger& logger) const {
   ImportedMemory imported;
 
-  auto err = cudaIpcOpenEventHandle(&imported.event, event_handle);
-  if (err != cudaSuccess) {
-    RCLCPP_WARN(logger, "cudaIpcOpenEventHandle failed: %s",
-                cudaGetErrorString(err));
+  auto err = cuIpcOpenEventHandle(&imported.event, event_handle);
+  if (err != CUDA_SUCCESS) {
+    RCLCPP_WARN(logger, "cuIpcOpenEventHandle failed: %s",
+                ros2_cuda_ipc_core::detail::cu_result_to_string(err).c_str());
     return std::nullopt;
   }
 
-  const cudaIpcMemHandle_t mem_handle = to_cuda_mem_handle(msg);
-  err = cudaIpcOpenMemHandle(&imported.dev_ptr, mem_handle,
-                             cudaIpcMemLazyEnablePeerAccess);
-  if (err != cudaSuccess) {
-    RCLCPP_WARN(logger, "cudaIpcOpenMemHandle failed: %s",
-                cudaGetErrorString(err));
-    cudaEventDestroy(imported.event);
+  const CUipcMemHandle mem_handle = to_cuda_mem_handle(msg);
+  CUdeviceptr device_ptr = 0;
+  err = cuIpcOpenMemHandle(&device_ptr, mem_handle,
+                           CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS);
+  imported.dev_ptr = reinterpret_cast<void*>(device_ptr);
+  if (err != CUDA_SUCCESS) {
+    RCLCPP_WARN(logger, "cuIpcOpenMemHandle failed: %s",
+                ros2_cuda_ipc_core::detail::cu_result_to_string(err).c_str());
+    cuEventDestroy(imported.event);
     return std::nullopt;
   }
 

--- a/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
@@ -18,10 +18,10 @@ void release_imported_memory(const ImportedMemory& imported) noexcept {
     cuMemRelease(imported.vmm_allocation);
   }
   if (imported.vmm_address == 0 && imported.dev_ptr != nullptr) {
-    cudaIpcCloseMemHandle(imported.dev_ptr);
+    cuIpcCloseMemHandle(reinterpret_cast<CUdeviceptr>(imported.dev_ptr));
   }
   if (imported.event != nullptr) {
-    cudaEventDestroy(imported.event);
+    cuEventDestroy(imported.event);
   }
 }
 

--- a/ros2_cuda_ipc_core/src/backend/vmm_fd/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/vmm_fd/memory_importer.cpp
@@ -130,8 +130,7 @@ std::optional<int> request_fd_from_publisher(const std::string& path,
 
 std::optional<ImportedMemory> MemoryImporter::import(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-    const cudaIpcEventHandle_t& event_handle,
-    const rclcpp::Logger& logger) const {
+    const CUipcEventHandle& event_handle, const rclcpp::Logger& logger) const {
   const auto meta = parse_vmm_payload(msg.mem_handle, logger);
   if (!meta.has_value()) {
     return std::nullopt;
@@ -227,10 +226,10 @@ std::optional<ImportedMemory> MemoryImporter::import(
     return std::nullopt;
   }
 
-  auto err = cudaIpcOpenEventHandle(&imported.event, event_handle);
-  if (err != cudaSuccess) {
-    RCLCPP_WARN(logger, "cudaIpcOpenEventHandle failed: %s",
-                cudaGetErrorString(err));
+  auto err = cuIpcOpenEventHandle(&imported.event, event_handle);
+  if (err != CUDA_SUCCESS) {
+    RCLCPP_WARN(logger, "cuIpcOpenEventHandle failed: %s",
+                ros2_cuda_ipc_core::detail::cu_result_to_string(err).c_str());
     cuMemUnmap(imported.vmm_address, imported.allocation_size);
     cuMemAddressFree(imported.vmm_address, imported.allocation_size);
     cuMemRelease(imported.vmm_allocation);

--- a/ros2_cuda_ipc_core/src/detail/cuda_runtime_util.cpp
+++ b/ros2_cuda_ipc_core/src/detail/cuda_runtime_util.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#include "ros2_cuda_ipc_core/detail/cuda_runtime_util.hpp"
+
+namespace ros2_cuda_ipc_core::detail {
+
+std::string cuda_error_to_string(cudaError_t error) {
+  return std::string(cudaGetErrorName(error)) + ": " +
+         cudaGetErrorString(error);
+}
+
+}  // namespace ros2_cuda_ipc_core::detail

--- a/ros2_cuda_ipc_core/src/detail/cuda_util.cpp
+++ b/ros2_cuda_ipc_core/src/detail/cuda_util.cpp
@@ -5,10 +5,6 @@
 
 namespace ros2_cuda_ipc_core::detail {
 
-std::string cuda_error_to_string(cudaError_t err) {
-  return std::string(cudaGetErrorName(err)) + ": " + cudaGetErrorString(err);
-}
-
 std::string cu_result_to_string(CUresult result) {
   const char* name = nullptr;
   const char* desc = nullptr;

--- a/ros2_cuda_ipc_core/src/publisher/gpu_buffer_pool.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/gpu_buffer_pool.cpp
@@ -6,7 +6,7 @@
 #include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/backend/cuda_ipc/memory_backend.hpp"
 #include "ros2_cuda_ipc_core/backend/vmm_fd/memory_backend.hpp"
-#include "ros2_cuda_ipc_core/detail/cuda_util.hpp"
+#include "ros2_cuda_ipc_core/detail/cuda_runtime_util.hpp"
 
 namespace ros2_cuda_ipc_core::publisher {
 namespace {

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp
@@ -72,12 +72,11 @@ BufferView& BufferView::operator=(BufferView&& other) noexcept {
   return *this;
 }
 
-cudaError_t BufferView::enqueue_ready_event(
-    cudaStream_t stream) const noexcept {
+CUresult BufferView::enqueue_ready_event(CUstream stream) const noexcept {
   if (!ready_evt) {
-    return cudaSuccess;
+    return CUDA_SUCCESS;
   }
-  return cudaStreamWaitEvent(stream, ready_evt, 0);
+  return cuStreamWaitEvent(stream, ready_evt, 0);
 }
 
 void BufferView::reset() noexcept {
@@ -96,7 +95,7 @@ void BufferView::reset() noexcept {
 void BufferView::set_ipc_handles(transport::MemoryBackendKind backend,
                                  const uint8_t* payload_bytes,
                                  std::size_t payload_size,
-                                 const cudaIpcEventHandle_t& evt) noexcept {
+                                 const CUipcEventHandle& evt) noexcept {
   backend_ = backend;
   std::memset(mem_payload_.data(), 0, mem_payload_.size());
   if (payload_bytes != nullptr && payload_size > 0) {

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
@@ -16,9 +16,14 @@ namespace ros2_cuda_ipc_core::subscriber {
 
 namespace {
 
-cudaIpcEventHandle_t to_cuda_event_handle(
+static_assert(
+    sizeof(CUipcEventHandle) ==
+        sizeof(ros2_cuda_ipc_msgs::msg::BufferCore::_event_handle_type),
+    "BufferCore.event_handle must match CUipcEventHandle");
+
+CUipcEventHandle to_cuda_event_handle(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg) {
-  cudaIpcEventHandle_t handle{};
+  CUipcEventHandle handle{};
   std::memcpy(&handle, msg.event_handle.data(), sizeof(handle));
   return handle;
 }
@@ -108,7 +113,7 @@ BufferView BufferViewMapper::map(
   }
 
   auto lease_ptr = std::make_shared<lease::LeaseHandle>(std::move(lease));
-  const cudaIpcEventHandle_t event_handle = to_cuda_event_handle(msg);
+  const CUipcEventHandle event_handle = to_cuda_event_handle(msg);
 
   IpcHandleKey key{};
   key.publisher_instance_id = instance_id;

--- a/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
+++ b/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
@@ -79,7 +79,7 @@ inline void seed_cache_for_message(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg, uintptr_t ptr_seed) {
   backend::ImportedMemory imported;
   imported.dev_ptr = reinterpret_cast<void*>(ptr_seed);
-  imported.event = reinterpret_cast<cudaEvent_t>(ptr_seed + 1U);
+  imported.event = reinterpret_cast<CUevent>(ptr_seed + 1U);
   subscriber::IpcHandleCache::instance().insert_or_discard_duplicate(
       make_key(msg), imported);
 }


### PR DESCRIPTION
### Motivation
- Reduce public linkage on the core library so subscriber paths depend only on the CUDA Driver (`libcuda`) and not the Runtime (`libcudart`).
- Unify subscriber/VMM error handling on the Driver API (`CUresult`, `cuGetErrorString`), and keep Runtime API error formatting and runtime-only calls inside a publisher-only implementation.
- Add an automated check to ensure built core/subscriber binaries do not depend on `libcudart.so` and do require `libcuda.so`.

### Description
- Split the package into two shared libraries: `${PROJECT_NAME}` (core) and `${PROJECT_NAME}_publisher` (publisher-side runtime code), moving runtime-only sources into the publisher target and removing `CUDA::cudart` from the core target; the core now links privately to `CUDA::cuda_driver` only.
- Replace Runtime IPC/event types and calls in subscriber/importer paths with Driver API types and calls (`cudaIpcEventHandle_t` -> `CUipcEventHandle`, `cudaEvent_t` -> `CUevent`, `cudaStream_t` -> `CUstream`, `cudaError_t` -> `CUresult`, `cudaIpcOpenMemHandle` / `cudaIpcOpenEventHandle` -> `cuIpcOpenMemHandle` / `cuIpcOpenEventHandle`, `cudaEventDestroy` -> `cuEventDestroy`, `cudaIpcCloseMemHandle` -> `cuIpcCloseMemHandle`, etc.).
- Keep Runtime error-to-string utilities for publisher code by introducing `detail/cuda_runtime_util.hpp` + `cuda_runtime_util.cpp`, and consolidate Driver error formatting into `detail/cuda_util.hpp` (`cu_result_to_string`).
- Adjust interfaces and caches to use Driver API handle sizes and types and add `static_assert`s to validate message field sizes against Driver handle types.
- Add `cmake/check_cuda_dependencies.cmake` and CTest entries in `CMakeLists.txt` to run a dynamic dependency check (`ldd`/`ldd`-equivalent) that fails if `libcudart.so` is present or `libcuda.so` is missing for the core library and the subscriber mapper test.

### Testing
- Ran `git diff --check` to ensure no whitespace / index issues (succeeded).
- Pre-commit `clang-format` was run as part of the commit hook (formatting hook passed after auto-fix).
- Performed a CMake configure attempt with `cmake -S ros2_cuda_ipc_core -B /tmp/ros2_cuda_ipc_core_build -DBUILD_TESTING=ON`, which could not complete in this environment because `ament_cmake` is not available (blocked configuration step).
- Ran repository scans (`rg`) and inspected changed sources to verify that subscriber/importer paths now reference Driver API types and that runtime-only usage remains in the publisher target (manual source checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5fdd7cc84883288e9d86a453a4765b)