### PR TITLE
Migrate CUDA IPC memory path to Driver API

### DIFF
--- a/ros2_cuda_ipc_core/CMakeLists.txt
+++ b/ros2_cuda_ipc_core/CMakeLists.txt
@@ -59,9 +59,8 @@ target_link_libraries(${PROJECT_NAME}
     ${ros2_cuda_ipc_msgs_TARGETS}
     ${sensor_msgs_TARGETS}
     ${std_msgs_TARGETS}
-    # The memory backends still use the Runtime API.  Ready-event calls use
-    # CUDA::cuda_driver exclusively; libcudart can be removed after the
-    # memory-path migration.
+    # Stream-facing public APIs and non-IPC users still depend on libcudart;
+    # CUDA IPC memory allocation/import itself uses CUDA::cuda_driver.
     CUDA::cudart
     CUDA::cuda_driver
     ${UUID_LIB}

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_backend.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_backend.hpp
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <cuda.h>
-#include <cuda_runtime_api.h>
 
 #include <cstdint>
 #include <memory>

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
@@ -4,9 +4,9 @@
 #pragma once
 
 #include <cuda.h>
-#include <cuda_runtime_api.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 
 #include "rclcpp/logger.hpp"

--- a/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_backend.cpp
+++ b/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_backend.cpp
@@ -3,14 +3,13 @@
 
 #include "ros2_cuda_ipc_core/backend/cuda_ipc/memory_backend.hpp"
 
-#include <cuda_runtime_api.h>
-
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <vector>
 
 #include "rclcpp/logging.hpp"
-#include "ros2_cuda_ipc_core/detail/cuda_util.hpp"
+#include "ros2_cuda_ipc_core/detail/cuda_driver_context.hpp"
 #include "ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 
@@ -24,19 +23,22 @@ class CudaIpcMemoryBackend : public publisher::GpuBufferPool::MemoryBackend {
                 rclcpp::Logger logger) override {
     (void)device_index;
     for (auto& slot : slots) {
-      cudaError_t err = cudaMalloc(&slot.device_ptr, frame_size_bytes);
-      if (err != cudaSuccess) {
-        RCLCPP_ERROR(logger, "cudaMalloc failed: %s",
-                     detail::cuda_error_to_string(err).c_str());
+      CUdeviceptr device_ptr = 0;
+      CUresult result = cuMemAlloc(&device_ptr, frame_size_bytes);
+      if (result != CUDA_SUCCESS) {
+        RCLCPP_ERROR(logger, "cuMemAlloc failed: %s",
+                     detail::CudaDriverError(result).to_string().c_str());
         destroy(slots, logger);
         return false;
       }
+      slot.device_ptr =
+          reinterpret_cast<void*>(static_cast<uintptr_t>(device_ptr));
 
-      cudaIpcMemHandle_t handle{};
-      err = cudaIpcGetMemHandle(&handle, slot.device_ptr);
-      if (err != cudaSuccess) {
-        RCLCPP_ERROR(logger, "cudaIpcGetMemHandle failed: %s",
-                     detail::cuda_error_to_string(err).c_str());
+      CUipcMemHandle handle{};
+      result = cuIpcGetMemHandle(&handle, device_ptr);
+      if (result != CUDA_SUCCESS) {
+        RCLCPP_ERROR(logger, "cuIpcGetMemHandle failed: %s",
+                     detail::CudaDriverError(result).to_string().c_str());
         destroy(slots, logger);
         return false;
       }
@@ -51,10 +53,12 @@ class CudaIpcMemoryBackend : public publisher::GpuBufferPool::MemoryBackend {
                rclcpp::Logger logger) noexcept override {
     for (auto& slot : slots) {
       if (slot.device_ptr) {
-        const cudaError_t free_err = cudaFree(slot.device_ptr);
-        if (free_err != cudaSuccess) {
-          RCLCPP_ERROR(logger, "cudaFree failed for slot %u: %s", slot.index,
-                       detail::cuda_error_to_string(free_err).c_str());
+        const CUdeviceptr device_ptr = static_cast<CUdeviceptr>(
+            reinterpret_cast<uintptr_t>(slot.device_ptr));
+        const CUresult result = cuMemFree(device_ptr);
+        if (result != CUDA_SUCCESS) {
+          RCLCPP_ERROR(logger, "cuMemFree failed for slot %u: %s", slot.index,
+                       detail::CudaDriverError(result).to_string().c_str());
         }
         slot.device_ptr = nullptr;
       }

--- a/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_importer.cpp
@@ -3,6 +3,7 @@
 
 #include "ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp"
 
+#include <cstdint>
 #include <cstring>
 
 #include "rclcpp/logging.hpp"
@@ -13,9 +14,9 @@ namespace ros2_cuda_ipc_core::backend::cuda_ipc {
 
 namespace {
 
-cudaIpcMemHandle_t to_cuda_mem_handle(
+CUipcMemHandle to_cuda_mem_handle(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg) {
-  cudaIpcMemHandle_t handle{};
+  CUipcMemHandle handle{};
   std::memcpy(&handle, msg.mem_handle.data(), sizeof(handle));
   return handle;
 }
@@ -51,16 +52,19 @@ std::optional<ImportedMemory> MemoryImporter::import(
     return std::nullopt;
   }
 
-  const cudaIpcMemHandle_t mem_handle = to_cuda_mem_handle(msg);
-  const cudaError_t err = cudaIpcOpenMemHandle(&imported.dev_ptr, mem_handle,
-                                               cudaIpcMemLazyEnablePeerAccess);
-  if (err != cudaSuccess) {
-    RCLCPP_WARN(logger, "cudaIpcOpenMemHandle failed: %s",
-                cudaGetErrorString(err));
+  const CUipcMemHandle mem_handle = to_cuda_mem_handle(msg);
+  CUdeviceptr device_ptr = 0;
+  result = cuIpcOpenMemHandle(&device_ptr, mem_handle,
+                              CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS);
+  if (result != CUDA_SUCCESS) {
+    RCLCPP_WARN(logger, "cuIpcOpenMemHandle failed: %s",
+                detail::CudaDriverError(result).to_string().c_str());
     (void)cuEventDestroy(imported.event);
     imported.event = nullptr;
     return std::nullopt;
   }
+  imported.dev_ptr =
+      reinterpret_cast<void*>(static_cast<uintptr_t>(device_ptr));
 
   return imported;
 }

--- a/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
@@ -3,6 +3,8 @@
 
 #include "ros2_cuda_ipc_core/backend/memory_importer.hpp"
 
+#include <cstdint>
+
 #include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp"
 #include "ros2_cuda_ipc_core/backend/vmm_fd/memory_importer.hpp"
@@ -35,7 +37,15 @@ void release_imported_memory(const ImportedMemory& imported) noexcept {
     cuMemRelease(imported.vmm_allocation);
   }
   if (imported.vmm_address == 0 && imported.dev_ptr != nullptr) {
-    cudaIpcCloseMemHandle(imported.dev_ptr);
+    const CUdeviceptr device_ptr =
+        static_cast<CUdeviceptr>(reinterpret_cast<uintptr_t>(imported.dev_ptr));
+    const CUresult result = cuIpcCloseMemHandle(device_ptr);
+    if (result != CUDA_SUCCESS) {
+      RCLCPP_ERROR(rclcpp::get_logger("ros2_cuda_ipc_core.memory_importer"),
+                   "cuIpcCloseMemHandle failed during imported resource "
+                   "cleanup: %s",
+                   detail::CudaDriverError(result).to_string().c_str());
+    }
   }
   if (imported.event != nullptr) {
     const CUresult result = cuEventDestroy(imported.event);

--- a/ros2_cuda_ipc_core/src/publisher/gpu_buffer_pool.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/gpu_buffer_pool.cpp
@@ -4,11 +4,11 @@
 #include "ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp"
 
 #include <cstring>
+#include <optional>
 
 #include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/backend/cuda_ipc/memory_backend.hpp"
 #include "ros2_cuda_ipc_core/backend/vmm_fd/memory_backend.hpp"
-#include "ros2_cuda_ipc_core/detail/cuda_util.hpp"
 
 namespace ros2_cuda_ipc_core::publisher {
 namespace {
@@ -47,12 +47,6 @@ bool GpuBufferPool::initialise(uint64_t byte_size, int device_index) {
   }
   if (initialised_ || !slots_.empty()) {
     destroy_slots();
-  }
-  const cudaError_t set_device_error = cudaSetDevice(device_index);
-  if (set_device_error != cudaSuccess) {
-    RCLCPP_ERROR(logger_, "cudaSetDevice failed: %s",
-                 detail::cuda_error_to_string(set_device_error).c_str());
-    return false;
   }
   auto context_result = detail::CudaDeviceContext::retain_primary(device_index);
   if (!context_result) {
@@ -120,20 +114,30 @@ const GpuBufferPool::SlotResources* GpuBufferPool::resources(
 }
 
 bool GpuBufferPool::allocate_slots() {
+  if (!context_) {
+    RCLCPP_ERROR(logger_, "CUDA primary context is unavailable");
+    return false;
+  }
   if (!memory_backend_) {
     memory_backend_ = make_backend(backend_kind_);
   }
   if (!memory_backend_) {
     return false;
   }
-  if (!memory_backend_->allocate(byte_size_, device_index_, slots_, logger_)) {
-    memory_backend_->destroy(slots_, logger_);
-    memory_backend_.reset();
-    return false;
-  }
-  if (!context_) {
-    RCLCPP_ERROR(logger_, "CUDA primary context is unavailable");
-    return false;
+  {
+    auto memory_guard_result = context_->push_current();
+    if (!memory_guard_result) {
+      RCLCPP_ERROR(logger_, "Failed to activate CUDA context: %s",
+                   memory_guard_result.error().to_string().c_str());
+      return false;
+    }
+    auto memory_guard = std::move(memory_guard_result).value();
+    if (!memory_backend_->allocate(byte_size_, device_index_, slots_,
+                                   logger_)) {
+      memory_backend_->destroy(slots_, logger_);
+      memory_backend_.reset();
+      return false;
+    }
   }
   auto guard_result = context_->push_current();
   if (!guard_result) {
@@ -166,9 +170,7 @@ bool GpuBufferPool::allocate_slots() {
 }
 
 void GpuBufferPool::destroy_slots() noexcept {
-  if (device_index_ >= 0) {
-    cudaSetDevice(device_index_);
-  }
+  std::optional<detail::CudaContextGuard> guard;
   if (context_) {
     auto guard_result = context_->push_current();
     if (!guard_result) {
@@ -176,7 +178,7 @@ void GpuBufferPool::destroy_slots() noexcept {
                    "Failed to activate CUDA context for event cleanup: %s",
                    guard_result.error().to_string().c_str());
     } else {
-      auto guard = std::move(guard_result).value();
+      guard.emplace(std::move(guard_result).value());
       for (auto& slot : slots_) {
         if (slot.event != nullptr) {
           const CUresult result = cuEventDestroy(slot.event);

--- a/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
@@ -47,11 +47,11 @@ TEST(IpcHandleCacheTest, DuplicateInsertReturnsExistingEntry) {
 
   backend::ImportedMemory first;
   first.dev_ptr = reinterpret_cast<void*>(0x1010);
-  first.event = reinterpret_cast<cudaEvent_t>(0x2020);
+  first.event = reinterpret_cast<CUevent>(0x2020);
 
   backend::ImportedMemory duplicate;
   duplicate.dev_ptr = reinterpret_cast<void*>(0x3030);
-  duplicate.event = reinterpret_cast<cudaEvent_t>(0x4040);
+  duplicate.event = reinterpret_cast<CUevent>(0x4040);
 
   auto inserted = cache.insert_or_discard_duplicate(key, first);
   auto second = cache.insert_or_discard_duplicate(key, duplicate);
@@ -73,11 +73,11 @@ TEST(IpcHandleCacheTest, DuplicateInsertInvokesReleaseHook) {
 
   backend::ImportedMemory first;
   first.dev_ptr = reinterpret_cast<void*>(0x5050);
-  first.event = reinterpret_cast<cudaEvent_t>(0x6060);
+  first.event = reinterpret_cast<CUevent>(0x6060);
 
   backend::ImportedMemory duplicate;
   duplicate.dev_ptr = reinterpret_cast<void*>(0x7070);
-  duplicate.event = reinterpret_cast<cudaEvent_t>(0x8080);
+  duplicate.event = reinterpret_cast<CUevent>(0x8080);
 
   cache.insert_or_discard_duplicate(key, first);
   cache.insert_or_discard_duplicate(key, duplicate);

--- a/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
+++ b/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
@@ -79,7 +79,7 @@ inline void seed_cache_for_message(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg, uintptr_t ptr_seed) {
   backend::ImportedMemory imported;
   imported.dev_ptr = reinterpret_cast<void*>(ptr_seed);
-  imported.event = reinterpret_cast<cudaEvent_t>(ptr_seed + 1U);
+  imported.event = reinterpret_cast<CUevent>(ptr_seed + 1U);
   subscriber::IpcHandleCache::instance().insert_or_discard_duplicate(
       make_key(msg), imported);
 }


### PR DESCRIPTION
## Summary

- Migrate CUDA IPC publisher allocation, export, and free operations to the CUDA Driver API.
- Migrate subscriber memory import and close operations to the CUDA Driver API.
- Keep the public `void*` device-pointer API and partial-allocation cleanup behavior.
- Use the primary context associated with `device_index` for IPC memory operations.

## Validation

- `colcon build --packages-select ros2_cuda_ipc_core`
- `colcon test --packages-select ros2_cuda_ipc_core`
- 11 tests passed; the multi-device context test was skipped because only one CUDA device is available.
- Verified that the CUDA IPC memory path contains no Runtime API memory/device functions.