### PR TITLE
Make ros2_cuda_ipc_core depend on CUDA Driver API only

### DIFF
--- a/examples/multi_process_image_fanout/include/multi_process_image_fanout/cuda_checks.hpp
+++ b/examples/multi_process_image_fanout/include/multi_process_image_fanout/cuda_checks.hpp
@@ -9,11 +9,11 @@
 #include <stdexcept>
 #include <string>
 
-#include "ros2_cuda_ipc_core/detail/cuda_util.hpp"
-
 namespace multi_process_image_fanout {
 
-using ros2_cuda_ipc_core::detail::cuda_error_to_string;
+inline std::string cuda_error_to_string(cudaError_t err) {
+  return std::string(cudaGetErrorName(err)) + ": " + cudaGetErrorString(err);
+}
 
 inline bool log_cuda_error(const rclcpp::Logger& logger, const char* operation,
                            cudaError_t err) {

--- a/examples/multi_process_image_fanout/src/gpu_image_publisher.cpp
+++ b/examples/multi_process_image_fanout/src/gpu_image_publisher.cpp
@@ -107,9 +107,8 @@ class GpuImagePublisherNode : public rclcpp::Node {
     if (stream_ != nullptr) {
       const cudaError_t error = cudaStreamDestroy(stream_);
       if (error != cudaSuccess) {
-        RCLCPP_ERROR(
-            get_logger(), "cudaStreamDestroy failed: %s",
-            ros2_cuda_ipc_core::detail::cuda_error_to_string(error).c_str());
+        RCLCPP_ERROR(get_logger(), "cudaStreamDestroy failed: %s",
+                     cuda_error_to_string(error).c_str());
       }
       stream_ = nullptr;
     }

--- a/examples/multi_process_image_fanout/src/preview_node.cpp
+++ b/examples/multi_process_image_fanout/src/preview_node.cpp
@@ -13,7 +13,6 @@
 #include "multi_process_image_fanout/cuda_checks.hpp"
 #include "multi_process_image_fanout/status_format.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "ros2_cuda_ipc_core/detail/cuda_util.hpp"
 #include "ros2_cuda_ipc_core/detail/nvtx_scoped_range.hpp"
 #include "ros2_cuda_ipc_core/image/image_view_mapper.hpp"
 #include "ros2_cuda_ipc_msgs/msg/gpu_image.hpp"
@@ -193,9 +192,8 @@ class PreviewNode : public rclcpp::Node {
       cudaEventRecord(copy_stop, stream_);
     }
     if (err != cudaSuccess) {
-      RCLCPP_WARN(
-          get_logger(), "cudaMemcpy2DAsync failed: %s",
-          ros2_cuda_ipc_core::detail::cuda_error_to_string(err).c_str());
+      RCLCPP_WARN(get_logger(), "cudaMemcpy2DAsync failed: %s",
+                  cuda_error_to_string(err).c_str());
       cudaEventDestroy(copy_start);
       cudaEventDestroy(copy_stop);
       return;
@@ -203,9 +201,8 @@ class PreviewNode : public rclcpp::Node {
 
     err = cudaStreamSynchronize(stream_);
     if (err != cudaSuccess) {
-      RCLCPP_WARN(
-          get_logger(), "cudaStreamSynchronize failed: %s",
-          ros2_cuda_ipc_core::detail::cuda_error_to_string(err).c_str());
+      RCLCPP_WARN(get_logger(), "cudaStreamSynchronize failed: %s",
+                  cuda_error_to_string(err).c_str());
       cudaEventDestroy(copy_start);
       cudaEventDestroy(copy_stop);
       return;

--- a/ros2_cuda_ipc_core/CMakeLists.txt
+++ b/ros2_cuda_ipc_core/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT UUID_LIB)
   message(FATAL_ERROR "Failed to find libuuid (uuid)")
 endif()
 
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED
   src/detail/cuda_util.cpp
   src/detail/cuda_driver_context.cpp
   src/detail/interprocess_event.cpp
@@ -60,9 +60,6 @@ target_link_libraries(${PROJECT_NAME}
     ${ros2_cuda_ipc_msgs_TARGETS}
     ${sensor_msgs_TARGETS}
     ${std_msgs_TARGETS}
-    # Stream-facing public APIs and non-IPC users still depend on libcudart;
-    # CUDA IPC memory allocation/import itself uses CUDA::cuda_driver.
-    CUDA::cudart
     CUDA::cuda_driver
     ${UUID_LIB}
 )
@@ -96,15 +93,15 @@ if(BUILD_TESTING)
   target_link_libraries(test_publisher_messages ${PROJECT_NAME})
   ament_add_gtest(test_gpu_buffer_manager
                   test/test_gpu_buffer_manager.cpp)
-  target_link_libraries(test_gpu_buffer_manager ${PROJECT_NAME})
+  target_link_libraries(test_gpu_buffer_manager ${PROJECT_NAME} CUDA::cudart)
   ament_add_gtest(test_gpu_buffer_pool test/test_gpu_buffer_pool.cpp)
-  target_link_libraries(test_gpu_buffer_pool ${PROJECT_NAME})
+  target_link_libraries(test_gpu_buffer_pool ${PROJECT_NAME} CUDA::cudart)
   ament_add_gtest(test_ready_event_driver test/test_ready_event_driver.cpp)
-  target_link_libraries(test_ready_event_driver ${PROJECT_NAME})
+  target_link_libraries(test_ready_event_driver ${PROJECT_NAME} CUDA::cudart)
   ament_add_gtest(test_lease_manager test/test_lease_manager.cpp)
   target_link_libraries(test_lease_manager ${PROJECT_NAME})
   ament_add_gtest(test_cuda_driver_context test/test_cuda_driver_context.cpp)
-  target_link_libraries(test_cuda_driver_context ${PROJECT_NAME})
+  target_link_libraries(test_cuda_driver_context ${PROJECT_NAME} CUDA::cudart)
   add_executable(cuda_ipc_import_helper
                  test/cuda_ipc_import_helper.cpp)
   target_include_directories(cuda_ipc_import_helper PRIVATE test)

--- a/ros2_cuda_ipc_core/CMakeLists.txt
+++ b/ros2_cuda_ipc_core/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT UUID_LIB)
   message(FATAL_ERROR "Failed to find libuuid (uuid)")
 endif()
 
-add_library(${PROJECT_NAME} SHARED
+add_library(${PROJECT_NAME}
   src/detail/cuda_util.cpp
   src/detail/cuda_driver_context.cpp
   src/detail/interprocess_event.cpp

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/detail/cuda_util.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/detail/cuda_util.hpp
@@ -4,14 +4,10 @@
 #pragma once
 
 #include <cuda.h>
-#include <cuda_runtime_api.h>
 
 #include <string>
 
 namespace ros2_cuda_ipc_core::detail {
-
-/// Convert a CUDA error code into a descriptive "<name>: <message>" string.
-std::string cuda_error_to_string(cudaError_t err);
 
 /// Convert a CUDA driver API error into "<name>: <message>".
 std::string cu_result_to_string(CUresult result);

--- a/ros2_cuda_ipc_core/src/detail/cuda_util.cpp
+++ b/ros2_cuda_ipc_core/src/detail/cuda_util.cpp
@@ -7,10 +7,6 @@
 
 namespace ros2_cuda_ipc_core::detail {
 
-std::string cuda_error_to_string(cudaError_t err) {
-  return std::string(cudaGetErrorName(err)) + ": " + cudaGetErrorString(err);
-}
-
 std::string cu_result_to_string(CUresult result) {
   return CudaDriverError(result).to_string();
 }


### PR DESCRIPTION
## Summary

- Remove the `CUDA::cudart` link dependency from `ros2_cuda_ipc_core`.
- Keep `CUDA::cuda_driver` as the core CUDA link dependency.
- Move `cuda_error_to_string(cudaError_t)` into the multi-process example, where CUDA Runtime API is already required.
- Link CUDA Runtime API explicitly only from tests and example targets that use it.

## Why

The core shared library should depend on `libcuda.so` without declaring a direct or transitive dependency on `libcudart.so`. The public `cudaStream_t` interfaces remain unchanged.

## Validation

- `colcon build --packages-select ros2_cuda_ipc_core --symlink-install`
- `colcon build --packages-select multi_process_image_fanout --symlink-install`
- Core CTest suite: 12/12 passed with `ROS_LOG_DIR=/tmp/ros2_cuda_ipc_core_test_logs`.
- `readelf -d libros2_cuda_ipc_core.so`: contains `libcuda.so.1`, does not contain `libcudart.so`.
- `ldd libros2_cuda_ipc_core.so`: does not show `libcudart.so`.
