### PR TITLE
Improve CUDA IPC resource RAII and cross-process coverage

### DIFF
--- a/doc/design.md
+++ b/doc/design.md
@@ -99,15 +99,17 @@ memo:
 
 #### BufferView
 
-  * BufferCore.msg を Subscriber mapper が import した結果 (dev_ptr, ready_evt, LeaseHandle)。
+  * BufferCore.msg を Subscriber mapper が import した結果（ImportedResources、LeaseHandle）。
   * データの解釈は持たない。
 
 ```cpp
 // BufferView: GPUバッファそのものの借用ビュー（意味付けなし）
 struct BufferView {
-  // === リソース（必ず有効時は同一 device 上） ===
-  void*       dev_ptr = nullptr;     // デバイス先頭
-  CUevent     ready_evt = nullptr;   // "書き終わり" を示すイベント（他プロセス発行）
+  // === リソースのaccessor（所有権はImportedResourcesに集約） ===
+  template<class T = void> T* data() const noexcept;
+  void* device_ptr() const noexcept;
+  CUevent ready_event() const noexcept;
+  bool valid() const noexcept;
   int         device_id = 0;
   uint64_t    byte_size = 0;
 
@@ -126,14 +128,10 @@ struct BufferView {
   BufferView(BufferView&&) noexcept;
   BufferView& operator=(BufferView&&) noexcept;
 
-  // === 最小アクセサ／ユーティリティ ===
-  template<class T = void> T* data() const noexcept { return static_cast<T*>(dev_ptr); }
-  bool valid() const noexcept { return dev_ptr != nullptr; }
-
   // 自分のストリームに書き終わりイベントを依存として積む
   detail::CudaResult<void> enqueue_ready_event(cudaStream_t s) const noexcept;
 
-  void reset() noexcept;             // dev_ptr/evt をリセットし lease を解放
+  void reset() noexcept;             // resourceとleaseを解放
   void set_ipc_handles(MemoryBackendKind backend,
                        const uint8_t* payload_bytes,
                        std::size_t payload_size,
@@ -141,6 +139,7 @@ struct BufferView {
   bool handles_ready() const noexcept;
 
 private:
+  std::shared_ptr<const backend::ImportedResources> imported_resource_;
   MemoryHandlePayload mem_payload_{};  // Publisher から渡されたハンドル
   EventHandlePayload event_handle_{};
   bool handles_ready_ = false;
@@ -154,7 +153,7 @@ private:
   メタデータだけを持つ。
 * データの意味付けを持たない：幅やレイアウトは一切保持しない（下位互換性と拡張性を保つため）。
 
-BufferView 自体はハンドルを開かず、受信側 mapper が構築した dev_ptr / ready_evt と
+BufferView 自体はハンドルを開かず、受信側 mapper が構築した ImportedResources と
 LeaseHandle を保持する。mapper はプロセス内キャッシュを使って同じハンドルの open/import を
 初回だけ実行し、フレームごとの open/close コストを排除する。
 
@@ -221,6 +220,13 @@ GPU メモリを「Shareable FD」として扱い、`backend=VMM_FD` で配布�
      stale socket を取り除く。socket path は uuid により一意である前提だが、所有者確認はまだ行っていない。
    * 今後の課題として、別 Publisher の socket を誤って削除しないよう、shm\_name やプロセス識別子を含む
      管理情報で socket の所有者を確認してから削除する仕組みを検討する。
+
+`IpcHandleCache` は import 済み resource のインデックスであり、resource 自体を強く所有しない。
+memory mapping、ready event、CUDA context、必要な VMM state は `backend::ImportedResources` という
+一つの bundle として `std::shared_ptr` で管理し、`BufferView` が active な間だけ生存させる。
+cache は `std::weak_ptr` を保持するため、view がなくなった resource は次回 lookup 時に再 import でき、
+Publisher restart による古い entry の蓄積も避けられる。`clear()` は cache の索引だけを削除し、
+既存の view の lifetime には影響しない。
 
 この設計により、GPU メモリの配布方法だけを MemoryBackend/MemoryImporter で差し替え、ROS 2 メッセージ形式と
 BufferView と Mapper の API を維持したまま Jetson Orin をサポートできる。
@@ -418,19 +424,20 @@ ROS message から View へのアプリケーションメタデータコピー**
   ハンドルごとの `cudaIpcOpen*Handle` や VMM import を初回だけ実行する。これにより、
   subscriber がフレームごとに IPC open/close を繰り返さずに済み、大きな
   API 開始コストを避けている。
-  * キャッシュのライフタイムはプロセス存続中。送信側がメモリを再初期化した
-    場合は新しいハンドルが publish されるため、受信側も自然に再オープンする。
-  * `BufferView` は破棄時に IPC ハンドルを閉じない。キャッシュと同じ
-    ライフタイムで利用する前提のため、ハンドルの解放は送信側に委ねる。
+  * キャッシュは weak index としてプロセス内で共有する。resource の実体は
+    active な `BufferView` が保持し、view がなくなった entry は次回 lookup 時に再 import する。
+  * `BufferView` は `ImportedResources` と LeaseHandle を保持し、最後の view が
+    破棄された時点で受信側の import 済み resource を解放する。
 
 Publisher/Subscriber の役割:
 * Publisher: cudaIpcGet*Handle でハンドル生成 → msg に格納。
 * Publisher (VMM-FD): VMM allocation を FD export し、uuid 経由の Unix domain socket で FD を配布する。
-* Subscriber: Mapper が BufferView を構築し、`BufferCore.backend` に応じて `backend::MemoryImporter` から dev_ptr/event を取得する。
+* Subscriber: Mapper が BufferView を構築し、`BufferCore.backend` に応じて `backend::MemoryImporter` から `ImportedResources` を取得する。
 * Subscriber は ROS message を受け取り、既定 mapper または Mapper オブジェクトを明示的に呼び出して View を取得する。
 
 memo:
-* cudaIpcOpenEventHandle で開いたイベントの破棄は受信側では不要（破棄は送信側が責任を持つ）。
+* `cudaIpcOpenEventHandle` で開いたイベントは受信側の `ImportedResources` と同じ
+  lifetime で破棄し、送信側のイベントは `InterprocessEvent` が別に管理する。
 
 エラーハンドリングポリシー:
 Mapper が ROS→View 変換中に cudaIpcOpen*Handle する際の失敗ケースと方針について:
@@ -446,7 +453,7 @@ Mapper が ROS→View 変換中に cudaIpcOpen*Handle する際の失敗ケー�
     * 同様に cudaErrorInvalidResourceHandle。
 
 **推奨ポリシー**
-* Mapper 内では例外を投げず、「無効な View (dev_ptr==nullptr)」を返す。
+* Mapper 内では例外を投げず、「無効な View (`device_ptr()==nullptr`)」を返す。
 * Subscriber 側のコールバックで view.valid() を必ず確認。
   * 無効ならログ出力して破棄。
   * QoS が reliable でも再送は要求しない（上位レイヤの責務にする）。
@@ -478,7 +485,7 @@ void on_message(const ros2_cuda_ipc_msgs::msg::GpuImage& message) {
   * バッファプール管理、書き込み、cudaEventRecord、ハンドル取得、ROS msg 生成・publish。
 * Subscriber
   * raw message を受け取り、`ImageViewMapper::map()` / `PointCloud2ViewMapper::map()` を呼ぶ。
-  * アプリは View の `dev_ptr` と `ready_evt` を使い、任意のストリームで同期・処理。
+  * アプリは View の `device_ptr()` / `data<T>()` と `enqueue_ready_event()` を使い、任意のストリームで同期・処理。
 
 ## 命名規則
 
@@ -504,5 +511,5 @@ void on_message(const ros2_cuda_ipc_msgs::msg::GpuImage& message) {
    * GpuImage/GpuPointCloud2 を publish
 2. Subscriber:
    * ROS msg を受信 → Mapper が View を返す
-   * `cudaStreamWaitEvent(my_stream, view.ready_evt, 0)`
-   * カーネル呼び出しで view.dev_ptr を利用
+   * `view.enqueue_ready_event(my_stream)`
+   * カーネル呼び出しで `view.device_ptr()` または `view.data<T>()` を利用

--- a/ros2_cuda_ipc_core/CMakeLists.txt
+++ b/ros2_cuda_ipc_core/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 add_library(${PROJECT_NAME}
   src/detail/cuda_util.cpp
   src/detail/cuda_driver_context.cpp
+  src/detail/interprocess_event.cpp
   src/publisher/gpu_buffer_manager.cpp
   src/publisher/gpu_buffer_pool.cpp
   src/backend/memory_importer.cpp
@@ -104,6 +105,19 @@ if(BUILD_TESTING)
   target_link_libraries(test_lease_manager ${PROJECT_NAME})
   ament_add_gtest(test_cuda_driver_context test/test_cuda_driver_context.cpp)
   target_link_libraries(test_cuda_driver_context ${PROJECT_NAME})
+  add_executable(cuda_ipc_import_helper
+                 test/cuda_ipc_import_helper.cpp)
+  target_include_directories(cuda_ipc_import_helper PRIVATE test)
+  target_link_libraries(cuda_ipc_import_helper ${PROJECT_NAME})
+  ament_add_gtest(test_cuda_ipc_memory_driver
+                  test/test_cuda_ipc_memory_driver.cpp)
+  target_include_directories(test_cuda_ipc_memory_driver PRIVATE test)
+  target_compile_definitions(
+    test_cuda_ipc_memory_driver
+    PRIVATE
+      CUDA_IPC_IMPORT_HELPER_PATH="$<TARGET_FILE:cuda_ipc_import_helper>")
+  target_link_libraries(test_cuda_ipc_memory_driver ${PROJECT_NAME})
+  add_dependencies(test_cuda_ipc_memory_driver cuda_ipc_import_helper)
 endif()
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp
@@ -9,7 +9,7 @@ namespace ros2_cuda_ipc_core::backend::cuda_ipc {
 
 class MemoryImporter final : public backend::MemoryImporter {
  public:
-  std::optional<ImportedMemory> import(
+  std::optional<ImportedResources> import(
       const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
       const CUipcEventHandle& event_handle,
       const rclcpp::Logger& logger) const override;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_backend.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_backend.hpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "rclcpp/logger.hpp"
+#include "ros2_cuda_ipc_core/detail/interprocess_event.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 
 namespace ros2_cuda_ipc_core::backend {
@@ -21,8 +22,7 @@ struct SlotBackendState {
 struct SlotResources {
   uint32_t index = 0;
   void* device_ptr = nullptr;
-  CUevent event = nullptr;
-  transport::EventHandlePayload event_handle{};
+  std::unique_ptr<detail::InterprocessEvent> ready_event;
   transport::MemoryBackendKind backend = transport::MemoryBackendKind::CUDA_IPC;
   transport::MemoryHandlePayload mem_handle{};
   std::shared_ptr<SlotBackendState> backend_state;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
+#include <utility>
 
 #include "rclcpp/logger.hpp"
 #include "ros2_cuda_ipc_core/detail/cuda_driver_context.hpp"
@@ -16,13 +17,16 @@
 
 namespace ros2_cuda_ipc_core::backend {
 
-struct ImportedMemory {
-  ImportedMemory() = default;
-  ImportedMemory(const ImportedMemory&) = delete;
-  ImportedMemory& operator=(const ImportedMemory&) = delete;
-  ImportedMemory& operator=(ImportedMemory&&) = delete;
+// The imported memory mapping and its synchronization event must have one
+// lifetime.  In particular, BufferView keeps this whole bundle alive after
+// the cache entry itself has been detached.
+struct ImportedResources {
+  ImportedResources() = default;
+  ImportedResources(const ImportedResources&) = delete;
+  ImportedResources& operator=(const ImportedResources&) = delete;
+  ImportedResources& operator=(ImportedResources&&) = delete;
 
-  ImportedMemory(ImportedMemory&& other) noexcept
+  ImportedResources(ImportedResources&& other) noexcept
       : dev_ptr(other.dev_ptr),
         event(other.event),
         context(std::move(other.context)),
@@ -48,13 +52,27 @@ class MemoryImporter {
  public:
   virtual ~MemoryImporter() = default;
 
-  virtual std::optional<ImportedMemory> import(
+  virtual std::optional<ImportedResources> import(
       const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
       const CUipcEventHandle& event_handle,
       const rclcpp::Logger& logger) const = 0;
 };
 
-bool release_imported_memory(const ImportedMemory& imported) noexcept;
+bool release_imported_resources(const ImportedResources& imported) noexcept;
+
+// Cache destruction cannot propagate a cleanup error, so its deleter uses an
+// explicit best-effort adapter.  The checked function above remains available
+// to callers such as cross-process tests that need the result.
+inline void release_imported_resources_best_effort(
+    const ImportedResources& imported) noexcept {
+  (void)release_imported_resources(imported);
+}
+
+// Compatibility wrapper for the pre-bundle name.
+inline bool release_imported_memory(
+    const ImportedResources& imported) noexcept {
+  return release_imported_resources(imported);
+}
 
 const MemoryImporter& get_memory_importer(uint8_t backend);
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
@@ -17,6 +17,25 @@
 namespace ros2_cuda_ipc_core::backend {
 
 struct ImportedMemory {
+  ImportedMemory() = default;
+  ImportedMemory(const ImportedMemory&) = delete;
+  ImportedMemory& operator=(const ImportedMemory&) = delete;
+  ImportedMemory& operator=(ImportedMemory&&) = delete;
+
+  ImportedMemory(ImportedMemory&& other) noexcept
+      : dev_ptr(other.dev_ptr),
+        event(other.event),
+        context(std::move(other.context)),
+        vmm_address(other.vmm_address),
+        vmm_allocation(other.vmm_allocation),
+        allocation_size(other.allocation_size) {
+    other.dev_ptr = nullptr;
+    other.event = nullptr;
+    other.vmm_address = 0;
+    other.vmm_allocation = 0;
+    other.allocation_size = 0;
+  }
+
   void* dev_ptr = nullptr;
   CUevent event = nullptr;
   std::shared_ptr<detail::CudaDeviceContext> context;
@@ -35,7 +54,7 @@ class MemoryImporter {
       const rclcpp::Logger& logger) const = 0;
 };
 
-void release_imported_memory(const ImportedMemory& imported) noexcept;
+bool release_imported_memory(const ImportedMemory& imported) noexcept;
 
 const MemoryImporter& get_memory_importer(uint8_t backend);
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
@@ -68,12 +68,6 @@ inline void release_imported_resources_best_effort(
   (void)release_imported_resources(imported);
 }
 
-// Compatibility wrapper for the pre-bundle name.
-inline bool release_imported_memory(
-    const ImportedResources& imported) noexcept {
-  return release_imported_resources(imported);
-}
-
 const MemoryImporter& get_memory_importer(uint8_t backend);
 
 }  // namespace ros2_cuda_ipc_core::backend

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/vmm_fd/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/vmm_fd/memory_importer.hpp
@@ -9,7 +9,7 @@ namespace ros2_cuda_ipc_core::backend::vmm_fd {
 
 class MemoryImporter final : public backend::MemoryImporter {
  public:
-  std::optional<ImportedMemory> import(
+  std::optional<ImportedResources> import(
       const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
       const CUipcEventHandle& event_handle,
       const rclcpp::Logger& logger) const override;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/detail/interprocess_event.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/detail/interprocess_event.hpp
@@ -22,6 +22,7 @@ class InterprocessEvent {
 
   InterprocessEvent(const InterprocessEvent&) = delete;
   InterprocessEvent& operator=(const InterprocessEvent&) = delete;
+  InterprocessEvent(InterprocessEvent&&) = delete;
   InterprocessEvent& operator=(InterprocessEvent&&) = delete;
 
   CudaResult<void> record(CUstream stream) const noexcept;
@@ -33,7 +34,6 @@ class InterprocessEvent {
  private:
   InterprocessEvent(std::shared_ptr<CudaDeviceContext> context, CUevent event,
                     transport::EventHandlePayload ipc_handle) noexcept;
-  InterprocessEvent(InterprocessEvent&& other) noexcept;
 
   void reset_noexcept() noexcept;
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/detail/interprocess_event.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/detail/interprocess_event.hpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cuda.h>
+
+#include <memory>
+
+#include "ros2_cuda_ipc_core/detail/cuda_driver_context.hpp"
+#include "ros2_cuda_ipc_core/transport/memory_types.hpp"
+
+namespace ros2_cuda_ipc_core::detail {
+
+/// Owns one publisher-side interprocess event and its exported IPC handle.
+class InterprocessEvent {
+ public:
+  static CudaResult<std::unique_ptr<InterprocessEvent>> create(
+      std::shared_ptr<CudaDeviceContext> context);
+
+  ~InterprocessEvent() noexcept;
+
+  InterprocessEvent(const InterprocessEvent&) = delete;
+  InterprocessEvent& operator=(const InterprocessEvent&) = delete;
+  InterprocessEvent& operator=(InterprocessEvent&&) = delete;
+
+  CudaResult<void> record(CUstream stream) const noexcept;
+
+  const transport::EventHandlePayload& ipc_handle() const noexcept {
+    return ipc_handle_;
+  }
+
+ private:
+  InterprocessEvent(std::shared_ptr<CudaDeviceContext> context, CUevent event,
+                    transport::EventHandlePayload ipc_handle) noexcept;
+  InterprocessEvent(InterprocessEvent&& other) noexcept;
+
+  void reset_noexcept() noexcept;
+
+  std::shared_ptr<CudaDeviceContext> context_;
+  CUevent event_ = nullptr;
+  transport::EventHandlePayload ipc_handle_{};
+};
+
+}  // namespace ros2_cuda_ipc_core::detail

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view.hpp
@@ -19,7 +19,6 @@
 namespace ros2_cuda_ipc_core::subscriber {
 
 struct BufferView {
-  std::shared_ptr<detail::CudaDeviceContext> context;
   int device_id = 0;
   uint64_t byte_size = 0;
   uint32_t slot_id = 0;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 
+#include "ros2_cuda_ipc_core/backend/memory_importer.hpp"
 #include "ros2_cuda_ipc_core/detail/cuda_driver_context.hpp"
 #include "ros2_cuda_ipc_core/lease/lease_handle.hpp"
 #include "ros2_cuda_ipc_core/publisher_instance_id.hpp"
@@ -51,6 +52,8 @@ struct BufferView {
   void set_ipc_handles(transport::MemoryBackendKind backend,
                        const uint8_t* payload_bytes, std::size_t payload_size,
                        const transport::EventHandlePayload& evt) noexcept;
+  void set_imported_resource(
+      std::shared_ptr<const backend::ImportedMemory> resource) noexcept;
   const transport::MemoryHandlePayload& mem_payload() const noexcept {
     return mem_payload_;
   }
@@ -61,6 +64,7 @@ struct BufferView {
   bool handles_ready() const noexcept { return handles_ready_; }
 
  private:
+  std::shared_ptr<const backend::ImportedMemory> imported_resource_;
   transport::MemoryHandlePayload mem_payload_{};
   transport::EventHandlePayload event_handle_{};
   transport::MemoryBackendKind backend_ =

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view.hpp
@@ -19,8 +19,6 @@
 namespace ros2_cuda_ipc_core::subscriber {
 
 struct BufferView {
-  void* dev_ptr = nullptr;
-  CUevent ready_evt = nullptr;
   std::shared_ptr<detail::CudaDeviceContext> context;
   int device_id = 0;
   uint64_t byte_size = 0;
@@ -39,10 +37,18 @@ struct BufferView {
 
   template <class T = void>
   T* data() const noexcept {
-    return static_cast<T*>(dev_ptr);
+    return static_cast<T*>(device_ptr());
   }
 
-  bool valid() const noexcept { return dev_ptr != nullptr; }
+  void* device_ptr() const noexcept {
+    return imported_resource_ ? imported_resource_->dev_ptr : nullptr;
+  }
+
+  CUevent ready_event() const noexcept {
+    return imported_resource_ ? imported_resource_->event : nullptr;
+  }
+
+  bool valid() const noexcept { return device_ptr() != nullptr; }
 
   detail::CudaResult<void> enqueue_ready_event(
       cudaStream_t stream) const noexcept;
@@ -53,7 +59,7 @@ struct BufferView {
                        const uint8_t* payload_bytes, std::size_t payload_size,
                        const transport::EventHandlePayload& evt) noexcept;
   void set_imported_resource(
-      std::shared_ptr<const backend::ImportedMemory> resource) noexcept;
+      std::shared_ptr<const backend::ImportedResources> resource) noexcept;
   const transport::MemoryHandlePayload& mem_payload() const noexcept {
     return mem_payload_;
   }
@@ -64,7 +70,7 @@ struct BufferView {
   bool handles_ready() const noexcept { return handles_ready_; }
 
  private:
-  std::shared_ptr<const backend::ImportedMemory> imported_resource_;
+  std::shared_ptr<const backend::ImportedResources> imported_resource_;
   transport::MemoryHandlePayload mem_payload_{};
   transport::EventHandlePayload event_handle_{};
   transport::MemoryBackendKind backend_ =

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp
@@ -37,6 +37,10 @@ struct IpcHandleKeyHash {
 
 class IpcHandleCache {
  public:
+  // The callback is copied into each Entry's shared_ptr deleter.  It may run
+  // after this cache instance has been destroyed, so callers must provide a
+  // self-contained callback and must not capture references to the cache or
+  // other state with a shorter lifetime than the returned Entry.
   using ReleaseFn = std::function<void(const backend::ImportedResources&)>;
   using Entry = std::shared_ptr<const backend::ImportedResources>;
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp
@@ -7,9 +7,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <unordered_map>
+#include <utility>
 
 #include "ros2_cuda_ipc_core/backend/memory_importer.hpp"
 #include "ros2_cuda_ipc_core/publisher_instance_id.hpp"
@@ -35,11 +37,11 @@ struct IpcHandleKeyHash {
 
 class IpcHandleCache {
  public:
-  using ReleaseFn = std::function<void(const backend::ImportedMemory&)>;
-  using Entry = std::shared_ptr<const backend::ImportedMemory>;
+  using ReleaseFn = std::function<void(const backend::ImportedResources&)>;
+  using Entry = std::shared_ptr<const backend::ImportedResources>;
 
   explicit IpcHandleCache(
-      ReleaseFn release_fn = backend::release_imported_memory);
+      ReleaseFn release_fn = backend::release_imported_resources_best_effort);
 
   ~IpcHandleCache();
 
@@ -48,17 +50,25 @@ class IpcHandleCache {
   Entry find(const IpcHandleKey& key) const;
 
   Entry insert_or_discard_duplicate(const IpcHandleKey& key,
-                                    backend::ImportedMemory imported);
+                                    backend::ImportedResources imported);
 
-  /// Release all cache-owned imported resources after detaching the map.
+  /// Remove all cached references without affecting resources held by views.
   void clear();
 
   std::size_t size() const;
 
  private:
+  using CachedEntry = std::weak_ptr<const backend::ImportedResources>;
+
+  void prune_expired_locked() const;
+
   ReleaseFn release_fn_;
   mutable std::mutex mutex_;
-  std::unordered_map<IpcHandleKey, Entry, IpcHandleKeyHash> cache_;
+  // The cache indexes resources but does not own them.  BufferView (or
+  // another active consumer) is the owner that keeps an imported resource
+  // alive; an expired entry is re-imported on the next lookup.
+  mutable std::unordered_map<IpcHandleKey, CachedEntry, IpcHandleKeyHash>
+      cache_;
 };
 
 }  // namespace ros2_cuda_ipc_core::subscriber

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp
@@ -36,6 +36,7 @@ struct IpcHandleKeyHash {
 class IpcHandleCache {
  public:
   using ReleaseFn = std::function<void(const backend::ImportedMemory&)>;
+  using Entry = std::shared_ptr<const backend::ImportedMemory>;
 
   explicit IpcHandleCache(
       ReleaseFn release_fn = backend::release_imported_memory);
@@ -44,10 +45,10 @@ class IpcHandleCache {
 
   static IpcHandleCache& instance();
 
-  std::optional<backend::ImportedMemory> find(const IpcHandleKey& key) const;
+  Entry find(const IpcHandleKey& key) const;
 
-  backend::ImportedMemory insert_or_discard_duplicate(
-      const IpcHandleKey& key, backend::ImportedMemory imported);
+  Entry insert_or_discard_duplicate(const IpcHandleKey& key,
+                                    backend::ImportedMemory imported);
 
   /// Release all cache-owned imported resources after detaching the map.
   void clear();
@@ -57,8 +58,7 @@ class IpcHandleCache {
  private:
   ReleaseFn release_fn_;
   mutable std::mutex mutex_;
-  std::unordered_map<IpcHandleKey, backend::ImportedMemory, IpcHandleKeyHash>
-      cache_;
+  std::unordered_map<IpcHandleKey, Entry, IpcHandleKeyHash> cache_;
 };
 
 }  // namespace ros2_cuda_ipc_core::subscriber

--- a/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_importer.cpp
@@ -23,7 +23,7 @@ CUipcMemHandle to_cuda_mem_handle(
 
 }  // namespace
 
-std::optional<ImportedMemory> MemoryImporter::import(
+std::optional<ImportedResources> MemoryImporter::import(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
     const CUipcEventHandle& event_handle, const rclcpp::Logger& logger) const {
   auto context_result = detail::CudaDeviceContext::retain_primary(
@@ -42,7 +42,7 @@ std::optional<ImportedMemory> MemoryImporter::import(
   }
   auto guard = std::move(guard_result).value();
 
-  ImportedMemory imported;
+  ImportedResources imported;
   imported.context = context;
 
   CUresult result = cuIpcOpenEventHandle(&imported.event, event_handle);

--- a/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
@@ -30,20 +30,27 @@ bool release_imported_resources(const ImportedResources& imported) noexcept {
   }
   guard.emplace(std::move(guard_result).value());
   bool success = true;
+  const auto logger = rclcpp::get_logger("ros2_cuda_ipc_core.memory_importer");
+  const auto report_cleanup_failure = [&success, &logger](const char* operation,
+                                                          CUresult result) {
+    if (result == CUDA_SUCCESS) {
+      return;
+    }
+    success = false;
+    RCLCPP_ERROR(logger, "%s failed during imported resource cleanup: %s",
+                 operation,
+                 detail::CudaDriverError(result).to_string().c_str());
+  };
   if (imported.vmm_address != 0 && imported.allocation_size != 0) {
-    if (cuMemUnmap(imported.vmm_address, imported.allocation_size) !=
-        CUDA_SUCCESS) {
-      success = false;
-    }
-    if (cuMemAddressFree(imported.vmm_address, imported.allocation_size) !=
-        CUDA_SUCCESS) {
-      success = false;
-    }
+    report_cleanup_failure("cuMemUnmap", cuMemUnmap(imported.vmm_address,
+                                                    imported.allocation_size));
+    report_cleanup_failure(
+        "cuMemAddressFree",
+        cuMemAddressFree(imported.vmm_address, imported.allocation_size));
   }
   if (imported.vmm_allocation != 0) {
-    if (cuMemRelease(imported.vmm_allocation) != CUDA_SUCCESS) {
-      success = false;
-    }
+    report_cleanup_failure("cuMemRelease",
+                           cuMemRelease(imported.vmm_allocation));
   }
   if (imported.vmm_address == 0 && imported.dev_ptr != nullptr) {
     const CUdeviceptr device_ptr =
@@ -51,7 +58,7 @@ bool release_imported_resources(const ImportedResources& imported) noexcept {
     const CUresult result = cuIpcCloseMemHandle(device_ptr);
     if (result != CUDA_SUCCESS) {
       success = false;
-      RCLCPP_ERROR(rclcpp::get_logger("ros2_cuda_ipc_core.memory_importer"),
+      RCLCPP_ERROR(logger,
                    "cuIpcCloseMemHandle failed during imported resource "
                    "cleanup: %s",
                    detail::CudaDriverError(result).to_string().c_str());
@@ -61,7 +68,7 @@ bool release_imported_resources(const ImportedResources& imported) noexcept {
     const CUresult result = cuEventDestroy(imported.event);
     if (result != CUDA_SUCCESS) {
       success = false;
-      RCLCPP_ERROR(rclcpp::get_logger("ros2_cuda_ipc_core.memory_importer"),
+      RCLCPP_ERROR(logger,
                    "cuEventDestroy failed during imported resource cleanup: %s",
                    detail::CudaDriverError(result).to_string().c_str());
     }

--- a/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
@@ -12,12 +12,12 @@
 
 namespace ros2_cuda_ipc_core::backend {
 
-void release_imported_memory(const ImportedMemory& imported) noexcept {
+bool release_imported_memory(const ImportedMemory& imported) noexcept {
   // Imported resources created by the Driver-backed importers always carry
   // the context that owns them.  A missing context denotes a non-owning test
   // or inspection value; do not issue CUDA cleanup calls for such a value.
   if (!imported.context) {
-    return;
+    return true;
   }
   std::optional<detail::CudaContextGuard> guard;
   auto guard_result = imported.context->push_current();
@@ -26,21 +26,31 @@ void release_imported_memory(const ImportedMemory& imported) noexcept {
         rclcpp::get_logger("ros2_cuda_ipc_core.memory_importer"),
         "Failed to activate CUDA context for imported resource cleanup: %s",
         guard_result.error().to_string().c_str());
-    return;
+    return false;
   }
   guard.emplace(std::move(guard_result).value());
+  bool success = true;
   if (imported.vmm_address != 0 && imported.allocation_size != 0) {
-    cuMemUnmap(imported.vmm_address, imported.allocation_size);
-    cuMemAddressFree(imported.vmm_address, imported.allocation_size);
+    if (cuMemUnmap(imported.vmm_address, imported.allocation_size) !=
+        CUDA_SUCCESS) {
+      success = false;
+    }
+    if (cuMemAddressFree(imported.vmm_address, imported.allocation_size) !=
+        CUDA_SUCCESS) {
+      success = false;
+    }
   }
   if (imported.vmm_allocation != 0) {
-    cuMemRelease(imported.vmm_allocation);
+    if (cuMemRelease(imported.vmm_allocation) != CUDA_SUCCESS) {
+      success = false;
+    }
   }
   if (imported.vmm_address == 0 && imported.dev_ptr != nullptr) {
     const CUdeviceptr device_ptr =
         static_cast<CUdeviceptr>(reinterpret_cast<uintptr_t>(imported.dev_ptr));
     const CUresult result = cuIpcCloseMemHandle(device_ptr);
     if (result != CUDA_SUCCESS) {
+      success = false;
       RCLCPP_ERROR(rclcpp::get_logger("ros2_cuda_ipc_core.memory_importer"),
                    "cuIpcCloseMemHandle failed during imported resource "
                    "cleanup: %s",
@@ -50,11 +60,13 @@ void release_imported_memory(const ImportedMemory& imported) noexcept {
   if (imported.event != nullptr) {
     const CUresult result = cuEventDestroy(imported.event);
     if (result != CUDA_SUCCESS) {
+      success = false;
       RCLCPP_ERROR(rclcpp::get_logger("ros2_cuda_ipc_core.memory_importer"),
                    "cuEventDestroy failed during imported resource cleanup: %s",
                    detail::CudaDriverError(result).to_string().c_str());
     }
   }
+  return success;
 }
 
 const MemoryImporter& get_memory_importer(uint8_t backend) {

--- a/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
@@ -12,7 +12,7 @@
 
 namespace ros2_cuda_ipc_core::backend {
 
-bool release_imported_memory(const ImportedMemory& imported) noexcept {
+bool release_imported_resources(const ImportedResources& imported) noexcept {
   // Imported resources created by the Driver-backed importers always carry
   // the context that owns them.  A missing context denotes a non-owning test
   // or inspection value; do not issue CUDA cleanup calls for such a value.

--- a/ros2_cuda_ipc_core/src/backend/vmm_fd/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/vmm_fd/memory_importer.cpp
@@ -114,7 +114,7 @@ std::optional<int> request_fd_from_publisher(const std::string& path,
 
 }  // namespace
 
-std::optional<ImportedMemory> MemoryImporter::import(
+std::optional<ImportedResources> MemoryImporter::import(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
     const CUipcEventHandle& event_handle, const rclcpp::Logger& logger) const {
   const auto meta = parse_vmm_payload(msg.mem_handle, logger);
@@ -152,7 +152,7 @@ std::optional<ImportedMemory> MemoryImporter::import(
   }
   auto guard = std::move(guard_result).value();
 
-  ImportedMemory imported;
+  ImportedResources imported;
   imported.context = context;
 
   void* os_handle =

--- a/ros2_cuda_ipc_core/src/detail/interprocess_event.cpp
+++ b/ros2_cuda_ipc_core/src/detail/interprocess_event.cpp
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#include "ros2_cuda_ipc_core/detail/interprocess_event.hpp"
+
+#include <cstring>
+#include <utility>
+
+#include "rclcpp/logging.hpp"
+
+namespace ros2_cuda_ipc_core::detail {
+
+InterprocessEvent::InterprocessEvent(
+    std::shared_ptr<CudaDeviceContext> context, CUevent event,
+    transport::EventHandlePayload ipc_handle) noexcept
+    : context_(std::move(context)),
+      event_(event),
+      ipc_handle_(std::move(ipc_handle)) {}
+
+InterprocessEvent::InterprocessEvent(InterprocessEvent&& other) noexcept
+    : context_(std::move(other.context_)),
+      event_(other.event_),
+      ipc_handle_(other.ipc_handle_) {
+  other.event_ = nullptr;
+  other.ipc_handle_.fill(0);
+}
+
+InterprocessEvent::~InterprocessEvent() noexcept { reset_noexcept(); }
+
+CudaResult<std::unique_ptr<InterprocessEvent>> InterprocessEvent::create(
+    std::shared_ptr<CudaDeviceContext> context) {
+  if (!context) {
+    return CudaResult<std::unique_ptr<InterprocessEvent>>::failure(
+        CudaDriverError(CUDA_ERROR_INVALID_CONTEXT));
+  }
+  auto guard_result = context->push_current();
+  if (!guard_result) {
+    return CudaResult<std::unique_ptr<InterprocessEvent>>::failure(
+        guard_result.error());
+  }
+  auto guard = std::move(guard_result).value();
+
+  CUevent event = nullptr;
+  CUresult result =
+      cuEventCreate(&event, CU_EVENT_DISABLE_TIMING | CU_EVENT_INTERPROCESS);
+  if (result != CUDA_SUCCESS) {
+    return CudaResult<std::unique_ptr<InterprocessEvent>>::failure(
+        CudaDriverError(result));
+  }
+
+  CUipcEventHandle event_handle{};
+  result = cuIpcGetEventHandle(&event_handle, event);
+  if (result != CUDA_SUCCESS) {
+    (void)cuEventDestroy(event);
+    return CudaResult<std::unique_ptr<InterprocessEvent>>::failure(
+        CudaDriverError(result));
+  }
+
+  transport::EventHandlePayload payload{};
+  static_assert(sizeof(event_handle) == sizeof(payload),
+                "CUDA IPC event handle payload size changed");
+  std::memcpy(payload.data(), &event_handle, sizeof(event_handle));
+
+  InterprocessEvent resource(std::move(context), event, payload);
+  return CudaResult<std::unique_ptr<InterprocessEvent>>::success(
+      std::unique_ptr<InterprocessEvent>(
+          new InterprocessEvent(std::move(resource))));
+}
+
+CudaResult<void> InterprocessEvent::record(CUstream stream) const noexcept {
+  if (!context_ || event_ == nullptr) {
+    return CudaResult<void>::failure(
+        CudaDriverError(CUDA_ERROR_INVALID_HANDLE));
+  }
+  auto guard_result = context_->push_current();
+  if (!guard_result) {
+    return CudaResult<void>::failure(guard_result.error());
+  }
+  auto guard = std::move(guard_result).value();
+  const CUresult result = cuEventRecord(event_, stream);
+  if (result != CUDA_SUCCESS) {
+    return CudaResult<void>::failure(CudaDriverError(result));
+  }
+  return CudaResult<void>::success();
+}
+
+void InterprocessEvent::reset_noexcept() noexcept {
+  if (event_ == nullptr) {
+    return;
+  }
+  try {
+    if (!context_) {
+      RCLCPP_ERROR(
+          rclcpp::get_logger("ros2_cuda_ipc_core.interprocess_event"),
+          "Cannot destroy interprocess event without its CUDA context");
+      event_ = nullptr;
+      return;
+    }
+    auto guard_result = context_->push_current();
+    if (!guard_result) {
+      RCLCPP_ERROR(rclcpp::get_logger("ros2_cuda_ipc_core.interprocess_event"),
+                   "Failed to activate CUDA context for event cleanup: %s",
+                   guard_result.error().to_string().c_str());
+      event_ = nullptr;
+      return;
+    }
+    auto guard = std::move(guard_result).value();
+    const CUresult result = cuEventDestroy(event_);
+    if (result != CUDA_SUCCESS) {
+      RCLCPP_ERROR(rclcpp::get_logger("ros2_cuda_ipc_core.interprocess_event"),
+                   "cuEventDestroy failed: %s",
+                   CudaDriverError(result).to_string().c_str());
+    }
+  } catch (...) {
+    // Destruction and error reporting must not escape a noexcept boundary.
+  }
+  event_ = nullptr;
+  ipc_handle_.fill(0);
+}
+
+}  // namespace ros2_cuda_ipc_core::detail

--- a/ros2_cuda_ipc_core/src/detail/interprocess_event.cpp
+++ b/ros2_cuda_ipc_core/src/detail/interprocess_event.cpp
@@ -17,14 +17,6 @@ InterprocessEvent::InterprocessEvent(
       event_(event),
       ipc_handle_(std::move(ipc_handle)) {}
 
-InterprocessEvent::InterprocessEvent(InterprocessEvent&& other) noexcept
-    : context_(std::move(other.context_)),
-      event_(other.event_),
-      ipc_handle_(other.ipc_handle_) {
-  other.event_ = nullptr;
-  other.ipc_handle_.fill(0);
-}
-
 InterprocessEvent::~InterprocessEvent() noexcept { reset_noexcept(); }
 
 CudaResult<std::unique_ptr<InterprocessEvent>> InterprocessEvent::create(
@@ -61,10 +53,16 @@ CudaResult<std::unique_ptr<InterprocessEvent>> InterprocessEvent::create(
                 "CUDA IPC event handle payload size changed");
   std::memcpy(payload.data(), &event_handle, sizeof(event_handle));
 
-  InterprocessEvent resource(std::move(context), event, payload);
-  return CudaResult<std::unique_ptr<InterprocessEvent>>::success(
-      std::unique_ptr<InterprocessEvent>(
-          new InterprocessEvent(std::move(resource))));
+  try {
+    return CudaResult<std::unique_ptr<InterprocessEvent>>::success(
+        std::unique_ptr<InterprocessEvent>(
+            new InterprocessEvent(std::move(context), event, payload)));
+  } catch (...) {
+    // The context guard is still active here, so the event can be cleaned up
+    // if allocation of the owning object fails.
+    (void)cuEventDestroy(event);
+    throw;
+  }
 }
 
 CudaResult<void> InterprocessEvent::record(CUstream stream) const noexcept {

--- a/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
@@ -160,7 +160,7 @@ detail::CudaResult<void> GpuBufferManager::record_ready(
 std::optional<transport::BufferDescriptor> GpuBufferManager::descriptor(
     const LeaseManager::Reservation& reservation) const {
   const auto* resources = buffer_pool_.resources(reservation.slot_id);
-  if (resources == nullptr) {
+  if (resources == nullptr || !resources->ready_event) {
     return std::nullopt;
   }
   if (reservation.shm_name != lease_manager_.shm_name() ||
@@ -177,7 +177,7 @@ std::optional<transport::BufferDescriptor> GpuBufferManager::descriptor(
   result.byte_size = config_.byte_size;
   result.backend = resources->backend;
   result.memory_handle = resources->mem_handle;
-  result.ready_event_handle = resources->event_handle;
+  result.ready_event_handle = resources->ready_event->ipc_handle();
   return result;
 }
 

--- a/ros2_cuda_ipc_core/src/publisher/gpu_buffer_pool.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/gpu_buffer_pool.cpp
@@ -3,7 +3,6 @@
 
 #include "ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp"
 
-#include <cstring>
 #include <optional>
 
 #include "rclcpp/logging.hpp"
@@ -57,7 +56,8 @@ bool GpuBufferPool::initialise(uint64_t byte_size, int device_index) {
   context_ = std::move(context_result).value();
   byte_size_ = byte_size;
   device_index_ = device_index;
-  slots_.assign(slot_count_, {});
+  slots_.clear();
+  slots_.resize(slot_count_);
   for (std::size_t i = 0; i < slots_.size(); ++i) {
     slots_[i].index = static_cast<uint32_t>(i);
   }
@@ -85,24 +85,11 @@ void* GpuBufferPool::device_ptr(uint32_t slot_id) const noexcept {
 detail::CudaResult<void> GpuBufferPool::record_ready(
     uint32_t slot_id, cudaStream_t stream) noexcept {
   const auto* slot = resources(slot_id);
-  if (!initialised_ || slot == nullptr || slot->event == nullptr) {
+  if (!initialised_ || slot == nullptr || !slot->ready_event) {
     return detail::CudaResult<void>::failure(
         detail::CudaDriverError(CUDA_ERROR_INVALID_HANDLE));
   }
-  if (!context_) {
-    return detail::CudaResult<void>::failure(
-        detail::CudaDriverError(CUDA_ERROR_INVALID_CONTEXT));
-  }
-  auto guard_result = context_->push_current();
-  if (!guard_result) {
-    return detail::CudaResult<void>::failure(guard_result.error());
-  }
-  auto guard = std::move(guard_result).value();
-  const CUresult result = cuEventRecord(slot->event, stream);
-  if (result != CUDA_SUCCESS) {
-    return detail::CudaResult<void>::failure(detail::CudaDriverError(result));
-  }
-  return detail::CudaResult<void>::success();
+  return slot->ready_event->record(stream);
 }
 
 const GpuBufferPool::SlotResources* GpuBufferPool::resources(
@@ -139,37 +126,22 @@ bool GpuBufferPool::allocate_slots() {
       return false;
     }
   }
-  auto guard_result = context_->push_current();
-  if (!guard_result) {
-    RCLCPP_ERROR(logger_, "Failed to activate CUDA context: %s",
-                 guard_result.error().to_string().c_str());
-    return false;
-  }
-  auto guard = std::move(guard_result).value();
   for (auto& slot : slots_) {
-    CUresult result = cuEventCreate(
-        &slot.event, CU_EVENT_DISABLE_TIMING | CU_EVENT_INTERPROCESS);
-    if (result != CUDA_SUCCESS) {
-      RCLCPP_ERROR(logger_, "cuEventCreate failed: %s",
-                   detail::CudaDriverError(result).to_string().c_str());
+    auto event_result = detail::InterprocessEvent::create(context_);
+    if (!event_result) {
+      RCLCPP_ERROR(logger_, "Failed to create interprocess event: %s",
+                   event_result.error().to_string().c_str());
       return false;
     }
-    CUipcEventHandle event_handle{};
-    result = cuIpcGetEventHandle(&event_handle, slot.event);
-    if (result != CUDA_SUCCESS) {
-      RCLCPP_ERROR(logger_, "cuIpcGetEventHandle failed: %s",
-                   detail::CudaDriverError(result).to_string().c_str());
-      return false;
-    }
-    static_assert(
-        sizeof(event_handle) == transport::EventHandlePayload{}.size(),
-        "CUDA IPC event handle payload size changed");
-    std::memcpy(slot.event_handle.data(), &event_handle, sizeof(event_handle));
+    slot.ready_event = std::move(event_result).value();
   }
   return true;
 }
 
 void GpuBufferPool::destroy_slots() noexcept {
+  for (auto& slot : slots_) {
+    slot.ready_event.reset();
+  }
   std::optional<detail::CudaContextGuard> guard;
   if (context_) {
     auto guard_result = context_->push_current();
@@ -179,17 +151,6 @@ void GpuBufferPool::destroy_slots() noexcept {
                    guard_result.error().to_string().c_str());
     } else {
       guard.emplace(std::move(guard_result).value());
-      for (auto& slot : slots_) {
-        if (slot.event != nullptr) {
-          const CUresult result = cuEventDestroy(slot.event);
-          if (result != CUDA_SUCCESS) {
-            RCLCPP_ERROR(logger_, "cuEventDestroy failed for slot %u: %s",
-                         slot.index,
-                         detail::CudaDriverError(result).to_string().c_str());
-          }
-          slot.event = nullptr;
-        }
-      }
     }
   }
   if (memory_backend_) {

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp
@@ -19,8 +19,6 @@ BufferView& BufferView::operator=(const BufferView& other) {
 
   reset();
 
-  dev_ptr = other.dev_ptr;
-  ready_evt = other.ready_evt;
   context = other.context;
   device_id = other.device_id;
   byte_size = other.byte_size;
@@ -49,8 +47,6 @@ BufferView& BufferView::operator=(BufferView&& other) noexcept {
 
   reset();
 
-  dev_ptr = other.dev_ptr;
-  ready_evt = other.ready_evt;
   context = std::move(other.context);
   device_id = other.device_id;
   byte_size = other.byte_size;
@@ -64,8 +60,6 @@ BufferView& BufferView::operator=(BufferView&& other) noexcept {
   event_handle_ = other.event_handle_;
   backend_ = other.backend_;
   handles_ready_ = other.handles_ready_;
-  other.dev_ptr = nullptr;
-  other.ready_evt = nullptr;
   other.byte_size = 0;
   other.slot_id = 0;
   other.generation = 0;
@@ -78,22 +72,25 @@ BufferView& BufferView::operator=(BufferView&& other) noexcept {
 
 detail::CudaResult<void> BufferView::enqueue_ready_event(
     cudaStream_t stream) const noexcept {
-  if (!ready_evt) {
+  const CUevent event = ready_event();
+  if (!event) {
     return detail::CudaResult<void>::success();
   }
-  if (context) {
-    auto guard_result = context->push_current();
+  const auto resource_context =
+      imported_resource_ ? imported_resource_->context : context;
+  if (resource_context) {
+    auto guard_result = resource_context->push_current();
     if (!guard_result) {
       return detail::CudaResult<void>::failure(guard_result.error());
     }
     auto guard = std::move(guard_result).value();
-    const CUresult result = cuStreamWaitEvent(stream, ready_evt, 0);
+    const CUresult result = cuStreamWaitEvent(stream, event, 0);
     if (result != CUDA_SUCCESS) {
       return detail::CudaResult<void>::failure(detail::CudaDriverError(result));
     }
     return detail::CudaResult<void>::success();
   }
-  const CUresult result = cuStreamWaitEvent(stream, ready_evt, 0);
+  const CUresult result = cuStreamWaitEvent(stream, event, 0);
   if (result != CUDA_SUCCESS) {
     return detail::CudaResult<void>::failure(detail::CudaDriverError(result));
   }
@@ -101,10 +98,10 @@ detail::CudaResult<void> BufferView::enqueue_ready_event(
 }
 
 void BufferView::reset() noexcept {
-  dev_ptr = nullptr;
-  ready_evt = nullptr;
   context.reset();
   imported_resource_.reset();
+  mem_payload_.fill(0);
+  event_handle_.fill(0);
   byte_size = 0;
   slot_id = 0;
   generation = 0;
@@ -116,16 +113,12 @@ void BufferView::reset() noexcept {
 }
 
 void BufferView::set_imported_resource(
-    std::shared_ptr<const backend::ImportedMemory> resource) noexcept {
+    std::shared_ptr<const backend::ImportedResources> resource) noexcept {
   imported_resource_ = std::move(resource);
   if (!imported_resource_) {
-    dev_ptr = nullptr;
-    ready_evt = nullptr;
     context.reset();
     return;
   }
-  dev_ptr = imported_resource_->dev_ptr;
-  ready_evt = imported_resource_->event;
   context = imported_resource_->context;
 }
 

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp
@@ -19,7 +19,6 @@ BufferView& BufferView::operator=(const BufferView& other) {
 
   reset();
 
-  context = other.context;
   device_id = other.device_id;
   byte_size = other.byte_size;
   slot_id = other.slot_id;
@@ -47,7 +46,6 @@ BufferView& BufferView::operator=(BufferView&& other) noexcept {
 
   reset();
 
-  context = std::move(other.context);
   device_id = other.device_id;
   byte_size = other.byte_size;
   slot_id = other.slot_id;
@@ -77,7 +75,7 @@ detail::CudaResult<void> BufferView::enqueue_ready_event(
     return detail::CudaResult<void>::success();
   }
   const auto resource_context =
-      imported_resource_ ? imported_resource_->context : context;
+      imported_resource_ ? imported_resource_->context : nullptr;
   if (resource_context) {
     auto guard_result = resource_context->push_current();
     if (!guard_result) {
@@ -98,7 +96,6 @@ detail::CudaResult<void> BufferView::enqueue_ready_event(
 }
 
 void BufferView::reset() noexcept {
-  context.reset();
   imported_resource_.reset();
   mem_payload_.fill(0);
   event_handle_.fill(0);
@@ -115,11 +112,6 @@ void BufferView::reset() noexcept {
 void BufferView::set_imported_resource(
     std::shared_ptr<const backend::ImportedResources> resource) noexcept {
   imported_resource_ = std::move(resource);
-  if (!imported_resource_) {
-    context.reset();
-    return;
-  }
-  context = imported_resource_->context;
 }
 
 void BufferView::set_ipc_handles(

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp
@@ -29,6 +29,7 @@ BufferView& BufferView::operator=(const BufferView& other) {
   shm_name = other.shm_name;
   publisher_instance_id = other.publisher_instance_id;
   lease = other.lease;
+  imported_resource_ = other.imported_resource_;
   mem_payload_ = other.mem_payload_;
   event_handle_ = other.event_handle_;
   backend_ = other.backend_;
@@ -58,6 +59,7 @@ BufferView& BufferView::operator=(BufferView&& other) noexcept {
   shm_name = std::move(other.shm_name);
   publisher_instance_id = other.publisher_instance_id;
   lease = std::move(other.lease);
+  imported_resource_ = std::move(other.imported_resource_);
   mem_payload_ = other.mem_payload_;
   event_handle_ = other.event_handle_;
   backend_ = other.backend_;
@@ -102,6 +104,7 @@ void BufferView::reset() noexcept {
   dev_ptr = nullptr;
   ready_evt = nullptr;
   context.reset();
+  imported_resource_.reset();
   byte_size = 0;
   slot_id = 0;
   generation = 0;
@@ -110,6 +113,20 @@ void BufferView::reset() noexcept {
   handles_ready_ = false;
   backend_ = transport::MemoryBackendKind::CUDA_IPC;
   lease.reset();
+}
+
+void BufferView::set_imported_resource(
+    std::shared_ptr<const backend::ImportedMemory> resource) noexcept {
+  imported_resource_ = std::move(resource);
+  if (!imported_resource_) {
+    dev_ptr = nullptr;
+    ready_evt = nullptr;
+    context.reset();
+    return;
+  }
+  dev_ptr = imported_resource_->dev_ptr;
+  ready_evt = imported_resource_->event;
+  context = imported_resource_->context;
 }
 
 void BufferView::set_ipc_handles(

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
@@ -121,25 +121,20 @@ BufferView BufferViewMapper::map(
   key.mem = msg.mem_handle;
   std::memcpy(key.event.data(), msg.event_handle.data(), key.event.size());
 
-  backend::ImportedMemory imported;
-  auto cached = IpcHandleCache::instance().find(key);
-  if (cached.has_value()) {
-    imported = *cached;
-  } else {
+  auto imported = IpcHandleCache::instance().find(key);
+  if (!imported) {
     const auto& importer =
         backend::get_memory_importer(static_cast<uint8_t>(msg.backend));
     auto opened = importer.import(msg, event_handle, options_.logger);
     if (!opened.has_value()) {
       return {};
     }
-    imported =
-        IpcHandleCache::instance().insert_or_discard_duplicate(key, *opened);
+    imported = IpcHandleCache::instance().insert_or_discard_duplicate(
+        key, std::move(*opened));
   }
 
   BufferView view;
-  view.dev_ptr = imported.dev_ptr;
-  view.ready_evt = imported.event;
-  view.context = imported.context;
+  view.set_imported_resource(imported);
   view.device_id = static_cast<int>(msg.device_id);
   view.byte_size = msg.byte_size;
   view.slot_id = msg.slot_id;

--- a/ros2_cuda_ipc_core/src/subscriber/ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/ipc_handle_cache.cpp
@@ -73,7 +73,12 @@ IpcHandleCache::Entry IpcHandleCache::insert_or_discard_duplicate(
     // caller-provided value.  Once the resource exists, its local guard has
     // already performed the release while unwinding.
     if (!resource_constructed) {
-      release_fn_(imported);
+      try {
+        release_fn_(imported);
+      } catch (...) {
+        // Preserve the original allocation/construction exception.  Cleanup
+        // callbacks are best-effort and must not terminate stack unwinding.
+      }
     }
     throw;
   }

--- a/ros2_cuda_ipc_core/src/subscriber/ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/ipc_handle_cache.cpp
@@ -3,6 +3,8 @@
 
 #include "ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp"
 
+#include <memory>
+
 namespace ros2_cuda_ipc_core::subscriber {
 
 std::size_t IpcHandleKeyHash::operator()(
@@ -37,16 +39,21 @@ IpcHandleCache::Entry IpcHandleCache::find(const IpcHandleKey& key) const {
   if (it == cache_.end()) {
     return {};
   }
-  return it->second;
+  auto resource = it->second.lock();
+  if (!resource) {
+    cache_.erase(it);
+  }
+  return resource;
 }
 
 IpcHandleCache::Entry IpcHandleCache::insert_or_discard_duplicate(
-    const IpcHandleKey& key, backend::ImportedMemory imported) {
+    const IpcHandleKey& key, backend::ImportedResources imported) {
   Entry candidate;
+  bool resource_constructed = false;
   try {
     ReleaseFn release = release_fn_;
     auto deleter = [release = std::move(release)](
-                       const backend::ImportedMemory* resource) noexcept {
+                       const backend::ImportedResources* resource) noexcept {
       try {
         release(*resource);
       } catch (...) {
@@ -54,38 +61,65 @@ IpcHandleCache::Entry IpcHandleCache::insert_or_discard_duplicate(
       }
       delete resource;
     };
-    auto* resource = new backend::ImportedMemory(std::move(imported));
-    candidate = Entry(resource, std::move(deleter));
+    using OwnedResource =
+        std::unique_ptr<backend::ImportedResources, decltype(deleter)>;
+    OwnedResource resource(new backend::ImportedResources(std::move(imported)),
+                           deleter);
+    resource_constructed = true;
+    candidate = Entry(resource.get(), deleter);
+    resource.release();
   } catch (...) {
-    // Ownership was not transferred when resource construction failed.
-    // After a successful move, imported is empty and this is a no-op.
-    release_fn_(imported);
+    // If allocation failed before the resource took ownership, release the
+    // caller-provided value.  Once the resource exists, its local guard has
+    // already performed the release while unwinding.
+    if (!resource_constructed) {
+      release_fn_(imported);
+    }
     throw;
   }
 
   Entry result;
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    auto [it, inserted] = cache_.emplace(key, candidate);
-    result = it->second;
+    auto it = cache_.find(key);
+    if (it != cache_.end()) {
+      result = it->second.lock();
+      if (result) {
+        // Keep the first successfully imported resource for this key.  The
+        // candidate is released after the lock is dropped.
+      } else {
+        it->second = candidate;
+        result = candidate;
+      }
+    } else {
+      cache_.emplace(key, candidate);
+      result = candidate;
+    }
   }
-  // A duplicate candidate is released here, after dropping the cache lock.
+  // A duplicate candidate is released here, after dropping the cache lock;
+  // for a new key this is only the local shared_ptr copy.
   return result;
 }
 
 void IpcHandleCache::clear() {
-  decltype(cache_) entries;
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    entries.swap(cache_);
-  }
-  // Dropping cache ownership does not invalidate entries still held by views.
-  entries.clear();
+  std::lock_guard<std::mutex> lock(mutex_);
+  cache_.clear();
 }
 
 std::size_t IpcHandleCache::size() const {
   std::lock_guard<std::mutex> lock(mutex_);
+  prune_expired_locked();
   return cache_.size();
+}
+
+void IpcHandleCache::prune_expired_locked() const {
+  for (auto it = cache_.begin(); it != cache_.end();) {
+    if (it->second.expired()) {
+      it = cache_.erase(it);
+    } else {
+      ++it;
+    }
+  }
 }
 
 }  // namespace ros2_cuda_ipc_core::subscriber

--- a/ros2_cuda_ipc_core/src/subscriber/ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/ipc_handle_cache.cpp
@@ -31,25 +31,46 @@ IpcHandleCache& IpcHandleCache::instance() {
   return cache;
 }
 
-std::optional<backend::ImportedMemory> IpcHandleCache::find(
-    const IpcHandleKey& key) const {
+IpcHandleCache::Entry IpcHandleCache::find(const IpcHandleKey& key) const {
   std::lock_guard<std::mutex> lock(mutex_);
   auto it = cache_.find(key);
   if (it == cache_.end()) {
-    return std::nullopt;
+    return {};
   }
   return it->second;
 }
 
-backend::ImportedMemory IpcHandleCache::insert_or_discard_duplicate(
+IpcHandleCache::Entry IpcHandleCache::insert_or_discard_duplicate(
     const IpcHandleKey& key, backend::ImportedMemory imported) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  auto [it, inserted] = cache_.emplace(key, imported);
-  if (!inserted) {
+  Entry candidate;
+  try {
+    ReleaseFn release = release_fn_;
+    auto deleter = [release = std::move(release)](
+                       const backend::ImportedMemory* resource) noexcept {
+      try {
+        release(*resource);
+      } catch (...) {
+        // shared_ptr deleters must not throw.
+      }
+      delete resource;
+    };
+    auto* resource = new backend::ImportedMemory(std::move(imported));
+    candidate = Entry(resource, std::move(deleter));
+  } catch (...) {
+    // Ownership was not transferred when resource construction failed.
+    // After a successful move, imported is empty and this is a no-op.
     release_fn_(imported);
-    return it->second;
+    throw;
   }
-  return imported;
+
+  Entry result;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto [it, inserted] = cache_.emplace(key, candidate);
+    result = it->second;
+  }
+  // A duplicate candidate is released here, after dropping the cache lock.
+  return result;
 }
 
 void IpcHandleCache::clear() {
@@ -58,13 +79,8 @@ void IpcHandleCache::clear() {
     std::lock_guard<std::mutex> lock(mutex_);
     entries.swap(cache_);
   }
-  for (const auto& entry : entries) {
-    try {
-      release_fn_(entry.second);
-    } catch (...) {
-      // Best-effort cleanup; keep cache clear/destruction noexcept.
-    }
-  }
+  // Dropping cache ownership does not invalidate entries still held by views.
+  entries.clear();
 }
 
 std::size_t IpcHandleCache::size() const {

--- a/ros2_cuda_ipc_core/test/cuda_ipc_import_helper.cpp
+++ b/ros2_cuda_ipc_core/test/cuda_ipc_import_helper.cpp
@@ -75,29 +75,30 @@ int main(int argc, char** argv) {
   {
     auto guard_result = imported->context->push_current();
     if (!guard_result) {
-      ros2_cuda_ipc_core::backend::release_imported_memory(*imported);
+      ros2_cuda_ipc_core::backend::release_imported_resources(*imported);
       return 6;
     }
     auto guard = std::move(guard_result).value();
     if (cuEventSynchronize(imported->event) != CUDA_SUCCESS) {
-      ros2_cuda_ipc_core::backend::release_imported_memory(*imported);
+      ros2_cuda_ipc_core::backend::release_imported_resources(*imported);
       return 7;
     }
     std::vector<uint8_t> host(payload.byte_size);
     const auto device_ptr = static_cast<CUdeviceptr>(
         reinterpret_cast<uintptr_t>(imported->dev_ptr));
     if (cuMemcpyDtoH(host.data(), device_ptr, host.size()) != CUDA_SUCCESS) {
-      ros2_cuda_ipc_core::backend::release_imported_memory(*imported);
+      ros2_cuda_ipc_core::backend::release_imported_resources(*imported);
       return 8;
     }
     for (const uint8_t value : host) {
       if (value != payload.expected_value) {
-        ros2_cuda_ipc_core::backend::release_imported_memory(*imported);
+        ros2_cuda_ipc_core::backend::release_imported_resources(*imported);
         return 9;
       }
     }
   }
 
-  return ros2_cuda_ipc_core::backend::release_imported_memory(*imported) ? 0
-                                                                         : 10;
+  return ros2_cuda_ipc_core::backend::release_imported_resources(*imported)
+             ? 0
+             : 10;
 }

--- a/ros2_cuda_ipc_core/test/cuda_ipc_import_helper.cpp
+++ b/ros2_cuda_ipc_core/test/cuda_ipc_import_helper.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include "cuda_ipc_memory_test_protocol.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp"
+#include "ros2_cuda_ipc_core/backend/memory_importer.hpp"
+#include "ros2_cuda_ipc_msgs/msg/buffer_core.hpp"
+
+namespace {
+
+bool read_all(int fd, void* data, std::size_t size) {
+  auto* bytes = static_cast<unsigned char*>(data);
+  std::size_t offset = 0;
+  while (offset < size) {
+    const ssize_t received = ::read(fd, bytes + offset, size - offset);
+    if (received > 0) {
+      offset += static_cast<std::size_t>(received);
+      continue;
+    }
+    if (received < 0 && errno == EINTR) {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  if (argc != 2) {
+    return 2;
+  }
+  char* end = nullptr;
+  const long parsed_fd = std::strtol(argv[1], &end, 10);
+  if (end == argv[1] || *end != '\0' || parsed_fd < 0) {
+    return 3;
+  }
+  const int read_fd = static_cast<int>(parsed_fd);
+
+  ros2_cuda_ipc_core::test::CudaIpcMemoryTestPayload payload;
+  const bool received = read_all(read_fd, &payload, sizeof(payload));
+  ::close(read_fd);
+  if (!received || payload.byte_size == 0) {
+    return 4;
+  }
+
+  ros2_cuda_ipc_msgs::msg::BufferCore msg;
+  msg.device_id = payload.device_id;
+  msg.byte_size = payload.byte_size;
+  msg.backend = ros2_cuda_ipc_msgs::msg::BufferCore::CUDA_IPC;
+  msg.mem_handle = payload.memory_handle;
+  msg.event_handle = payload.event_handle;
+
+  CUipcEventHandle event_handle{};
+  static_assert(sizeof(event_handle) == sizeof(payload.event_handle));
+  std::memcpy(&event_handle, payload.event_handle.data(), sizeof(event_handle));
+
+  ros2_cuda_ipc_core::backend::cuda_ipc::MemoryImporter importer;
+  auto imported = importer.import(
+      msg, event_handle,
+      rclcpp::get_logger("ros2_cuda_ipc_core.cuda_ipc_import_helper"));
+  if (!imported.has_value()) {
+    return 5;
+  }
+
+  {
+    auto guard_result = imported->context->push_current();
+    if (!guard_result) {
+      ros2_cuda_ipc_core::backend::release_imported_memory(*imported);
+      return 6;
+    }
+    auto guard = std::move(guard_result).value();
+    if (cuEventSynchronize(imported->event) != CUDA_SUCCESS) {
+      ros2_cuda_ipc_core::backend::release_imported_memory(*imported);
+      return 7;
+    }
+    std::vector<uint8_t> host(payload.byte_size);
+    const auto device_ptr = static_cast<CUdeviceptr>(
+        reinterpret_cast<uintptr_t>(imported->dev_ptr));
+    if (cuMemcpyDtoH(host.data(), device_ptr, host.size()) != CUDA_SUCCESS) {
+      ros2_cuda_ipc_core::backend::release_imported_memory(*imported);
+      return 8;
+    }
+    for (const uint8_t value : host) {
+      if (value != payload.expected_value) {
+        ros2_cuda_ipc_core::backend::release_imported_memory(*imported);
+        return 9;
+      }
+    }
+  }
+
+  return ros2_cuda_ipc_core::backend::release_imported_memory(*imported) ? 0
+                                                                         : 10;
+}

--- a/ros2_cuda_ipc_core/test/cuda_ipc_memory_test_protocol.hpp
+++ b/ros2_cuda_ipc_core/test/cuda_ipc_memory_test_protocol.hpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+#include "ros2_cuda_ipc_core/transport/memory_types.hpp"
+
+namespace ros2_cuda_ipc_core::test {
+
+struct CudaIpcMemoryTestPayload {
+  uint32_t device_id = 0;
+  uint64_t byte_size = 0;
+  uint8_t expected_value = 0;
+  transport::MemoryHandlePayload memory_handle{};
+  transport::EventHandlePayload event_handle{};
+};
+
+static_assert(std::is_trivially_copyable_v<CudaIpcMemoryTestPayload>);
+
+}  // namespace ros2_cuda_ipc_core::test

--- a/ros2_cuda_ipc_core/test/test_cuda_ipc_memory_driver.cpp
+++ b/ros2_cuda_ipc_core/test/test_cuda_ipc_memory_driver.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#include <gtest/gtest.h>
+#include <spawn.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include "cuda_ipc_memory_test_protocol.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "ros2_cuda_ipc_core/detail/cuda_driver_context.hpp"
+#include "ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp"
+
+#ifndef CUDA_IPC_IMPORT_HELPER_PATH
+#error "CUDA_IPC_IMPORT_HELPER_PATH is not defined"
+#endif
+
+extern char** environ;
+
+namespace {
+
+bool write_all(int fd, const void* data, std::size_t size) {
+  const auto* bytes = static_cast<const unsigned char*>(data);
+  std::size_t offset = 0;
+  while (offset < size) {
+    const ssize_t written = ::write(fd, bytes + offset, size - offset);
+    if (written > 0) {
+      offset += static_cast<std::size_t>(written);
+      continue;
+    }
+    if (written < 0 && errno == EINTR) {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+}  // namespace
+
+TEST(CudaIpcMemoryDriverTest, ImportsReadsAndClosesInChildProcess) {
+  using ros2_cuda_ipc_core::detail::CudaDeviceContext;
+  using ros2_cuda_ipc_core::publisher::GpuBufferPool;
+  using ros2_cuda_ipc_core::test::CudaIpcMemoryTestPayload;
+  using ros2_cuda_ipc_core::transport::MemoryBackendKind;
+
+  auto context_result = CudaDeviceContext::retain_primary(0);
+  if (!context_result) {
+    GTEST_SKIP() << "CUDA device not available: "
+                 << context_result.error().to_string();
+  }
+  auto context = std::move(context_result).value();
+
+  constexpr uint64_t kByteSize = 4096;
+  constexpr uint8_t kExpectedValue = 0x5a;
+  GpuBufferPool pool(1, MemoryBackendKind::CUDA_IPC,
+                     rclcpp::get_logger("CudaIpcMemoryDriverTest"));
+  ASSERT_TRUE(pool.initialise(kByteSize, 0));
+  const auto* resources = pool.resources(0);
+  ASSERT_NE(resources, nullptr);
+  ASSERT_NE(pool.device_ptr(0), nullptr);
+
+  {
+    auto guard_result = context->push_current();
+    ASSERT_TRUE(guard_result);
+    auto guard = std::move(guard_result).value();
+    const CUdeviceptr device_ptr = static_cast<CUdeviceptr>(
+        reinterpret_cast<uintptr_t>(pool.device_ptr(0)));
+    ASSERT_EQ(cuMemsetD8(device_ptr, kExpectedValue, kByteSize), CUDA_SUCCESS);
+  }
+  ASSERT_TRUE(pool.record_ready(0, nullptr));
+
+  CudaIpcMemoryTestPayload payload;
+  payload.device_id = 0;
+  payload.byte_size = kByteSize;
+  payload.expected_value = kExpectedValue;
+  payload.memory_handle = resources->mem_handle;
+  payload.event_handle = resources->ready_event->ipc_handle();
+
+  int payload_pipe[2] = {-1, -1};
+  ASSERT_EQ(::pipe(payload_pipe), 0);
+  const std::string fd_arg = std::to_string(payload_pipe[0]);
+  char* const child_argv[] = {const_cast<char*>(CUDA_IPC_IMPORT_HELPER_PATH),
+                              const_cast<char*>(fd_arg.c_str()), nullptr};
+  posix_spawn_file_actions_t actions;
+  ASSERT_EQ(::posix_spawn_file_actions_init(&actions), 0);
+  ASSERT_EQ(::posix_spawn_file_actions_addclose(&actions, payload_pipe[1]), 0);
+  pid_t child = -1;
+  const int spawn_result =
+      ::posix_spawn(&child, CUDA_IPC_IMPORT_HELPER_PATH, &actions, nullptr,
+                    child_argv, environ);
+  ASSERT_EQ(::posix_spawn_file_actions_destroy(&actions), 0);
+  ASSERT_EQ(spawn_result, 0);
+  ::close(payload_pipe[0]);
+
+  ASSERT_TRUE(write_all(payload_pipe[1], &payload, sizeof(payload)));
+  ::close(payload_pipe[1]);
+
+  int status = 0;
+  ASSERT_EQ(::waitpid(child, &status, 0), child);
+  ASSERT_TRUE(WIFEXITED(status));
+  EXPECT_EQ(WEXITSTATUS(status), 0);
+}

--- a/ros2_cuda_ipc_core/test/test_cuda_ipc_memory_driver.cpp
+++ b/ros2_cuda_ipc_core/test/test_cuda_ipc_memory_driver.cpp
@@ -7,6 +7,7 @@
 #include <unistd.h>
 
 #include <cerrno>
+#include <csignal>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>

--- a/ros2_cuda_ipc_core/test/test_cuda_ipc_memory_driver.cpp
+++ b/ros2_cuda_ipc_core/test/test_cuda_ipc_memory_driver.cpp
@@ -26,6 +26,19 @@ extern char** environ;
 
 namespace {
 
+class ScopedSigpipeIgnore {
+ public:
+  ScopedSigpipeIgnore() : previous_(std::signal(SIGPIPE, SIG_IGN)) {}
+  ~ScopedSigpipeIgnore() { std::signal(SIGPIPE, previous_); }
+
+  ScopedSigpipeIgnore(const ScopedSigpipeIgnore&) = delete;
+  ScopedSigpipeIgnore& operator=(const ScopedSigpipeIgnore&) = delete;
+
+ private:
+  using SignalHandler = void (*)(int);
+  SignalHandler previous_;
+};
+
 bool write_all(int fd, const void* data, std::size_t size) {
   const auto* bytes = static_cast<const unsigned char*>(data);
   std::size_t offset = 0;
@@ -100,10 +113,15 @@ TEST(CudaIpcMemoryDriverTest, ImportsReadsAndClosesInChildProcess) {
   ASSERT_EQ(spawn_result, 0);
   ::close(payload_pipe[0]);
 
-  ASSERT_TRUE(write_all(payload_pipe[1], &payload, sizeof(payload)));
+  bool wrote_payload = false;
+  {
+    ScopedSigpipeIgnore sigpipe_ignore;
+    wrote_payload = write_all(payload_pipe[1], &payload, sizeof(payload));
+  }
   ::close(payload_pipe[1]);
 
   int status = 0;
+  EXPECT_TRUE(wrote_payload);
   ASSERT_EQ(::waitpid(child, &status, 0), child);
   ASSERT_TRUE(WIFEXITED(status));
   EXPECT_EQ(WEXITSTATUS(status), 0);

--- a/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
@@ -5,6 +5,7 @@
 
 #include <atomic>
 
+#include "ros2_cuda_ipc_core/subscriber/buffer_view.hpp"
 #include "ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp"
 #include "test_instance_id.hpp"
 
@@ -53,12 +54,14 @@ TEST(IpcHandleCacheTest, DuplicateInsertReturnsExistingEntry) {
   duplicate.dev_ptr = reinterpret_cast<void*>(0x3030);
   duplicate.event = reinterpret_cast<CUevent>(0x4040);
 
-  auto inserted = cache.insert_or_discard_duplicate(key, first);
-  auto second = cache.insert_or_discard_duplicate(key, duplicate);
+  auto inserted = cache.insert_or_discard_duplicate(key, std::move(first));
+  auto second = cache.insert_or_discard_duplicate(key, std::move(duplicate));
 
-  EXPECT_EQ(inserted.dev_ptr, first.dev_ptr);
-  EXPECT_EQ(second.dev_ptr, first.dev_ptr);
-  EXPECT_EQ(second.event, first.event);
+  ASSERT_TRUE(inserted);
+  ASSERT_TRUE(second);
+  EXPECT_EQ(inserted->dev_ptr, reinterpret_cast<void*>(0x1010));
+  EXPECT_EQ(second->dev_ptr, inserted->dev_ptr);
+  EXPECT_EQ(second->event, inserted->event);
   EXPECT_EQ(cache.size(), 1u);
 }
 
@@ -79,8 +82,8 @@ TEST(IpcHandleCacheTest, DuplicateInsertInvokesReleaseHook) {
   duplicate.dev_ptr = reinterpret_cast<void*>(0x7070);
   duplicate.event = reinterpret_cast<CUevent>(0x8080);
 
-  cache.insert_or_discard_duplicate(key, first);
-  cache.insert_or_discard_duplicate(key, duplicate);
+  cache.insert_or_discard_duplicate(key, std::move(first));
+  cache.insert_or_discard_duplicate(key, std::move(duplicate));
 
   EXPECT_EQ(released.load(), 1);
 }
@@ -92,12 +95,56 @@ TEST(IpcHandleCacheTest, ClearReleasesCacheOwnedResources) {
   subscriber::IpcHandleKey key{};
   backend::ImportedMemory imported;
   imported.dev_ptr = reinterpret_cast<void*>(0x9090);
-  cache.insert_or_discard_duplicate(key, imported);
+  cache.insert_or_discard_duplicate(key, std::move(imported));
 
   cache.clear();
 
   EXPECT_EQ(released.load(), 1);
   EXPECT_EQ(cache.size(), 0u);
+}
+
+TEST(IpcHandleCacheTest, ClearDefersReleaseUntilExternalOwnerIsGone) {
+  std::atomic<int> released{0};
+  subscriber::IpcHandleCache cache(
+      [&released](const backend::ImportedMemory&) { released.fetch_add(1); });
+  subscriber::IpcHandleKey key{};
+  backend::ImportedMemory imported;
+  imported.dev_ptr = reinterpret_cast<void*>(0xa0a0);
+  auto entry = cache.insert_or_discard_duplicate(key, std::move(imported));
+
+  cache.clear();
+
+  EXPECT_EQ(cache.size(), 0u);
+  EXPECT_EQ(released.load(), 0);
+  ASSERT_TRUE(entry);
+  EXPECT_EQ(entry->dev_ptr, reinterpret_cast<void*>(0xa0a0));
+
+  entry.reset();
+  EXPECT_EQ(released.load(), 1);
+}
+
+TEST(IpcHandleCacheTest, BufferViewCopiesShareImportedResourceOwnership) {
+  std::atomic<int> released{0};
+  auto* imported = new backend::ImportedMemory();
+  imported->dev_ptr = reinterpret_cast<void*>(0xb0b0);
+  std::shared_ptr<const backend::ImportedMemory> resource(
+      imported, [&released](const backend::ImportedMemory* value) {
+        released.fetch_add(1);
+        delete value;
+      });
+
+  subscriber::BufferView first;
+  first.set_imported_resource(resource);
+  subscriber::BufferView second = first;
+  resource.reset();
+  first.reset();
+
+  EXPECT_EQ(released.load(), 0);
+  EXPECT_TRUE(second.valid());
+  EXPECT_EQ(second.dev_ptr, reinterpret_cast<void*>(0xb0b0));
+
+  second.reset();
+  EXPECT_EQ(released.load(), 1);
 }
 
 }  // namespace ros2_cuda_ipc_core

--- a/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
@@ -40,17 +40,17 @@ TEST(IpcHandleCacheTest, KeyEqualityAndHashUseInstanceBackendPayloadAndEvent) {
 }
 
 TEST(IpcHandleCacheTest, DuplicateInsertReturnsExistingEntry) {
-  subscriber::IpcHandleCache cache([](const backend::ImportedMemory&) {});
+  subscriber::IpcHandleCache cache([](const backend::ImportedResources&) {});
   subscriber::IpcHandleKey key{};
   key.backend = 1;
   key.mem[0] = 11;
   key.event[0] = 13;
 
-  backend::ImportedMemory first;
+  backend::ImportedResources first;
   first.dev_ptr = reinterpret_cast<void*>(0x1010);
   first.event = reinterpret_cast<CUevent>(0x2020);
 
-  backend::ImportedMemory duplicate;
+  backend::ImportedResources duplicate;
   duplicate.dev_ptr = reinterpret_cast<void*>(0x3030);
   duplicate.event = reinterpret_cast<CUevent>(0x4040);
 
@@ -68,47 +68,59 @@ TEST(IpcHandleCacheTest, DuplicateInsertReturnsExistingEntry) {
 TEST(IpcHandleCacheTest, DuplicateInsertInvokesReleaseHook) {
   std::atomic<int> released{0};
   subscriber::IpcHandleCache cache(
-      [&released](const backend::ImportedMemory&) { released.fetch_add(1); });
+      [&released](const backend::ImportedResources&) {
+        released.fetch_add(1);
+      });
   subscriber::IpcHandleKey key{};
   key.backend = 1;
   key.mem[0] = 17;
   key.event[0] = 19;
 
-  backend::ImportedMemory first;
+  backend::ImportedResources first;
   first.dev_ptr = reinterpret_cast<void*>(0x5050);
   first.event = reinterpret_cast<CUevent>(0x6060);
 
-  backend::ImportedMemory duplicate;
+  backend::ImportedResources duplicate;
   duplicate.dev_ptr = reinterpret_cast<void*>(0x7070);
   duplicate.event = reinterpret_cast<CUevent>(0x8080);
 
-  cache.insert_or_discard_duplicate(key, std::move(first));
-  cache.insert_or_discard_duplicate(key, std::move(duplicate));
+  auto first_entry = cache.insert_or_discard_duplicate(key, std::move(first));
+  auto duplicate_entry =
+      cache.insert_or_discard_duplicate(key, std::move(duplicate));
 
   EXPECT_EQ(released.load(), 1);
+  first_entry.reset();
+  duplicate_entry.reset();
+  EXPECT_EQ(released.load(), 2);
 }
 
-TEST(IpcHandleCacheTest, ClearReleasesCacheOwnedResources) {
+TEST(IpcHandleCacheTest, ClearDoesNotReleaseActiveResources) {
   std::atomic<int> released{0};
   subscriber::IpcHandleCache cache(
-      [&released](const backend::ImportedMemory&) { released.fetch_add(1); });
+      [&released](const backend::ImportedResources&) {
+        released.fetch_add(1);
+      });
   subscriber::IpcHandleKey key{};
-  backend::ImportedMemory imported;
+  backend::ImportedResources imported;
   imported.dev_ptr = reinterpret_cast<void*>(0x9090);
-  cache.insert_or_discard_duplicate(key, std::move(imported));
+  auto entry = cache.insert_or_discard_duplicate(key, std::move(imported));
 
   cache.clear();
 
-  EXPECT_EQ(released.load(), 1);
+  EXPECT_EQ(released.load(), 0);
   EXPECT_EQ(cache.size(), 0u);
+  entry.reset();
+  EXPECT_EQ(released.load(), 1);
 }
 
 TEST(IpcHandleCacheTest, ClearDefersReleaseUntilExternalOwnerIsGone) {
   std::atomic<int> released{0};
   subscriber::IpcHandleCache cache(
-      [&released](const backend::ImportedMemory&) { released.fetch_add(1); });
+      [&released](const backend::ImportedResources&) {
+        released.fetch_add(1);
+      });
   subscriber::IpcHandleKey key{};
-  backend::ImportedMemory imported;
+  backend::ImportedResources imported;
   imported.dev_ptr = reinterpret_cast<void*>(0xa0a0);
   auto entry = cache.insert_or_discard_duplicate(key, std::move(imported));
 
@@ -123,12 +135,29 @@ TEST(IpcHandleCacheTest, ClearDefersReleaseUntilExternalOwnerIsGone) {
   EXPECT_EQ(released.load(), 1);
 }
 
+TEST(IpcHandleCacheTest, ExpiredEntriesArePruned) {
+  std::atomic<int> released{0};
+  subscriber::IpcHandleCache cache(
+      [&released](const backend::ImportedResources&) {
+        released.fetch_add(1);
+      });
+  subscriber::IpcHandleKey key{};
+  backend::ImportedResources imported;
+  imported.dev_ptr = reinterpret_cast<void*>(0xa0a0);
+
+  cache.insert_or_discard_duplicate(key, std::move(imported));
+
+  EXPECT_EQ(released.load(), 1);
+  EXPECT_EQ(cache.find(key), nullptr);
+  EXPECT_EQ(cache.size(), 0u);
+}
+
 TEST(IpcHandleCacheTest, BufferViewCopiesShareImportedResourceOwnership) {
   std::atomic<int> released{0};
-  auto* imported = new backend::ImportedMemory();
+  auto* imported = new backend::ImportedResources();
   imported->dev_ptr = reinterpret_cast<void*>(0xb0b0);
-  std::shared_ptr<const backend::ImportedMemory> resource(
-      imported, [&released](const backend::ImportedMemory* value) {
+  std::shared_ptr<const backend::ImportedResources> resource(
+      imported, [&released](const backend::ImportedResources* value) {
         released.fetch_add(1);
         delete value;
       });
@@ -141,9 +170,33 @@ TEST(IpcHandleCacheTest, BufferViewCopiesShareImportedResourceOwnership) {
 
   EXPECT_EQ(released.load(), 0);
   EXPECT_TRUE(second.valid());
-  EXPECT_EQ(second.dev_ptr, reinterpret_cast<void*>(0xb0b0));
+  EXPECT_EQ(second.device_ptr(), reinterpret_cast<void*>(0xb0b0));
 
   second.reset();
+  EXPECT_EQ(released.load(), 1);
+}
+
+TEST(IpcHandleCacheTest, BufferViewSurvivesCacheClear) {
+  std::atomic<int> released{0};
+  subscriber::IpcHandleCache cache(
+      [&released](const backend::ImportedResources&) {
+        released.fetch_add(1);
+      });
+  subscriber::IpcHandleKey key{};
+  backend::ImportedResources imported;
+  imported.dev_ptr = reinterpret_cast<void*>(0xc0c0);
+
+  auto entry = cache.insert_or_discard_duplicate(key, std::move(imported));
+  subscriber::BufferView view;
+  view.set_imported_resource(entry);
+  entry.reset();
+  cache.clear();
+
+  EXPECT_TRUE(view.valid());
+  EXPECT_EQ(view.device_ptr(), reinterpret_cast<void*>(0xc0c0));
+  EXPECT_EQ(released.load(), 0);
+
+  view.reset();
   EXPECT_EQ(released.load(), 1);
 }
 

--- a/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
+++ b/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_cuda_ipc_core/backend/memory_importer.hpp"
@@ -77,11 +78,15 @@ inline ros2_cuda_ipc_msgs::msg::BufferCore make_cached_buffer_core_message(
 
 inline void seed_cache_for_message(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg, uintptr_t ptr_seed) {
-  backend::ImportedMemory imported;
+  backend::ImportedResources imported;
   imported.dev_ptr = reinterpret_cast<void*>(ptr_seed);
   imported.event = reinterpret_cast<CUevent>(ptr_seed + 1U);
-  subscriber::IpcHandleCache::instance().insert_or_discard_duplicate(
-      make_key(msg), std::move(imported));
+  // The production cache is weakly owned.  Keep this synthetic resource
+  // alive for the mapper test until the test process exits.
+  static std::vector<subscriber::IpcHandleCache::Entry> test_owners;
+  test_owners.push_back(
+      subscriber::IpcHandleCache::instance().insert_or_discard_duplicate(
+          make_key(msg), std::move(imported)));
 }
 
 inline ros2_cuda_ipc_msgs::msg::BufferCore make_seeded_buffer_core_message(

--- a/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
+++ b/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
@@ -81,7 +81,7 @@ inline void seed_cache_for_message(
   imported.dev_ptr = reinterpret_cast<void*>(ptr_seed);
   imported.event = reinterpret_cast<CUevent>(ptr_seed + 1U);
   subscriber::IpcHandleCache::instance().insert_or_discard_duplicate(
-      make_key(msg), imported);
+      make_key(msg), std::move(imported));
 }
 
 inline ros2_cuda_ipc_msgs::msg::BufferCore make_seeded_buffer_core_message(

--- a/ros2_cuda_ipc_core/test/test_ready_event_driver.cpp
+++ b/ros2_cuda_ipc_core/test/test_ready_event_driver.cpp
@@ -5,6 +5,9 @@
 #include <cuda_runtime_api.h>
 #include <gtest/gtest.h>
 
+#include <memory>
+
+#include "ros2_cuda_ipc_core/backend/memory_importer.hpp"
 #include "ros2_cuda_ipc_core/subscriber/buffer_view.hpp"
 
 namespace {
@@ -25,8 +28,11 @@ TEST(ReadyEventDriverTest, DriverWaitAcceptsRuntimeCreatedStream) {
             cudaSuccess);
   ASSERT_EQ(cudaEventRecord(runtime_event, producer), cudaSuccess);
 
+  auto imported =
+      std::make_shared<ros2_cuda_ipc_core::backend::ImportedResources>();
+  imported->event = reinterpret_cast<CUevent>(runtime_event);
   ros2_cuda_ipc_core::subscriber::BufferView view;
-  view.ready_evt = reinterpret_cast<CUevent>(runtime_event);
+  view.set_imported_resource(std::move(imported));
   const auto result = view.enqueue_ready_event(consumer);
   ASSERT_TRUE(result) << result.error().to_string();
   ASSERT_EQ(cudaStreamSynchronize(consumer), cudaSuccess);


### PR DESCRIPTION
## Summary

- imported CUDA IPC/VMM resources を `ImportedResources` bundle として共有所有する
- `IpcHandleCache` を weak index 化し、active `BufferView` の lifetime と resource lifetime を一致させる
- `BufferView` から公開 raw field の `dev_ptr` / `ready_evt` を削除する
- Publisher 側の IPC event を context-aware RAII resource に集約する
- 別processの CUDA Driver API import / wait / validation / close test を追加する

## Design

### Subscriber resource ownership

`ImportedResources` が次のresourceを一つのbundleとして表現します。

- imported memory mappingまたはVMM mapping
- imported ready event
- CUDA device context
- VMM address/allocation state（VMM backendの場合）

`IpcHandleCache` は `weak_ptr` のindexだけを保持し、実体は `BufferView` が `shared_ptr` で保持します。そのため、cacheをclearしてもactive viewは有効で、最後のviewが破棄された時点でimport済みresourceがcleanupされます。期限切れentryは次回lookup時に再importされます。

`BufferView` は `device_ptr()`、`ready_event()`、`data<T>()`、`enqueue_ready_event()` を通じてresourceへアクセスします。resourceのallocation/event stateをpublic raw fieldへ複製しません。

### Publisher event ownership

Publisher側では `InterprocessEvent` が以下を所有します。

- CUDA interprocess eventの生成
- IPC handle export
- event record
- context activation
- event destruction

`GpuBufferPool` のslot resourceがeventを所有し、descriptorは同じslotのevent resourceからIPC handleを取得します。

### Cross-process validation

専用helper processがCUDA Driver APIで次を検証します。

1. exported memory/event handleのimport
2. ready eventのwait
3. device dataの読み出しと内容検証
4. imported memory/eventのclose

## Error handling

- VMM cleanupの `cuMemUnmap`、`cuMemAddressFree`、`cuMemRelease` の失敗を操作名とDriver error付きでログします。
- cache entry生成時のallocation例外経路では、cleanup callbackの例外が元の例外を隠したりterminateさせたりしないようにします。
- cross-process testではSIGPIPEを抑制し、pipe write失敗時もpipe closeとchild waitを実行します。
- `ReleaseFn` がcache本体の破棄後に呼ばれ得ることをheaderに明記しています。

## Validation

- `colcon build --packages-select ros2_cuda_ipc_core --cmake-args -DBUILD_TESTING=ON`
- `colcon test --packages-select ros2_cuda_ipc_core`
- 12 test executables passed
- CUDA multi-device testは利用可能なdevice数不足のためskip
- `git diff --check`
- CUDA IPC memory pathでRuntime APIのmemory/device操作を使用していないことを確認

Review follow-up commit: `811c6f2`
