### PR TITLE
Migrate ready events to CUDA Driver API

### DIFF
--- a/doc/cuda_driver_context_design.md
+++ b/doc/cuda_driver_context_design.md
@@ -23,9 +23,11 @@ the same CPU thread. Guards are move-only and must not be moved to a different
 thread for destruction because CUDA context stacks are thread-local. Cleanup
 errors are logged and never thrown from the destructor.
 
-The foundation does not migrate resource operations in this change. In
-particular, it does not change CUDA Runtime streams or error types, and it does
-not reset contexts with `cuDevicePrimaryCtxReset()` or `cudaDeviceReset()`.
+Ready-event operations use this foundation: each publisher pool and imported
+subscriber event retains the device primary context, and each Driver API call
+is enclosed by a short-lived guard. CUDA Runtime-created streams remain valid
+because the public stream type is still `cudaStream_t`. The library never
+resets contexts with `cuDevicePrimaryCtxReset()` or `cudaDeviceReset()`.
 
 ## Current VMM assumptions
 
@@ -38,26 +40,24 @@ thread. The VMM backend then calls `cuMemGetAllocationGranularity`,
 context. The backend separately calls `cuInit(0)` through a local
 `std::call_once`.
 
-The VMM importer calls `cuInit(0)` before
-`cuMemImportFromShareableHandle`, allocation-granularity lookup, address
-reservation, mapping, and access setup, but does not explicitly activate the
-message's device primary context. It therefore has an implicit current-context
-precondition that should be removed during later migration.
+The VMM importer retains and activates the message's device primary context
+before `cuMemImportFromShareableHandle`, allocation-granularity lookup, address
+reservation, mapping, access setup, and Driver API event import. The retained
+context is carried with the imported resource so cleanup can establish the same
+context later.
 
 VMM slot cleanup runs from `GpuBufferPool::destroy_slots()` and the
-`VmmSlotState` destructor. The state can outlive the callback that created it;
-the current code does not attach a Driver context to the state or establish a
-thread-local context before its `cuMemUnmap`, `cuMemAddressFree`, and
-`cuMemRelease` calls. The Unix FD server has its own worker thread, but that
-thread only serves file descriptors and does not call CUDA APIs. Later cleanup
-work must make the context and thread ownership explicit.
+`VmmSlotState` destructor. The Unix FD server has its own worker thread, but
+that thread only serves file descriptors and does not call CUDA APIs. The
+imported-resource cleanup path now carries the retained context for its Driver
+API cleanup; VMM publisher-side allocation cleanup remains part of the memory
+path migration.
 
 ## Later integration points
 
 Future Driver API migration should add scoped guards around:
 
 * VMM allocation, import, map, unmap, and release operations;
-* CUDA IPC event creation, recording, export, import, waiting, and destruction;
 * CUDA IPC memory export, import, and close operations;
 * Publisher and Subscriber resource classes that own those CUDA objects.
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -107,7 +107,7 @@ memo:
 struct BufferView {
   // === リソース（必ず有効時は同一 device 上） ===
   void*       dev_ptr = nullptr;     // デバイス先頭
-  cudaEvent_t ready_evt = nullptr;   // "書き終わり" を示すイベント（他プロセス発行）
+  CUevent     ready_evt = nullptr;   // "書き終わり" を示すイベント（他プロセス発行）
   int         device_id = 0;
   uint64_t    byte_size = 0;
 
@@ -131,20 +131,18 @@ struct BufferView {
   bool valid() const noexcept { return dev_ptr != nullptr; }
 
   // 自分のストリームに書き終わりイベントを依存として積む
-  cudaError_t enqueue_ready_event(cudaStream_t s) const noexcept {
-    return ready_evt ? cudaStreamWaitEvent(s, ready_evt, 0) : cudaSuccess;
-  }
+  detail::CudaResult<void> enqueue_ready_event(cudaStream_t s) const noexcept;
 
   void reset() noexcept;             // dev_ptr/evt をリセットし lease を解放
   void set_ipc_handles(MemoryBackendKind backend,
                        const uint8_t* payload_bytes,
                        std::size_t payload_size,
-                       const cudaIpcEventHandle_t& evt) noexcept;
+                       const EventHandlePayload& evt) noexcept;
   bool handles_ready() const noexcept;
 
 private:
   MemoryHandlePayload mem_payload_{};  // Publisher から渡されたハンドル
-  cudaIpcEventHandle_t event_handle_{};
+  EventHandlePayload event_handle_{};
   bool handles_ready_ = false;
 };
 ```
@@ -173,7 +171,8 @@ Subscriber 側の import/open を抽象化する。どちらも `BufferCore.back
 MemoryBackend は「slot 用 GPU メモリの確保」「BufferCore に載せるハンドル情報の生成」
 「Publisher 側リソースのクリーンアップ」をまとめる小さなクラスである。Subscriber 側では
 `BufferViewMapper` が `backend::MemoryImporter` を通して CUDA IPC open または VMM import を呼び分ける。
-イベントハンドル（`cudaIpcEventHandle_t`）は共通実装を維持し、CUDA IPC ベースの同期を継続する。
+  イベントのwire payload（64 byte）は共通実装を維持する。library内部では
+  Driver APIの`CUipcEventHandle`/`CUevent`を使い、CUDA IPCベースの同期を継続する。
 
 ##### x86 + dGPU: 既存の cudaIpcMemHandle_t パス
 
@@ -290,7 +289,7 @@ struct ImageView {
   }
 
   // 同期依存の登録（必要なら呼ぶ。どのストリームで待つかは呼び手が決める）
-  cudaError_t enqueue_ready_event(cudaStream_t s) const noexcept {
+  detail::CudaResult<void> enqueue_ready_event(cudaStream_t s) const noexcept {
     return core.enqueue_ready_event(s);
   }
 
@@ -388,7 +387,7 @@ struct PointCloud2View {
   }
 
   size_t num_points() const noexcept { return static_cast<size_t>(width) * height; }
-  cudaError_t enqueue_ready_event(cudaStream_t s) const noexcept {
+  detail::CudaResult<void> enqueue_ready_event(cudaStream_t s) const noexcept {
     return core.enqueue_ready_event(s);
   }
 };

--- a/examples/multi_process_image_fanout/src/encoder_like_node.cpp
+++ b/examples/multi_process_image_fanout/src/encoder_like_node.cpp
@@ -163,7 +163,7 @@ class EncoderLikeNode : public rclcpp::Node {
       NvtxScopedRange wait_range("EncoderLikeNode::wait_input_event");
       auto result = view.enqueue_ready_event(stream_);
       if (!result) {
-        RCLCPP_WARN(get_logger(), "cuStreamWaitEvent failed: %s",
+        RCLCPP_WARN(get_logger(), "enqueue_ready_event failed: %s",
                     result.error().to_string().c_str());
         cudaEventDestroy(kernel_start);
         cudaEventDestroy(kernel_stop);

--- a/examples/multi_process_image_fanout/src/encoder_like_node.cpp
+++ b/examples/multi_process_image_fanout/src/encoder_like_node.cpp
@@ -161,16 +161,15 @@ class EncoderLikeNode : public rclcpp::Node {
       // Order this node's stream after the publisher's ready event before any
       // kernel reads the shared input slot.
       NvtxScopedRange wait_range("EncoderLikeNode::wait_input_event");
-      err = view.enqueue_ready_event(stream_);
+      auto result = view.enqueue_ready_event(stream_);
+      if (!result) {
+        RCLCPP_WARN(get_logger(), "cuStreamWaitEvent failed: %s",
+                    result.error().to_string().c_str());
+        cudaEventDestroy(kernel_start);
+        cudaEventDestroy(kernel_stop);
+        return;
+      }
     }
-    if (err != cudaSuccess) {
-      RCLCPP_WARN(get_logger(), "cudaStreamWaitEvent failed: %s",
-                  cuda_error_to_string(err).c_str());
-      cudaEventDestroy(kernel_start);
-      cudaEventDestroy(kernel_stop);
-      return;
-    }
-
     err = cudaEventRecord(kernel_start, stream_);
     if (err != cudaSuccess) {
       RCLCPP_WARN(get_logger(), "cudaEventRecord failed: %s",

--- a/examples/multi_process_image_fanout/src/gpu_image_publisher.cpp
+++ b/examples/multi_process_image_fanout/src/gpu_image_publisher.cpp
@@ -148,10 +148,12 @@ class GpuImagePublisherNode : public rclcpp::Node {
 
     {
       NvtxScopedRange event_range("GpuImagePublisherNode::record_ready");
-      error = slot->record_ready(stream_);
-    }
-    if (!log_cuda_error(get_logger(), "record_ready", error)) {
-      return;
+      auto result = slot->record_ready(stream_);
+      if (!result) {
+        RCLCPP_WARN(get_logger(), "record_ready failed: %s",
+                    result.error().to_string().c_str());
+        return;
+      }
     }
 
     const auto descriptor = slot->descriptor();

--- a/examples/multi_process_image_fanout/src/inference_like_node.cpp
+++ b/examples/multi_process_image_fanout/src/inference_like_node.cpp
@@ -146,7 +146,7 @@ class InferenceLikeNode : public rclcpp::Node {
       NvtxScopedRange wait_range("InferenceLikeNode::wait_input_event");
       auto result = view.enqueue_ready_event(stream_);
       if (!result) {
-        RCLCPP_WARN(get_logger(), "cuStreamWaitEvent failed: %s",
+        RCLCPP_WARN(get_logger(), "enqueue_ready_event failed: %s",
                     result.error().to_string().c_str());
         cudaEventDestroy(kernel_start);
         cudaEventDestroy(kernel_stop);

--- a/examples/multi_process_image_fanout/src/inference_like_node.cpp
+++ b/examples/multi_process_image_fanout/src/inference_like_node.cpp
@@ -144,10 +144,10 @@ class InferenceLikeNode : public rclcpp::Node {
       // Wait on the publisher's ready event before reading the shared input
       // slot from this node's stream.
       NvtxScopedRange wait_range("InferenceLikeNode::wait_input_event");
-      const cudaError_t err = view.enqueue_ready_event(stream_);
-      if (err != cudaSuccess) {
-        RCLCPP_WARN(get_logger(), "cudaStreamWaitEvent failed: %s",
-                    cuda_error_to_string(err).c_str());
+      auto result = view.enqueue_ready_event(stream_);
+      if (!result) {
+        RCLCPP_WARN(get_logger(), "cuStreamWaitEvent failed: %s",
+                    result.error().to_string().c_str());
         cudaEventDestroy(kernel_start);
         cudaEventDestroy(kernel_stop);
         return;

--- a/examples/multi_process_image_fanout/src/preview_node.cpp
+++ b/examples/multi_process_image_fanout/src/preview_node.cpp
@@ -171,15 +171,14 @@ class PreviewNode : public rclcpp::Node {
     {
       // Wait for the publisher's ready event before copying.
       NvtxScopedRange wait_range("PreviewNode::wait_input_event");
-      err = view.enqueue_ready_event(stream_);
-    }
-    if (err != cudaSuccess) {
-      RCLCPP_WARN(
-          get_logger(), "cudaStreamWaitEvent failed: %s",
-          ros2_cuda_ipc_core::detail::cuda_error_to_string(err).c_str());
-      cudaEventDestroy(copy_start);
-      cudaEventDestroy(copy_stop);
-      return;
+      auto result = view.enqueue_ready_event(stream_);
+      if (!result) {
+        RCLCPP_WARN(get_logger(), "cuStreamWaitEvent failed: %s",
+                    result.error().to_string().c_str());
+        cudaEventDestroy(copy_start);
+        cudaEventDestroy(copy_stop);
+        return;
+      }
     }
 
     {

--- a/examples/multi_process_image_fanout/src/preview_node.cpp
+++ b/examples/multi_process_image_fanout/src/preview_node.cpp
@@ -173,7 +173,7 @@ class PreviewNode : public rclcpp::Node {
       NvtxScopedRange wait_range("PreviewNode::wait_input_event");
       auto result = view.enqueue_ready_event(stream_);
       if (!result) {
-        RCLCPP_WARN(get_logger(), "cuStreamWaitEvent failed: %s",
+        RCLCPP_WARN(get_logger(), "enqueue_ready_event failed: %s",
                     result.error().to_string().c_str());
         cudaEventDestroy(copy_start);
         cudaEventDestroy(copy_stop);

--- a/ros2_cuda_ipc_core/CMakeLists.txt
+++ b/ros2_cuda_ipc_core/CMakeLists.txt
@@ -59,6 +59,9 @@ target_link_libraries(${PROJECT_NAME}
     ${ros2_cuda_ipc_msgs_TARGETS}
     ${sensor_msgs_TARGETS}
     ${std_msgs_TARGETS}
+    # The memory backends still use the Runtime API.  Ready-event calls use
+    # CUDA::cuda_driver exclusively; libcudart can be removed after the
+    # memory-path migration.
     CUDA::cudart
     CUDA::cuda_driver
     ${UUID_LIB}
@@ -96,6 +99,8 @@ if(BUILD_TESTING)
   target_link_libraries(test_gpu_buffer_manager ${PROJECT_NAME})
   ament_add_gtest(test_gpu_buffer_pool test/test_gpu_buffer_pool.cpp)
   target_link_libraries(test_gpu_buffer_pool ${PROJECT_NAME})
+  ament_add_gtest(test_ready_event_driver test/test_ready_event_driver.cpp)
+  target_link_libraries(test_ready_event_driver ${PROJECT_NAME})
   ament_add_gtest(test_lease_manager test/test_lease_manager.cpp)
   target_link_libraries(test_lease_manager ${PROJECT_NAME})
   ament_add_gtest(test_cuda_driver_context test/test_cuda_driver_context.cpp)

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp
@@ -11,7 +11,7 @@ class MemoryImporter final : public backend::MemoryImporter {
  public:
   std::optional<ImportedMemory> import(
       const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-      const cudaIpcEventHandle_t& event_handle,
+      const CUipcEventHandle& event_handle,
       const rclcpp::Logger& logger) const override;
 };
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_backend.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_backend.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cuda.h>
 #include <cuda_runtime_api.h>
 
 #include <cstdint>
@@ -21,8 +22,8 @@ struct SlotBackendState {
 struct SlotResources {
   uint32_t index = 0;
   void* device_ptr = nullptr;
-  cudaEvent_t event = nullptr;
-  cudaIpcEventHandle_t event_handle{};
+  CUevent event = nullptr;
+  transport::EventHandlePayload event_handle{};
   transport::MemoryBackendKind backend = transport::MemoryBackendKind::CUDA_IPC;
   transport::MemoryHandlePayload mem_handle{};
   std::shared_ptr<SlotBackendState> backend_state;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
@@ -10,6 +10,7 @@
 #include <optional>
 
 #include "rclcpp/logger.hpp"
+#include "ros2_cuda_ipc_core/detail/cuda_driver_context.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 #include "ros2_cuda_ipc_msgs/msg/buffer_core.hpp"
 
@@ -17,7 +18,8 @@ namespace ros2_cuda_ipc_core::backend {
 
 struct ImportedMemory {
   void* dev_ptr = nullptr;
-  cudaEvent_t event = nullptr;
+  CUevent event = nullptr;
+  std::shared_ptr<detail::CudaDeviceContext> context;
   CUdeviceptr vmm_address = 0;
   CUmemGenericAllocationHandle vmm_allocation = 0;
   std::size_t allocation_size = 0;
@@ -29,7 +31,7 @@ class MemoryImporter {
 
   virtual std::optional<ImportedMemory> import(
       const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-      const cudaIpcEventHandle_t& event_handle,
+      const CUipcEventHandle& event_handle,
       const rclcpp::Logger& logger) const = 0;
 };
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/vmm_fd/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/vmm_fd/memory_importer.hpp
@@ -11,7 +11,7 @@ class MemoryImporter final : public backend::MemoryImporter {
  public:
   std::optional<ImportedMemory> import(
       const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-      const cudaIpcEventHandle_t& event_handle,
+      const CUipcEventHandle& event_handle,
       const rclcpp::Logger& logger) const override;
 };
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/image/image_view.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/image/image_view.hpp
@@ -51,7 +51,8 @@ struct ImageView {
 
   uint32_t elem_size_bytes() const noexcept;
 
-  cudaError_t enqueue_ready_event(cudaStream_t stream) const noexcept {
+  detail::CudaResult<void> enqueue_ready_event(
+      cudaStream_t stream) const noexcept {
     return core.enqueue_ready_event(stream);
   }
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/pointcloud2/pointcloud2_view.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/pointcloud2/pointcloud2_view.hpp
@@ -56,7 +56,8 @@ struct PointCloud2View {
   size_t num_points() const noexcept {
     return static_cast<size_t>(width) * height;
   }
-  cudaError_t enqueue_ready_event(cudaStream_t stream) const noexcept {
+  detail::CudaResult<void> enqueue_ready_event(
+      cudaStream_t stream) const noexcept {
     return core.enqueue_ready_event(stream);
   }
   bool valid() const noexcept { return core.valid() && point_step > 0; }

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp
@@ -11,6 +11,7 @@
 #include <string>
 
 #include "rclcpp/logger.hpp"
+#include "ros2_cuda_ipc_core/detail/cuda_driver_context.hpp"
 #include "ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp"
 #include "ros2_cuda_ipc_core/publisher/lease_manager.hpp"
 #include "ros2_cuda_ipc_core/transport/buffer_descriptor.hpp"
@@ -47,9 +48,9 @@ class PublishSlot {
 
   /// Record that the slot's GPU payload is ready on the given stream.
   ///
-  /// @return CUDA error code, or cudaErrorInvalidResourceHandle when the slot
-  /// is not in the reserved state.
-  cudaError_t record_ready(cudaStream_t stream) noexcept;
+  /// @return A Driver API result. A failed result is returned when the slot
+  /// is not in the reserved state or the event cannot be recorded.
+  detail::CudaResult<void> record_ready(cudaStream_t stream) noexcept;
 
   /// Build the transport descriptor after the ready event has been recorded.
   ///
@@ -160,8 +161,9 @@ class GpuBufferManager {
   friend class PublishSlot;
 
   void* device_ptr(const LeaseManager::Reservation& reservation) const noexcept;
-  cudaError_t record_ready(const LeaseManager::Reservation& reservation,
-                           cudaStream_t stream) noexcept;
+  detail::CudaResult<void> record_ready(
+      const LeaseManager::Reservation& reservation,
+      cudaStream_t stream) noexcept;
   std::optional<transport::BufferDescriptor> descriptor(
       const LeaseManager::Reservation& reservation) const;
   void cancel(const LeaseManager::Reservation& reservation) noexcept;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp
@@ -10,6 +10,7 @@
 
 #include "rclcpp/logger.hpp"
 #include "ros2_cuda_ipc_core/backend/memory_backend.hpp"
+#include "ros2_cuda_ipc_core/detail/cuda_driver_context.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 
 namespace ros2_cuda_ipc_core::publisher {
@@ -41,7 +42,8 @@ class GpuBufferPool {
   int device_index() const noexcept { return device_index_; }
 
   void* device_ptr(uint32_t slot_id) const noexcept;
-  cudaError_t record_ready(uint32_t slot_id, cudaStream_t stream) noexcept;
+  detail::CudaResult<void> record_ready(uint32_t slot_id,
+                                        cudaStream_t stream) noexcept;
   const SlotResources* resources(uint32_t slot_id) const noexcept;
 
  private:
@@ -56,6 +58,7 @@ class GpuBufferPool {
   int device_index_ = -1;
   bool initialised_ = false;
   std::unique_ptr<MemoryBackend> memory_backend_;
+  std::shared_ptr<detail::CudaDeviceContext> context_;
 };
 
 }  // namespace ros2_cuda_ipc_core::publisher

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view.hpp
@@ -3,12 +3,14 @@
 
 #pragma once
 
-#include <cuda_runtime_api.h>
+#include <cuda.h>
+#include <driver_types.h>
 
 #include <cstdint>
 #include <memory>
 #include <string>
 
+#include "ros2_cuda_ipc_core/detail/cuda_driver_context.hpp"
 #include "ros2_cuda_ipc_core/lease/lease_handle.hpp"
 #include "ros2_cuda_ipc_core/publisher_instance_id.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
@@ -17,7 +19,8 @@ namespace ros2_cuda_ipc_core::subscriber {
 
 struct BufferView {
   void* dev_ptr = nullptr;
-  cudaEvent_t ready_evt = nullptr;
+  CUevent ready_evt = nullptr;
+  std::shared_ptr<detail::CudaDeviceContext> context;
   int device_id = 0;
   uint64_t byte_size = 0;
   uint32_t slot_id = 0;
@@ -40,17 +43,18 @@ struct BufferView {
 
   bool valid() const noexcept { return dev_ptr != nullptr; }
 
-  cudaError_t enqueue_ready_event(cudaStream_t stream) const noexcept;
+  detail::CudaResult<void> enqueue_ready_event(
+      cudaStream_t stream) const noexcept;
 
   void reset() noexcept;
 
   void set_ipc_handles(transport::MemoryBackendKind backend,
                        const uint8_t* payload_bytes, std::size_t payload_size,
-                       const cudaIpcEventHandle_t& evt) noexcept;
+                       const transport::EventHandlePayload& evt) noexcept;
   const transport::MemoryHandlePayload& mem_payload() const noexcept {
     return mem_payload_;
   }
-  const cudaIpcEventHandle_t& event_handle() const noexcept {
+  const transport::EventHandlePayload& event_handle() const noexcept {
     return event_handle_;
   }
   transport::MemoryBackendKind backend() const noexcept { return backend_; }
@@ -58,7 +62,7 @@ struct BufferView {
 
  private:
   transport::MemoryHandlePayload mem_payload_{};
-  cudaIpcEventHandle_t event_handle_{};
+  transport::EventHandlePayload event_handle_{};
   transport::MemoryBackendKind backend_ =
       transport::MemoryBackendKind::CUDA_IPC;
   bool handles_ready_ = false;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <cuda_runtime_api.h>
-
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -23,7 +21,7 @@ struct IpcHandleKey {
   PublisherInstanceId publisher_instance_id{};
   uint8_t backend = 0;
   transport::MemoryHandlePayload mem{};
-  std::array<uint8_t, sizeof(cudaIpcEventHandle_t)> event{};
+  transport::EventHandlePayload event{};
 
   bool operator==(const IpcHandleKey& other) const noexcept {
     return publisher_instance_id == other.publisher_instance_id &&
@@ -42,12 +40,17 @@ class IpcHandleCache {
   explicit IpcHandleCache(
       ReleaseFn release_fn = backend::release_imported_memory);
 
+  ~IpcHandleCache();
+
   static IpcHandleCache& instance();
 
   std::optional<backend::ImportedMemory> find(const IpcHandleKey& key) const;
 
   backend::ImportedMemory insert_or_discard_duplicate(
       const IpcHandleKey& key, backend::ImportedMemory imported);
+
+  /// Release all cache-owned imported resources after detaching the map.
+  void clear();
 
   std::size_t size() const;
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/transport/buffer_descriptor.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/transport/buffer_descriptor.hpp
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <cuda_runtime_api.h>
-
 #include <cstdint>
 #include <string>
 
@@ -25,7 +23,7 @@ struct BufferDescriptor {
   uint64_t byte_size = 0;
   MemoryBackendKind backend = MemoryBackendKind::CUDA_IPC;
   MemoryHandlePayload memory_handle{};
-  cudaIpcEventHandle_t ready_event_handle{};
+  EventHandlePayload ready_event_handle{};
 };
 
 }  // namespace ros2_cuda_ipc_core::transport

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/transport/memory_types.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/transport/memory_types.hpp
@@ -35,4 +35,7 @@ inline constexpr MemoryBackendKind backend_from_byte(uint8_t value) noexcept {
 
 using MemoryHandlePayload = std::array<uint8_t, kMemoryHandleSize>;
 
+/// Fixed-size wire payload for a CUDA IPC event handle.
+using EventHandlePayload = std::array<uint8_t, 64>;
+
 }  // namespace ros2_cuda_ipc_core::transport

--- a/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_importer.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 
 #include "rclcpp/logging.hpp"
+#include "ros2_cuda_ipc_core/detail/cuda_driver_context.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 
 namespace ros2_cuda_ipc_core::backend::cuda_ipc {
@@ -23,24 +24,41 @@ cudaIpcMemHandle_t to_cuda_mem_handle(
 
 std::optional<ImportedMemory> MemoryImporter::import(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-    const cudaIpcEventHandle_t& event_handle,
-    const rclcpp::Logger& logger) const {
-  ImportedMemory imported;
+    const CUipcEventHandle& event_handle, const rclcpp::Logger& logger) const {
+  auto context_result = detail::CudaDeviceContext::retain_primary(
+      static_cast<int>(msg.device_id));
+  if (!context_result) {
+    RCLCPP_WARN(logger, "Failed to retain CUDA primary context: %s",
+                context_result.error().to_string().c_str());
+    return std::nullopt;
+  }
+  auto context = std::move(context_result).value();
+  auto guard_result = context->push_current();
+  if (!guard_result) {
+    RCLCPP_WARN(logger, "Failed to activate CUDA context: %s",
+                guard_result.error().to_string().c_str());
+    return std::nullopt;
+  }
+  auto guard = std::move(guard_result).value();
 
-  auto err = cudaIpcOpenEventHandle(&imported.event, event_handle);
-  if (err != cudaSuccess) {
-    RCLCPP_WARN(logger, "cudaIpcOpenEventHandle failed: %s",
-                cudaGetErrorString(err));
+  ImportedMemory imported;
+  imported.context = context;
+
+  CUresult result = cuIpcOpenEventHandle(&imported.event, event_handle);
+  if (result != CUDA_SUCCESS) {
+    RCLCPP_WARN(logger, "cuIpcOpenEventHandle failed: %s",
+                detail::CudaDriverError(result).to_string().c_str());
     return std::nullopt;
   }
 
   const cudaIpcMemHandle_t mem_handle = to_cuda_mem_handle(msg);
-  err = cudaIpcOpenMemHandle(&imported.dev_ptr, mem_handle,
-                             cudaIpcMemLazyEnablePeerAccess);
+  const cudaError_t err = cudaIpcOpenMemHandle(&imported.dev_ptr, mem_handle,
+                                               cudaIpcMemLazyEnablePeerAccess);
   if (err != cudaSuccess) {
     RCLCPP_WARN(logger, "cudaIpcOpenMemHandle failed: %s",
                 cudaGetErrorString(err));
-    cudaEventDestroy(imported.event);
+    (void)cuEventDestroy(imported.event);
+    imported.event = nullptr;
     return std::nullopt;
   }
 

--- a/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
@@ -3,6 +3,7 @@
 
 #include "ros2_cuda_ipc_core/backend/memory_importer.hpp"
 
+#include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp"
 #include "ros2_cuda_ipc_core/backend/vmm_fd/memory_importer.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
@@ -10,6 +11,22 @@
 namespace ros2_cuda_ipc_core::backend {
 
 void release_imported_memory(const ImportedMemory& imported) noexcept {
+  // Imported resources created by the Driver-backed importers always carry
+  // the context that owns them.  A missing context denotes a non-owning test
+  // or inspection value; do not issue CUDA cleanup calls for such a value.
+  if (!imported.context) {
+    return;
+  }
+  std::optional<detail::CudaContextGuard> guard;
+  auto guard_result = imported.context->push_current();
+  if (!guard_result) {
+    RCLCPP_ERROR(
+        rclcpp::get_logger("ros2_cuda_ipc_core.memory_importer"),
+        "Failed to activate CUDA context for imported resource cleanup: %s",
+        guard_result.error().to_string().c_str());
+    return;
+  }
+  guard.emplace(std::move(guard_result).value());
   if (imported.vmm_address != 0 && imported.allocation_size != 0) {
     cuMemUnmap(imported.vmm_address, imported.allocation_size);
     cuMemAddressFree(imported.vmm_address, imported.allocation_size);
@@ -21,7 +38,12 @@ void release_imported_memory(const ImportedMemory& imported) noexcept {
     cudaIpcCloseMemHandle(imported.dev_ptr);
   }
   if (imported.event != nullptr) {
-    cudaEventDestroy(imported.event);
+    const CUresult result = cuEventDestroy(imported.event);
+    if (result != CUDA_SUCCESS) {
+      RCLCPP_ERROR(rclcpp::get_logger("ros2_cuda_ipc_core.memory_importer"),
+                   "cuEventDestroy failed during imported resource cleanup: %s",
+                   detail::CudaDriverError(result).to_string().c_str());
+    }
   }
 }
 

--- a/ros2_cuda_ipc_core/src/backend/vmm_fd/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/vmm_fd/memory_importer.cpp
@@ -10,7 +10,6 @@
 
 #include <cerrno>
 #include <cstring>
-#include <mutex>
 #include <optional>
 #include <string>
 
@@ -33,19 +32,6 @@ std::size_t align_up_size(std::size_t value, std::size_t alignment) {
     return value;
   }
   return value + alignment - remainder;
-}
-
-bool ensure_cuda_driver_initialised(const rclcpp::Logger& logger) {
-  static std::once_flag once;
-  static CUresult init_status = CUDA_SUCCESS;
-  std::call_once(once, []() { init_status = cuInit(0); });
-  if (init_status != CUDA_SUCCESS) {
-    RCLCPP_ERROR(
-        logger, "cuInit failed: %s",
-        ros2_cuda_ipc_core::detail::cu_result_to_string(init_status).c_str());
-    return false;
-  }
-  return true;
 }
 
 std::optional<std::string> parse_vmm_payload(
@@ -130,8 +116,7 @@ std::optional<int> request_fd_from_publisher(const std::string& path,
 
 std::optional<ImportedMemory> MemoryImporter::import(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-    const cudaIpcEventHandle_t& event_handle,
-    const rclcpp::Logger& logger) const {
+    const CUipcEventHandle& event_handle, const rclcpp::Logger& logger) const {
   const auto meta = parse_vmm_payload(msg.mem_handle, logger);
   if (!meta.has_value()) {
     return std::nullopt;
@@ -149,12 +134,26 @@ std::optional<ImportedMemory> MemoryImporter::import(
     return std::nullopt;
   }
 
-  if (!ensure_cuda_driver_initialised(logger)) {
+  auto context_result = detail::CudaDeviceContext::retain_primary(
+      static_cast<int>(msg.device_id));
+  if (!context_result) {
+    RCLCPP_WARN(logger, "Failed to retain CUDA primary context: %s",
+                context_result.error().to_string().c_str());
     ::close(fd_opt.value());
     return std::nullopt;
   }
+  auto context = std::move(context_result).value();
+  auto guard_result = context->push_current();
+  if (!guard_result) {
+    RCLCPP_WARN(logger, "Failed to activate CUDA context: %s",
+                guard_result.error().to_string().c_str());
+    ::close(fd_opt.value());
+    return std::nullopt;
+  }
+  auto guard = std::move(guard_result).value();
 
   ImportedMemory imported;
+  imported.context = context;
 
   void* os_handle =
       reinterpret_cast<void*>(static_cast<intptr_t>(fd_opt.value()));
@@ -227,10 +226,12 @@ std::optional<ImportedMemory> MemoryImporter::import(
     return std::nullopt;
   }
 
-  auto err = cudaIpcOpenEventHandle(&imported.event, event_handle);
-  if (err != cudaSuccess) {
-    RCLCPP_WARN(logger, "cudaIpcOpenEventHandle failed: %s",
-                cudaGetErrorString(err));
+  cu_res = cuIpcOpenEventHandle(&imported.event, event_handle);
+  if (cu_res != CUDA_SUCCESS) {
+    RCLCPP_WARN(logger, "cuIpcOpenEventHandle failed: %s",
+                ros2_cuda_ipc_core::detail::CudaDriverError(cu_res)
+                    .to_string()
+                    .c_str());
     cuMemUnmap(imported.vmm_address, imported.allocation_size);
     cuMemAddressFree(imported.vmm_address, imported.allocation_size);
     cuMemRelease(imported.vmm_allocation);

--- a/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
@@ -43,15 +43,17 @@ void* PublishSlot::device_ptr() const noexcept {
   return valid() ? owner_->device_ptr(reservation_) : nullptr;
 }
 
-cudaError_t PublishSlot::record_ready(cudaStream_t stream) noexcept {
+detail::CudaResult<void> PublishSlot::record_ready(
+    cudaStream_t stream) noexcept {
   if (owner_ == nullptr || state_ != State::reserved) {
-    return cudaErrorInvalidResourceHandle;
+    return detail::CudaResult<void>::failure(
+        detail::CudaDriverError(CUDA_ERROR_INVALID_HANDLE));
   }
-  const cudaError_t error = owner_->record_ready(reservation_, stream);
-  if (error == cudaSuccess) {
+  auto result = owner_->record_ready(reservation_, stream);
+  if (result) {
     state_ = State::ready_recorded;
   }
-  return error;
+  return result;
 }
 
 std::optional<transport::BufferDescriptor> PublishSlot::descriptor() const {
@@ -143,13 +145,14 @@ void* GpuBufferManager::device_ptr(
   return buffer_pool_.device_ptr(reservation.slot_id);
 }
 
-cudaError_t GpuBufferManager::record_ready(
+detail::CudaResult<void> GpuBufferManager::record_ready(
     const LeaseManager::Reservation& reservation,
     cudaStream_t stream) noexcept {
   if (reservation.shm_name != lease_manager_.shm_name() ||
       reservation.publisher_instance_id !=
           lease_manager_.publisher_instance_id()) {
-    return cudaErrorInvalidResourceHandle;
+    return detail::CudaResult<void>::failure(
+        detail::CudaDriverError(CUDA_ERROR_INVALID_HANDLE));
   }
   return buffer_pool_.record_ready(reservation.slot_id, stream);
 }

--- a/ros2_cuda_ipc_core/src/publisher/gpu_buffer_pool.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/gpu_buffer_pool.cpp
@@ -3,6 +3,8 @@
 
 #include "ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp"
 
+#include <cstring>
+
 #include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/backend/cuda_ipc/memory_backend.hpp"
 #include "ros2_cuda_ipc_core/backend/vmm_fd/memory_backend.hpp"
@@ -52,6 +54,13 @@ bool GpuBufferPool::initialise(uint64_t byte_size, int device_index) {
                  detail::cuda_error_to_string(set_device_error).c_str());
     return false;
   }
+  auto context_result = detail::CudaDeviceContext::retain_primary(device_index);
+  if (!context_result) {
+    RCLCPP_ERROR(logger_, "Failed to retain CUDA primary context: %s",
+                 context_result.error().to_string().c_str());
+    return false;
+  }
+  context_ = std::move(context_result).value();
   byte_size_ = byte_size;
   device_index_ = device_index;
   slots_.assign(slot_count_, {});
@@ -79,13 +88,27 @@ void* GpuBufferPool::device_ptr(uint32_t slot_id) const noexcept {
   return slot ? slot->device_ptr : nullptr;
 }
 
-cudaError_t GpuBufferPool::record_ready(uint32_t slot_id,
-                                        cudaStream_t stream) noexcept {
+detail::CudaResult<void> GpuBufferPool::record_ready(
+    uint32_t slot_id, cudaStream_t stream) noexcept {
   const auto* slot = resources(slot_id);
   if (!initialised_ || slot == nullptr || slot->event == nullptr) {
-    return cudaErrorInvalidResourceHandle;
+    return detail::CudaResult<void>::failure(
+        detail::CudaDriverError(CUDA_ERROR_INVALID_HANDLE));
   }
-  return cudaEventRecord(slot->event, stream);
+  if (!context_) {
+    return detail::CudaResult<void>::failure(
+        detail::CudaDriverError(CUDA_ERROR_INVALID_CONTEXT));
+  }
+  auto guard_result = context_->push_current();
+  if (!guard_result) {
+    return detail::CudaResult<void>::failure(guard_result.error());
+  }
+  auto guard = std::move(guard_result).value();
+  const CUresult result = cuEventRecord(slot->event, stream);
+  if (result != CUDA_SUCCESS) {
+    return detail::CudaResult<void>::failure(detail::CudaDriverError(result));
+  }
+  return detail::CudaResult<void>::success();
 }
 
 const GpuBufferPool::SlotResources* GpuBufferPool::resources(
@@ -108,20 +131,36 @@ bool GpuBufferPool::allocate_slots() {
     memory_backend_.reset();
     return false;
   }
+  if (!context_) {
+    RCLCPP_ERROR(logger_, "CUDA primary context is unavailable");
+    return false;
+  }
+  auto guard_result = context_->push_current();
+  if (!guard_result) {
+    RCLCPP_ERROR(logger_, "Failed to activate CUDA context: %s",
+                 guard_result.error().to_string().c_str());
+    return false;
+  }
+  auto guard = std::move(guard_result).value();
   for (auto& slot : slots_) {
-    cudaError_t error = cudaEventCreateWithFlags(
-        &slot.event, cudaEventDisableTiming | cudaEventInterprocess);
-    if (error != cudaSuccess) {
-      RCLCPP_ERROR(logger_, "cudaEventCreateWithFlags failed: %s",
-                   detail::cuda_error_to_string(error).c_str());
+    CUresult result = cuEventCreate(
+        &slot.event, CU_EVENT_DISABLE_TIMING | CU_EVENT_INTERPROCESS);
+    if (result != CUDA_SUCCESS) {
+      RCLCPP_ERROR(logger_, "cuEventCreate failed: %s",
+                   detail::CudaDriverError(result).to_string().c_str());
       return false;
     }
-    error = cudaIpcGetEventHandle(&slot.event_handle, slot.event);
-    if (error != cudaSuccess) {
-      RCLCPP_ERROR(logger_, "cudaIpcGetEventHandle failed: %s",
-                   detail::cuda_error_to_string(error).c_str());
+    CUipcEventHandle event_handle{};
+    result = cuIpcGetEventHandle(&event_handle, slot.event);
+    if (result != CUDA_SUCCESS) {
+      RCLCPP_ERROR(logger_, "cuIpcGetEventHandle failed: %s",
+                   detail::CudaDriverError(result).to_string().c_str());
       return false;
     }
+    static_assert(
+        sizeof(event_handle) == transport::EventHandlePayload{}.size(),
+        "CUDA IPC event handle payload size changed");
+    std::memcpy(slot.event_handle.data(), &event_handle, sizeof(event_handle));
   }
   return true;
 }
@@ -130,14 +169,25 @@ void GpuBufferPool::destroy_slots() noexcept {
   if (device_index_ >= 0) {
     cudaSetDevice(device_index_);
   }
-  for (auto& slot : slots_) {
-    if (slot.event != nullptr) {
-      const cudaError_t error = cudaEventDestroy(slot.event);
-      if (error != cudaSuccess) {
-        RCLCPP_ERROR(logger_, "cudaEventDestroy failed for slot %u: %s",
-                     slot.index, detail::cuda_error_to_string(error).c_str());
+  if (context_) {
+    auto guard_result = context_->push_current();
+    if (!guard_result) {
+      RCLCPP_ERROR(logger_,
+                   "Failed to activate CUDA context for event cleanup: %s",
+                   guard_result.error().to_string().c_str());
+    } else {
+      auto guard = std::move(guard_result).value();
+      for (auto& slot : slots_) {
+        if (slot.event != nullptr) {
+          const CUresult result = cuEventDestroy(slot.event);
+          if (result != CUDA_SUCCESS) {
+            RCLCPP_ERROR(logger_, "cuEventDestroy failed for slot %u: %s",
+                         slot.index,
+                         detail::CudaDriverError(result).to_string().c_str());
+          }
+          slot.event = nullptr;
+        }
       }
-      slot.event = nullptr;
     }
   }
   if (memory_backend_) {
@@ -148,6 +198,7 @@ void GpuBufferPool::destroy_slots() noexcept {
   byte_size_ = 0;
   device_index_ = -1;
   initialised_ = false;
+  context_.reset();
 }
 
 }  // namespace ros2_cuda_ipc_core::publisher

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp
@@ -21,6 +21,7 @@ BufferView& BufferView::operator=(const BufferView& other) {
 
   dev_ptr = other.dev_ptr;
   ready_evt = other.ready_evt;
+  context = other.context;
   device_id = other.device_id;
   byte_size = other.byte_size;
   slot_id = other.slot_id;
@@ -49,6 +50,7 @@ BufferView& BufferView::operator=(BufferView&& other) noexcept {
 
   dev_ptr = other.dev_ptr;
   ready_evt = other.ready_evt;
+  context = std::move(other.context);
   device_id = other.device_id;
   byte_size = other.byte_size;
   slot_id = other.slot_id;
@@ -72,17 +74,34 @@ BufferView& BufferView::operator=(BufferView&& other) noexcept {
   return *this;
 }
 
-cudaError_t BufferView::enqueue_ready_event(
+detail::CudaResult<void> BufferView::enqueue_ready_event(
     cudaStream_t stream) const noexcept {
   if (!ready_evt) {
-    return cudaSuccess;
+    return detail::CudaResult<void>::success();
   }
-  return cudaStreamWaitEvent(stream, ready_evt, 0);
+  if (context) {
+    auto guard_result = context->push_current();
+    if (!guard_result) {
+      return detail::CudaResult<void>::failure(guard_result.error());
+    }
+    auto guard = std::move(guard_result).value();
+    const CUresult result = cuStreamWaitEvent(stream, ready_evt, 0);
+    if (result != CUDA_SUCCESS) {
+      return detail::CudaResult<void>::failure(detail::CudaDriverError(result));
+    }
+    return detail::CudaResult<void>::success();
+  }
+  const CUresult result = cuStreamWaitEvent(stream, ready_evt, 0);
+  if (result != CUDA_SUCCESS) {
+    return detail::CudaResult<void>::failure(detail::CudaDriverError(result));
+  }
+  return detail::CudaResult<void>::success();
 }
 
 void BufferView::reset() noexcept {
   dev_ptr = nullptr;
   ready_evt = nullptr;
+  context.reset();
   byte_size = 0;
   slot_id = 0;
   generation = 0;
@@ -93,10 +112,10 @@ void BufferView::reset() noexcept {
   lease.reset();
 }
 
-void BufferView::set_ipc_handles(transport::MemoryBackendKind backend,
-                                 const uint8_t* payload_bytes,
-                                 std::size_t payload_size,
-                                 const cudaIpcEventHandle_t& evt) noexcept {
+void BufferView::set_ipc_handles(
+    transport::MemoryBackendKind backend, const uint8_t* payload_bytes,
+    std::size_t payload_size,
+    const transport::EventHandlePayload& evt) noexcept {
   backend_ = backend;
   std::memset(mem_payload_.data(), 0, mem_payload_.size());
   if (payload_bytes != nullptr && payload_size > 0) {
@@ -104,7 +123,7 @@ void BufferView::set_ipc_handles(transport::MemoryBackendKind backend,
         std::min(payload_size, static_cast<std::size_t>(mem_payload_.size()));
     std::memcpy(mem_payload_.data(), payload_bytes, copy);
   }
-  std::memcpy(&event_handle_, &evt, sizeof(event_handle_));
+  event_handle_ = evt;
   handles_ready_ = true;
 }
 

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
@@ -16,9 +16,11 @@ namespace ros2_cuda_ipc_core::subscriber {
 
 namespace {
 
-cudaIpcEventHandle_t to_cuda_event_handle(
+CUipcEventHandle to_cuda_event_handle(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg) {
-  cudaIpcEventHandle_t handle{};
+  CUipcEventHandle handle{};
+  static_assert(sizeof(handle) == transport::EventHandlePayload{}.size(),
+                "CUDA IPC event handle payload size changed");
   std::memcpy(&handle, msg.event_handle.data(), sizeof(handle));
   return handle;
 }
@@ -108,13 +110,16 @@ BufferView BufferViewMapper::map(
   }
 
   auto lease_ptr = std::make_shared<lease::LeaseHandle>(std::move(lease));
-  const cudaIpcEventHandle_t event_handle = to_cuda_event_handle(msg);
+  const CUipcEventHandle event_handle = to_cuda_event_handle(msg);
+  transport::EventHandlePayload event_payload{};
+  std::memcpy(event_payload.data(), msg.event_handle.data(),
+              event_payload.size());
 
   IpcHandleKey key{};
   key.publisher_instance_id = instance_id;
   key.backend = static_cast<uint8_t>(msg.backend);
   key.mem = msg.mem_handle;
-  std::memcpy(key.event.data(), &event_handle, sizeof(event_handle));
+  std::memcpy(key.event.data(), msg.event_handle.data(), key.event.size());
 
   backend::ImportedMemory imported;
   auto cached = IpcHandleCache::instance().find(key);
@@ -134,6 +139,7 @@ BufferView BufferViewMapper::map(
   BufferView view;
   view.dev_ptr = imported.dev_ptr;
   view.ready_evt = imported.event;
+  view.context = imported.context;
   view.device_id = static_cast<int>(msg.device_id);
   view.byte_size = msg.byte_size;
   view.slot_id = msg.slot_id;
@@ -143,7 +149,7 @@ BufferView BufferViewMapper::map(
   view.lease = std::move(lease_ptr);
   view.set_ipc_handles(
       transport::backend_from_byte(static_cast<uint8_t>(msg.backend)),
-      msg.mem_handle.data(), msg.mem_handle.size(), event_handle);
+      msg.mem_handle.data(), msg.mem_handle.size(), event_payload);
   return view;
 }
 

--- a/ros2_cuda_ipc_core/src/subscriber/ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/ipc_handle_cache.cpp
@@ -58,8 +58,11 @@ void IpcHandleCache::clear() {
     std::lock_guard<std::mutex> lock(mutex_);
     entries.swap(cache_);
   }
-  for (const auto& entry : entries) {
+for (const auto& entry : entries) {
+  try {
     release_fn_(entry.second);
+  } catch (...) {
+    // Best-effort cleanup; keep cache clear/destruction noexcept.
   }
 }
 

--- a/ros2_cuda_ipc_core/src/subscriber/ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/ipc_handle_cache.cpp
@@ -58,11 +58,12 @@ void IpcHandleCache::clear() {
     std::lock_guard<std::mutex> lock(mutex_);
     entries.swap(cache_);
   }
-for (const auto& entry : entries) {
-  try {
-    release_fn_(entry.second);
-  } catch (...) {
-    // Best-effort cleanup; keep cache clear/destruction noexcept.
+  for (const auto& entry : entries) {
+    try {
+      release_fn_(entry.second);
+    } catch (...) {
+      // Best-effort cleanup; keep cache clear/destruction noexcept.
+    }
   }
 }
 

--- a/ros2_cuda_ipc_core/src/subscriber/ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/ipc_handle_cache.cpp
@@ -24,6 +24,8 @@ std::size_t IpcHandleKeyHash::operator()(
 IpcHandleCache::IpcHandleCache(ReleaseFn release_fn)
     : release_fn_(std::move(release_fn)) {}
 
+IpcHandleCache::~IpcHandleCache() { clear(); }
+
 IpcHandleCache& IpcHandleCache::instance() {
   static IpcHandleCache cache;
   return cache;
@@ -48,6 +50,17 @@ backend::ImportedMemory IpcHandleCache::insert_or_discard_duplicate(
     return it->second;
   }
   return imported;
+}
+
+void IpcHandleCache::clear() {
+  decltype(cache_) entries;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    entries.swap(cache_);
+  }
+  for (const auto& entry : entries) {
+    release_fn_(entry.second);
+  }
 }
 
 std::size_t IpcHandleCache::size() const {

--- a/ros2_cuda_ipc_core/src/transport/message_utils.cpp
+++ b/ros2_cuda_ipc_core/src/transport/message_utils.cpp
@@ -3,6 +3,8 @@
 
 #include "ros2_cuda_ipc_core/transport/message_utils.hpp"
 
+#include <cuda.h>
+
 #include <cstring>
 
 namespace ros2_cuda_ipc_core::transport {
@@ -14,9 +16,11 @@ using BufferCoreMessage = ros2_cuda_ipc_msgs::msg::BufferCore;
 static_assert(sizeof(BufferCoreMessage::_mem_handle_type) ==
                   sizeof(MemoryHandlePayload),
               "BufferCore.mem_handle must match MemoryHandlePayload");
+static_assert(sizeof(CUipcEventHandle) == EventHandlePayload{}.size(),
+              "CUDA IPC event handle payload size changed");
 static_assert(sizeof(BufferCoreMessage::_event_handle_type) ==
-                  sizeof(cudaIpcEventHandle_t),
-              "BufferCore.event_handle must match cudaIpcEventHandle_t");
+                  EventHandlePayload{}.size(),
+              "BufferCore.event_handle must remain a 64-byte payload");
 
 }  // namespace
 

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
@@ -62,7 +62,7 @@ TEST_F(GpuBufferManagerTest, DescriptorIsGatedByReadyRecording) {
   auto slot = manager.acquire_for_publish(1);
   ASSERT_TRUE(slot.has_value());
   EXPECT_EQ(slot->descriptor(), std::nullopt);
-  ASSERT_EQ(slot->record_ready(nullptr), cudaSuccess);
+  ASSERT_TRUE(slot->record_ready(nullptr));
   auto descriptor = slot->descriptor();
   ASSERT_TRUE(descriptor.has_value());
   EXPECT_EQ(descriptor->slot_id, 0u);
@@ -70,7 +70,7 @@ TEST_F(GpuBufferManagerTest, DescriptorIsGatedByReadyRecording) {
   EXPECT_EQ(descriptor->lease_shm_name, manager.shm_name());
   EXPECT_EQ(descriptor->publisher_instance_id, instance_id);
   EXPECT_EQ(descriptor->byte_size, 1024u);
-  EXPECT_NE(slot->record_ready(nullptr), cudaSuccess);
+  EXPECT_FALSE(slot->record_ready(nullptr));
   slot->commit_publish();
   slot->commit_publish();
   EXPECT_FALSE(slot->valid());
@@ -92,7 +92,7 @@ TEST_F(GpuBufferManagerTest, CommittedDestructionKeepsPending) {
   {
     auto slot = manager.acquire_for_publish(1);
     ASSERT_TRUE(slot.has_value());
-    ASSERT_EQ(slot->record_ready(nullptr), cudaSuccess);
+    ASSERT_TRUE(slot->record_ready(nullptr));
     slot->commit_publish();
   }
   EXPECT_FALSE(manager.acquire_for_publish(1).has_value());
@@ -150,7 +150,7 @@ TEST_F(GpuBufferManagerTest, AcquireAutomaticallyReclaimsExpiredPending) {
   {
     auto slot = manager.acquire_for_publish(1);
     ASSERT_TRUE(slot.has_value());
-    ASSERT_EQ(slot->record_ready(nullptr), cudaSuccess);
+    ASSERT_TRUE(slot->record_ready(nullptr));
     slot->commit_publish();
   }
 

--- a/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
@@ -85,4 +85,19 @@ TEST(IpcHandleCacheTest, DuplicateInsertInvokesReleaseHook) {
   EXPECT_EQ(released.load(), 1);
 }
 
+TEST(IpcHandleCacheTest, ClearReleasesCacheOwnedResources) {
+  std::atomic<int> released{0};
+  subscriber::IpcHandleCache cache(
+      [&released](const backend::ImportedMemory&) { released.fetch_add(1); });
+  subscriber::IpcHandleKey key{};
+  backend::ImportedMemory imported;
+  imported.dev_ptr = reinterpret_cast<void*>(0x9090);
+  cache.insert_or_discard_duplicate(key, imported);
+
+  cache.clear();
+
+  EXPECT_EQ(released.load(), 1);
+  EXPECT_EQ(cache.size(), 0u);
+}
+
 }  // namespace ros2_cuda_ipc_core

--- a/ros2_cuda_ipc_core/test/test_ready_event_driver.cpp
+++ b/ros2_cuda_ipc_core/test/test_ready_event_driver.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
+
+#include "ros2_cuda_ipc_core/subscriber/buffer_view.hpp"
+
+namespace {
+
+TEST(ReadyEventDriverTest, DriverWaitAcceptsRuntimeCreatedStream) {
+  int device_count = 0;
+  if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0) {
+    GTEST_SKIP() << "CUDA device not available";
+  }
+  ASSERT_EQ(cudaSetDevice(0), cudaSuccess);
+
+  cudaStream_t producer = nullptr;
+  cudaStream_t consumer = nullptr;
+  cudaEvent_t runtime_event = nullptr;
+  ASSERT_EQ(cudaStreamCreate(&producer), cudaSuccess);
+  ASSERT_EQ(cudaStreamCreate(&consumer), cudaSuccess);
+  ASSERT_EQ(cudaEventCreateWithFlags(&runtime_event, cudaEventDisableTiming),
+            cudaSuccess);
+  ASSERT_EQ(cudaEventRecord(runtime_event, producer), cudaSuccess);
+
+  ros2_cuda_ipc_core::subscriber::BufferView view;
+  view.ready_evt = reinterpret_cast<CUevent>(runtime_event);
+  const auto result = view.enqueue_ready_event(consumer);
+  ASSERT_TRUE(result) << result.error().to_string();
+  ASSERT_EQ(cudaStreamSynchronize(consumer), cudaSuccess);
+
+  EXPECT_EQ(cudaEventDestroy(runtime_event), cudaSuccess);
+  EXPECT_EQ(cudaStreamDestroy(consumer), cudaSuccess);
+  EXPECT_EQ(cudaStreamDestroy(producer), cudaSuccess);
+}
+
+}  // namespace

--- a/utils/gpu_image_transport/src/gpu_image_transport_base.cpp
+++ b/utils/gpu_image_transport/src/gpu_image_transport_base.cpp
@@ -71,12 +71,12 @@ void GpuImageTransportNodeBase::on_image(
   cudaError_t err = cudaSuccess;
   {
     NvtxScopedRange wait_range("GpuImageTransportNodeBase::stream_wait_event");
-    err = view.enqueue_ready_event(stream_);
-  }
-  if (err != cudaSuccess) {
-    RCLCPP_ERROR(get_logger(), "cudaStreamWaitEvent failed: %s",
-                 cuda_error_to_string(err).c_str());
-    return;
+    auto result = view.enqueue_ready_event(stream_);
+    if (!result) {
+      RCLCPP_ERROR(get_logger(), "cuStreamWaitEvent failed: %s",
+                   result.error().to_string().c_str());
+      return;
+    }
   }
 
   const std::uint64_t bytes_to_copy = view.core.byte_size;

--- a/utils/gpu_image_transport/src/gpu_image_transport_base.cpp
+++ b/utils/gpu_image_transport/src/gpu_image_transport_base.cpp
@@ -73,7 +73,7 @@ void GpuImageTransportNodeBase::on_image(
     NvtxScopedRange wait_range("GpuImageTransportNodeBase::stream_wait_event");
     auto result = view.enqueue_ready_event(stream_);
     if (!result) {
-      RCLCPP_ERROR(get_logger(), "cuStreamWaitEvent failed: %s",
+      RCLCPP_ERROR(get_logger(), "enqueue_ready_event failed: %s",
                    result.error().to_string().c_str());
       return;
     }


### PR DESCRIPTION
## Summary

- Migrate publisher ready-event creation, recording, IPC export, and destruction to the CUDA Driver API.
- Migrate subscriber event import, stream wait, and destruction to the CUDA Driver API.
- Preserve the public `cudaStream_t` API and the existing 64-byte ROS wire payload.
- Add context-aware imported-resource cleanup and Runtime-created-stream interoperability coverage.

## Validation

- `colcon build --packages-select ros2_cuda_ipc_core gpu_image_transport multi_process_image_fanout --cmake-args -DBUILD_TESTING=ON`
- `ctest --test-dir build/ros2_cuda_ipc_core --output-on-failure`
- 11 core tests passed.
- No CUDA Runtime event function calls remain in `ros2_cuda_ipc_core/src` or `include`.

## Follow-up

The target still links `CUDA::cudart` because the memory backends continue to use CUDA Runtime API calls. That dependency can be removed after the separate memory-path migration.