### PR TITLE
Use strong ownership for CUDA IPC cache

### DIFF
--- a/doc/cache_check.md
+++ b/doc/cache_check.md
@@ -1,0 +1,175 @@
+## 結論
+
+`IpcHandleCache` は import 済み `ImportedResources` を `shared_ptr` で strong ownership し、
+callback 内だけで `BufferView` を保持する場合も同じ key の resource を message 間で再利用する。
+cache entry は `clear()` または process 終了まで保持され、active な `BufferView` は cache clear 後も
+同じ resource の shared ownership により有効である。
+
+以下の Scenario 1 は strong cache 化前の比較値、Scenario 2 は strong owner を使った合成検証である。
+strong cache 化後の実GPU結果は「実装後の検証」に記録する。
+
+## 実行条件
+
+| 項目 | 値 |
+|---|---|
+| commit | `facdd2c5aaaae0ee268b702ad38acefcf72dcefd` |
+| GPU | NVIDIA GeForce RTX 4060 Laptop GPU |
+| Driver / CUDA | 580.173.02 / CUDA 13.0 |
+| build | Release, `-O3 -DNDEBUG` |
+| backend | CUDA IPC |
+| slot数 | 4 |
+| publish rate | 30 Hz |
+| Subscriber数 | 3 |
+| message数 | 各Subscriber 1124 map |
+| warm-up | 100 message |
+
+## 変更前の比較値: callback内だけBufferViewを保持
+
+一時的なCUDA Driver API interposerで、実際のCUDA IPC open/closeを計測しました。
+
+### Subscriberごとの結果
+
+| counter | 値 |
+|---|---:|
+| map_count | 1124 |
+| cache_hit_count | 0 |
+| cache_miss_count | 1124 |
+| memory_import_count | 1124 |
+| event_import_count | 1124 |
+| imported_resource_create_count | 1124 |
+| imported_resource_release_count | 1124 |
+| duplicate_import_count | 0 |
+| cache_entry_count | 0 |
+
+warm-up後の1024 mapはすべて cache miss による再importでした。
+
+### slot別集計
+
+| slot | map | hit | import | release |
+|---:|---:|---:|---:|---:|
+| 0 | 281 | 0 | 281 | 281 |
+| 1 | 281 | 0 | 281 | 281 |
+| 2 | 281 | 0 | 281 | 281 |
+| 3 | 281 | 0 | 281 | 281 |
+
+つまり、同じslotに戻る間隔は約4 messageですが、resourceは再利用されず、毎回importされています。
+
+### `map()` latency
+
+warm-up後の再import：
+
+| Subscriber | average | p50 | p95 | p99 | maximum |
+|---|---:|---:|---:|---:|---:|
+| encoder-like | 0.896 ms | 0.923 ms | 1.360 ms | 2.035 ms | 2.515 ms |
+| inference-like | 0.880 ms | 0.892 ms | 1.333 ms | 2.106 ms | 2.461 ms |
+
+初回CUDA初期化を含むcold importでは、最初の4 resourceについて平均約59.5 ms、最大約237.8 msでした。これは定常処理から分離しています。
+
+preview Subscriberも、別計測で各slot 281回のmemory/event importとreleaseを確認しました。
+
+## 比較検証: slotごとにviewをstrong保持
+
+一時的なmapper/cache harnessで確認しました。
+
+| counter | 値 |
+|---|---:|
+| map_count | 1000 |
+| cache_hit_count | 1000 |
+| cache_miss_count | 0 |
+| 追加memory import | 0 |
+| 追加event import | 0 |
+| resource release | 最後に4回 |
+| cache_entry_max | 4 |
+| final cache_entry_count | 0 |
+
+各slotのviewを保持している間は、既存の `ImportedResources` を再利用できています。
+
+cache-hit時のCPU側map latencyは約0.271 µsでした。ただし、これはCUDA APIを合成したcache/lifetime検証であり、実GPUのhit latencyではありません。実exampleではhit自体が発生しませんでした。
+
+## Strong cache の ownership
+
+実装は次の構造です。
+
+- [`IpcHandleCache`](</home/dskkato/workspace/ros2_cuda_ipc/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp:38>) は
+  `shared_ptr<const ImportedResources>` を map に保持
+- [`BufferViewMapper::map()`](</home/dskkato/workspace/ros2_cuda_ipc/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp:124>) は
+  cache hit なら既存 entry を使い、miss のときだけ importer を呼ぶ
+- [`BufferView`](</home/dskkato/workspace/ros2_cuda_ipc/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp:98>) も同じ
+  resource の shared ownership を保持
+- `clear()` 後も view が保持されていれば resource は生存し、最後の cache/view reference 解放時に
+  `cuIpcCloseMemHandle` と `cuEventDestroy` が呼ばれる
+
+exampleのcallbackは次の形です。
+
+```cpp
+auto view = map_image_view(message);
+on_image(view);
+```
+
+callback終了時に `view` が破棄されても、cache が `ImportedResources` を保持するため、次の message で
+同じ key の entry を取得できます。
+
+変更前の比較計測ではmemory import、event import、resource releaseがすべて同数でした。
+
+## Resource identity
+
+実測したkeyは、publisher instance、backend、device、slot、opaque handle digestで識別しました。
+
+例:
+
+| slot | memory handle digest | event handle digest | publisher instance |
+|---:|---|---|---|
+| 0 | `9800c7e1d5302041` | `fcda49341249e6ff` | `e129aa9f74e94ce2a5cb30e2e1bdca76` |
+| 1 | `89873a1d813e25f0` | `50267dbf2231455e` | 同上 |
+| 2 | `5827042d90071a6f` | `8d4f6a71dbcff2e1` | 同上 |
+| 3 | `6aab271c8f5d8672` | `e09b9efcebb75140` | 同上 |
+
+変更前は各 resource が281回 import、281回 releaseされました。
+
+## 実装後の設計
+
+| 項目 | 方針 |
+|---|---|
+| ownership | `IpcHandleCache` と `BufferView` が同じ `shared_ptr<const ImportedResources>` を共有 |
+| hit | 同じ publisher instance/backend/memory handle/event handle の key なら既存 entry を返す |
+| clear | map を mutex 外で破棄し、active view の resource は保持 |
+| policy | unbounded。上限、LRU、TTL、automatic eviction、instance 単位 prune は導入しない |
+| restart | publisher instance identity が key に含まれるため、restart 後は異なる entry が追加され得る |
+
+## 実装後の検証
+
+2026-07-24 に RTX 4060 Laptop GPU（driver 580.173.02、CUDA 13.0）で、Release build の
+`multi_process_image_fanout` を `cuda_ipc`、4 slot、30 Hz、640x480、約50秒で実行した。
+各 Subscriber は約1400 messageを callback 内だけで処理した。
+
+| counter | encoder-like | inference-like |
+|---|---:|---:|
+| map_count | 約1400（status log） | 約1400（status log） |
+| memory_import_count | 4 | 4 |
+| event_import_count | 4 | 4 |
+| imported_resource_create_count | 4 | 4 |
+| messageごとの追加import | 0 | 0 |
+| 実行中のresource release | 0 | 0 |
+
+4つのresource identityがそれぞれ一度だけ importされたため、slotごとの import は 1回、
+残り約1396 messageは cache hit と判断できる。preview nodeも約1400 messageを処理し、同じ
+4 resourceだけを使用した。
+
+`BufferViewMapper::map()` の厳密な実GPU latencyは、exampleが `ImageViewMapper` の内部呼び出しを
+使うため、今回の一時 Driver API interposerでは直接取得できなかった。したがって、0.9 msの
+変更前値に対する変更後の厳密な平均値は未計測である。一方、memory/event importが初回4回で
+止まったことから、定常messageでのIPC importコストが発生していないことは確認できた。
+
+終了時はSIGINTによる停止を使ったため、SubscriberのCUDA context cleanupで
+`CUDA_ERROR_UNKNOWN` が記録され、process終了時のDriver API release回数はこの計測では確定できなかった。
+unit testでは `clear()` 後に active view が保持する場合の release=0、最後の view解放後の release=1、
+active viewなしの `clear()` 後の release=1 を確認している。
+
+## 使用した一時計測物
+
+- [実GPU用interposer](/tmp/ros2_cuda_ipc_count_interposer.cpp)
+- Scenario 1/2 の比較 harness
+- 合成 CUDA shim
+- [実GPU計測ログ](/tmp/ros2_cuda_ipc_actual_measure2.log)
+
+core Release build、core 81 tests、example Release build は成功した。

--- a/doc/cache_check.md
+++ b/doc/cache_check.md
@@ -90,11 +90,11 @@ cache-hit時のCPU側map latencyは約0.271 µsでした。ただし、これは
 
 実装は次の構造です。
 
-- [`IpcHandleCache`](</home/dskkato/workspace/ros2_cuda_ipc/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp:38>) は
+- [`IpcHandleCache`](../ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp#L38) は
   `shared_ptr<const ImportedResources>` を map に保持
-- [`BufferViewMapper::map()`](</home/dskkato/workspace/ros2_cuda_ipc/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp:124>) は
+- [`BufferViewMapper::map()`](../ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp#L124) は
   cache hit なら既存 entry を使い、miss のときだけ importer を呼ぶ
-- [`BufferView`](</home/dskkato/workspace/ros2_cuda_ipc/ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp:98>) も同じ
+- [`BufferView`](../ros2_cuda_ipc_core/src/subscriber/buffer_view.cpp#L98) も同じ
   resource の shared ownership を保持
 - `clear()` 後も view が保持されていれば resource は生存し、最後の cache/view reference 解放時に
   `cuIpcCloseMemHandle` と `cuEventDestroy` が呼ばれる
@@ -131,7 +131,7 @@ callback終了時に `view` が破棄されても、cache が `ImportedResources
 | 項目 | 方針 |
 |---|---|
 | ownership | `IpcHandleCache` と `BufferView` が同じ `shared_ptr<const ImportedResources>` を共有 |
-| hit | 同じ publisher instance/backend/memory handle/event handle の key なら既存 entry を返す |
+| hit | 同じ publisher instance/backend/device/memory handle/event handle の key なら既存 entry を返す |
 | clear | map を mutex 外で破棄し、active view の resource は保持 |
 | policy | unbounded。上限、LRU、TTL、automatic eviction、instance 単位 prune は導入しない |
 | restart | publisher instance identity が key に含まれるため、restart 後は異なる entry が追加され得る |
@@ -167,9 +167,9 @@ active viewなしの `clear()` 後の release=1 を確認している。
 
 ## 使用した一時計測物
 
-- [実GPU用interposer](/tmp/ros2_cuda_ipc_count_interposer.cpp)
-- Scenario 1/2 の比較 harness
-- 合成 CUDA shim
-- [実GPU計測ログ](/tmp/ros2_cuda_ipc_actual_measure2.log)
+- 実GPU用interposer（ローカル計測用、一時ファイル）
+- Scenario 1/2 の比較 harness（ローカル計測用、一時ファイル）
+- 合成 CUDA shim（ローカル計測用、一時ファイル）
+- 実GPU計測ログ（ローカル計測用、一時ファイル）
 
 core Release build、core 81 tests、example Release build は成功した。

--- a/doc/design.md
+++ b/doc/design.md
@@ -221,12 +221,17 @@ GPU メモリを「Shareable FD」として扱い、`backend=VMM_FD` で配布�
    * 今後の課題として、別 Publisher の socket を誤って削除しないよう、shm\_name やプロセス識別子を含む
      管理情報で socket の所有者を確認してから削除する仕組みを検討する。
 
-`IpcHandleCache` は import 済み resource のインデックスであり、resource 自体を強く所有しない。
-memory mapping、ready event、CUDA context、必要な VMM state は `backend::ImportedResources` という
-一つの bundle として `std::shared_ptr` で管理し、`BufferView` が active な間だけ生存させる。
-cache は `std::weak_ptr` を保持するため、view がなくなった resource は次回 lookup 時に再 import でき、
-Publisher restart による古い entry の蓄積も避けられる。`clear()` は cache の索引だけを削除し、
-既存の view の lifetime には影響しない。
+`IpcHandleCache` は、slot ごとに固定された CUDA IPC/VMM resource を message 間で再利用するため、
+`backend::ImportedResources` を `std::shared_ptr` として strong ownership する。memory mapping、ready event、
+CUDA context、必要な VMM state は一つの bundle として管理され、cache entry と `BufferView` が同じ
+`shared_ptr` の所有権を共有する。
+cache key は publisher instance identity、backend、device、memory handle、event handle を含み、
+Publisher restart や異なる device/resource を別 entry として扱う。
+
+cache entry は明示的な `clear()` または process 終了まで保持される。`clear()` は map を mutex の外で
+破棄するため、active な `BufferView` が同じ resource を保持していれば view は有効なままである。
+Publisher restart では publisher instance identity が変わり、異なる key の entry が追加され得る。
+現時点では entry 数の上限、eviction、Publisher instance 単位の自動 prune は行わない unbounded policy とする。
 
 この設計により、GPU メモリの配布方法だけを MemoryBackend/MemoryImporter で差し替え、ROS 2 メッセージ形式と
 BufferView と Mapper の API を維持したまま Jetson Orin をサポートできる。
@@ -420,14 +425,16 @@ ROS message から View へのアプリケーションメタデータコピー**
 
 * GPU データ本体のコピーは行わない。ROS msg と View の間では、shape や strides などのメタデータだけをコピーする。
 * 同期 (cudaStreamWaitEvent) はユーザ側の責務。
-* 同一 (mem\_handle,event\_handle) の組み合わせをプロセス内でキャッシュし、
+* 同一 (publisher instance, backend, device, mem\_handle, event\_handle) の組み合わせをプロセス内でキャッシュし、
   ハンドルごとの `cudaIpcOpen*Handle` や VMM import を初回だけ実行する。これにより、
   subscriber がフレームごとに IPC open/close を繰り返さずに済み、大きな
   API 開始コストを避けている。
-  * キャッシュは weak index としてプロセス内で共有する。resource の実体は
-    active な `BufferView` が保持し、view がなくなった entry は次回 lookup 時に再 import する。
-  * `BufferView` は `ImportedResources` と LeaseHandle を保持し、最後の view が
-    破棄された時点で受信側の import 済み resource を解放する。
+  * キャッシュは `ImportedResources` を strong ownership するプロセス内 cache として共有し、
+    callback 終了後も同じ handle の resource を次の message で再利用する。
+  * `BufferView` も同じ `shared_ptr<const ImportedResources>` と LeaseHandle を保持するため、
+    cache を clear した後も active な view は有効である。resource は cache と view の最後の参照が
+    なくなった時点で解放される。
+  * cache は unbounded policy であり、entry は明示的な `clear()` または process 終了まで保持する。
 
 Publisher/Subscriber の役割:
 * Publisher: cudaIpcGet*Handle でハンドル生成 → msg に格納。

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp
@@ -9,7 +9,6 @@
 #include <functional>
 #include <memory>
 #include <mutex>
-#include <optional>
 #include <unordered_map>
 #include <utility>
 
@@ -22,12 +21,14 @@ namespace ros2_cuda_ipc_core::subscriber {
 struct IpcHandleKey {
   PublisherInstanceId publisher_instance_id{};
   uint8_t backend = 0;
+  uint32_t device_id = 0;
   transport::MemoryHandlePayload mem{};
   transport::EventHandlePayload event{};
 
   bool operator==(const IpcHandleKey& other) const noexcept {
     return publisher_instance_id == other.publisher_instance_id &&
-           backend == other.backend && mem == other.mem && event == other.event;
+           backend == other.backend && device_id == other.device_id &&
+           mem == other.mem && event == other.event;
   }
 };
 
@@ -62,17 +63,12 @@ class IpcHandleCache {
   std::size_t size() const;
 
  private:
-  using CachedEntry = std::weak_ptr<const backend::ImportedResources>;
-
-  void prune_expired_locked() const;
-
   ReleaseFn release_fn_;
   mutable std::mutex mutex_;
-  // The cache indexes resources but does not own them.  BufferView (or
-  // another active consumer) is the owner that keeps an imported resource
-  // alive; an expired entry is re-imported on the next lookup.
-  mutable std::unordered_map<IpcHandleKey, CachedEntry, IpcHandleKeyHash>
-      cache_;
+  // Keep imported resources alive between messages.  BufferView also keeps a
+  // shared ownership reference so clearing the cache cannot invalidate an
+  // active view.
+  std::unordered_map<IpcHandleKey, Entry, IpcHandleKeyHash> cache_;
 };
 
 }  // namespace ros2_cuda_ipc_core::subscriber

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
@@ -118,6 +118,7 @@ BufferView BufferViewMapper::map(
   IpcHandleKey key{};
   key.publisher_instance_id = instance_id;
   key.backend = static_cast<uint8_t>(msg.backend);
+  key.device_id = msg.device_id;
   key.mem = msg.mem_handle;
   std::memcpy(key.event.data(), msg.event_handle.data(), key.event.size());
 

--- a/ros2_cuda_ipc_core/src/subscriber/ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/ipc_handle_cache.cpp
@@ -11,6 +11,9 @@ std::size_t IpcHandleKeyHash::operator()(
     const IpcHandleKey& key) const noexcept {
   constexpr std::size_t PRIME{131};
   std::size_t hash = key.backend;
+  for (unsigned int shift = 0; shift < sizeof(key.device_id) * 8; shift += 8) {
+    hash = hash * PRIME + ((key.device_id >> shift) & 0xffU);
+  }
   for (uint8_t byte : key.publisher_instance_id) {
     hash = hash * PRIME + byte;
   }
@@ -35,15 +38,11 @@ IpcHandleCache& IpcHandleCache::instance() {
 
 IpcHandleCache::Entry IpcHandleCache::find(const IpcHandleKey& key) const {
   std::lock_guard<std::mutex> lock(mutex_);
-  auto it = cache_.find(key);
+  const auto it = cache_.find(key);
   if (it == cache_.end()) {
     return {};
   }
-  auto resource = it->second.lock();
-  if (!resource) {
-    cache_.erase(it);
-  }
-  return resource;
+  return it->second;
 }
 
 IpcHandleCache::Entry IpcHandleCache::insert_or_discard_duplicate(
@@ -64,9 +63,12 @@ IpcHandleCache::Entry IpcHandleCache::insert_or_discard_duplicate(
     using OwnedResource =
         std::unique_ptr<backend::ImportedResources, decltype(deleter)>;
     OwnedResource resource(new backend::ImportedResources(std::move(imported)),
-                           deleter);
+                           std::move(deleter));
     resource_constructed = true;
-    candidate = Entry(resource.get(), deleter);
+    // The unique_ptr owns the resource while shared_ptr allocates its control
+    // block.  If this copy throws, the unique_ptr still invokes the moved-in
+    // deleter during unwinding.
+    candidate = Entry(resource.get(), resource.get_deleter());
     resource.release();
   } catch (...) {
     // If allocation failed before the resource took ownership, release the
@@ -86,20 +88,12 @@ IpcHandleCache::Entry IpcHandleCache::insert_or_discard_duplicate(
   Entry result;
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    auto it = cache_.find(key);
-    if (it != cache_.end()) {
-      result = it->second.lock();
-      if (result) {
-        // Keep the first successfully imported resource for this key.  The
-        // candidate is released after the lock is dropped.
-      } else {
-        it->second = candidate;
-        result = candidate;
-      }
-    } else {
-      cache_.emplace(key, candidate);
-      result = candidate;
-    }
+    const auto [it, inserted] = cache_.emplace(key, candidate);
+    (void)inserted;
+    // Keep the first imported resource for this key.  If this was a
+    // duplicate, candidate remains a local shared_ptr and is released after
+    // this scope drops the cache mutex.
+    result = it->second;
   }
   // A duplicate candidate is released here, after dropping the cache lock;
   // for a new key this is only the local shared_ptr copy.
@@ -107,24 +101,19 @@ IpcHandleCache::Entry IpcHandleCache::insert_or_discard_duplicate(
 }
 
 void IpcHandleCache::clear() {
-  std::lock_guard<std::mutex> lock(mutex_);
-  cache_.clear();
+  decltype(cache_) entries;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    entries.swap(cache_);
+  }
+  // Imported resource cleanup can call arbitrary backend code.  Do not run
+  // it while holding the cache mutex.
+  entries.clear();
 }
 
 std::size_t IpcHandleCache::size() const {
   std::lock_guard<std::mutex> lock(mutex_);
-  prune_expired_locked();
   return cache_.size();
-}
-
-void IpcHandleCache::prune_expired_locked() const {
-  for (auto it = cache_.begin(); it != cache_.end();) {
-    if (it->second.expired()) {
-      it = cache_.erase(it);
-    } else {
-      ++it;
-    }
-  }
 }
 
 }  // namespace ros2_cuda_ipc_core::subscriber

--- a/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
+++ b/ros2_cuda_ipc_core/test/test_ipc_handle_cache.cpp
@@ -4,6 +4,9 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <stdexcept>
+#include <thread>
+#include <vector>
 
 #include "ros2_cuda_ipc_core/subscriber/buffer_view.hpp"
 #include "ros2_cuda_ipc_core/subscriber/ipc_handle_cache.hpp"
@@ -11,16 +14,20 @@
 
 namespace ros2_cuda_ipc_core {
 
-TEST(IpcHandleCacheTest, KeyEqualityAndHashUseInstanceBackendPayloadAndEvent) {
+TEST(IpcHandleCacheTest,
+     KeyEqualityAndHashUseInstanceBackendDevicePayloadAndEvent) {
   subscriber::IpcHandleKey lhs{};
   lhs.publisher_instance_id = test::publisher_instance_id("lhs");
   lhs.backend = 1;
+  lhs.device_id = 2;
   lhs.mem[0] = 3;
   lhs.event[0] = 5;
 
   subscriber::IpcHandleKey same = lhs;
   subscriber::IpcHandleKey different_backend = lhs;
   different_backend.backend = 2;
+  subscriber::IpcHandleKey different_device = lhs;
+  different_device.device_id = 3;
   subscriber::IpcHandleKey different_mem = lhs;
   different_mem.mem[1] = 7;
   subscriber::IpcHandleKey different_event = lhs;
@@ -33,6 +40,8 @@ TEST(IpcHandleCacheTest, KeyEqualityAndHashUseInstanceBackendPayloadAndEvent) {
   EXPECT_TRUE(lhs == same);
   EXPECT_EQ(hash(lhs), hash(same));
   EXPECT_FALSE(lhs == different_backend);
+  EXPECT_FALSE(lhs == different_device);
+  EXPECT_NE(hash(lhs), hash(different_device));
   EXPECT_FALSE(lhs == different_mem);
   EXPECT_FALSE(lhs == different_event);
   EXPECT_FALSE(lhs == different_instance);
@@ -67,10 +76,17 @@ TEST(IpcHandleCacheTest, DuplicateInsertReturnsExistingEntry) {
 
 TEST(IpcHandleCacheTest, DuplicateInsertInvokesReleaseHook) {
   std::atomic<int> released{0};
+  std::atomic<std::size_t> observed_cache_size{999};
+  subscriber::IpcHandleCache* cache_ptr = nullptr;
   subscriber::IpcHandleCache cache(
-      [&released](const backend::ImportedResources&) {
+      [&released, &observed_cache_size,
+       &cache_ptr](const backend::ImportedResources&) {
         released.fetch_add(1);
+        // A duplicate candidate must be destroyed after insert releases the
+        // cache mutex; otherwise this lookup would deadlock.
+        observed_cache_size.store(cache_ptr->size());
       });
+  cache_ptr = &cache;
   subscriber::IpcHandleKey key{};
   key.backend = 1;
   key.mem[0] = 17;
@@ -89,8 +105,11 @@ TEST(IpcHandleCacheTest, DuplicateInsertInvokesReleaseHook) {
       cache.insert_or_discard_duplicate(key, std::move(duplicate));
 
   EXPECT_EQ(released.load(), 1);
+  EXPECT_EQ(observed_cache_size.load(), 1u);
   first_entry.reset();
   duplicate_entry.reset();
+  EXPECT_EQ(released.load(), 1);
+  cache.clear();
   EXPECT_EQ(released.load(), 2);
 }
 
@@ -104,12 +123,17 @@ TEST(IpcHandleCacheTest, ClearDoesNotReleaseActiveResources) {
   backend::ImportedResources imported;
   imported.dev_ptr = reinterpret_cast<void*>(0x9090);
   auto entry = cache.insert_or_discard_duplicate(key, std::move(imported));
+  subscriber::BufferView view;
+  view.set_imported_resource(entry);
+  entry.reset();
 
   cache.clear();
 
   EXPECT_EQ(released.load(), 0);
   EXPECT_EQ(cache.size(), 0u);
-  entry.reset();
+  ASSERT_TRUE(view.valid());
+  EXPECT_EQ(view.device_ptr(), reinterpret_cast<void*>(0x9090));
+  view.reset();
   EXPECT_EQ(released.load(), 1);
 }
 
@@ -135,7 +159,7 @@ TEST(IpcHandleCacheTest, ClearDefersReleaseUntilExternalOwnerIsGone) {
   EXPECT_EQ(released.load(), 1);
 }
 
-TEST(IpcHandleCacheTest, ExpiredEntriesArePruned) {
+TEST(IpcHandleCacheTest, ClearWithoutActiveViewReleasesCachedResource) {
   std::atomic<int> released{0};
   subscriber::IpcHandleCache cache(
       [&released](const backend::ImportedResources&) {
@@ -143,13 +167,156 @@ TEST(IpcHandleCacheTest, ExpiredEntriesArePruned) {
       });
   subscriber::IpcHandleKey key{};
   backend::ImportedResources imported;
-  imported.dev_ptr = reinterpret_cast<void*>(0xa0a0);
+  imported.dev_ptr = reinterpret_cast<void*>(0xa1a1);
 
-  cache.insert_or_discard_duplicate(key, std::move(imported));
+  auto entry = cache.insert_or_discard_duplicate(key, std::move(imported));
+  entry.reset();
 
+  EXPECT_EQ(released.load(), 0);
+  EXPECT_EQ(cache.size(), 1u);
+  cache.clear();
   EXPECT_EQ(released.load(), 1);
-  EXPECT_EQ(cache.find(key), nullptr);
   EXPECT_EQ(cache.size(), 0u);
+}
+
+TEST(IpcHandleCacheTest, CacheHitReusesTheSameEntry) {
+  std::atomic<int> released{0};
+  subscriber::IpcHandleCache cache(
+      [&released](const backend::ImportedResources&) {
+        released.fetch_add(1);
+      });
+  subscriber::IpcHandleKey key{};
+  key.backend = 1;
+  key.mem[0] = 41;
+  key.event[0] = 43;
+
+  int import_count = 0;
+  backend::ImportedResources imported;
+  imported.dev_ptr = reinterpret_cast<void*>(0xd0d0);
+  ++import_count;
+  auto first = cache.insert_or_discard_duplicate(key, std::move(imported));
+  ASSERT_TRUE(first);
+
+  int hit_count = 0;
+  for (int i = 0; i < 1000; ++i) {
+    auto hit = cache.find(key);
+    ASSERT_TRUE(hit);
+    ++hit_count;
+    EXPECT_EQ(hit.get(), first.get());
+  }
+
+  EXPECT_EQ(import_count, 1);
+  EXPECT_EQ(hit_count, 1000);
+  EXPECT_EQ(released.load(), 0);
+  first.reset();
+  cache.clear();
+  EXPECT_EQ(released.load(), 1);
+}
+
+TEST(IpcHandleCacheTest, EntryRemainsCachedAfterBufferViewIsDestroyed) {
+  std::atomic<int> released{0};
+  subscriber::IpcHandleCache cache(
+      [&released](const backend::ImportedResources&) {
+        released.fetch_add(1);
+      });
+  subscriber::IpcHandleKey key{};
+  backend::ImportedResources imported;
+  imported.dev_ptr = reinterpret_cast<void*>(0xe0e0);
+
+  auto entry = cache.insert_or_discard_duplicate(key, std::move(imported));
+  const auto* address = entry.get();
+  {
+    subscriber::BufferView view;
+    view.set_imported_resource(entry);
+    entry.reset();
+    ASSERT_TRUE(view.valid());
+  }
+
+  EXPECT_EQ(released.load(), 0);
+  EXPECT_EQ(cache.size(), 1u);
+  auto hit = cache.find(key);
+  ASSERT_TRUE(hit);
+  EXPECT_EQ(hit.get(), address);
+  hit.reset();
+  EXPECT_EQ(released.load(), 0);
+
+  cache.clear();
+  EXPECT_EQ(released.load(), 1);
+}
+
+TEST(IpcHandleCacheTest, DuplicateInsertionsAreThreadSafeAndReleaseLosers) {
+  constexpr std::size_t kThreadCount = 8;
+  std::atomic<int> released{0};
+  subscriber::IpcHandleCache cache(
+      [&released](const backend::ImportedResources&) {
+        released.fetch_add(1);
+      });
+  subscriber::IpcHandleKey key{};
+  key.backend = 1;
+  key.mem[0] = 51;
+  key.event[0] = 53;
+
+  std::vector<subscriber::IpcHandleCache::Entry> entries(kThreadCount);
+  std::vector<std::thread> threads;
+  threads.reserve(kThreadCount);
+  std::atomic<std::size_t> ready{0};
+  std::atomic<bool> start{false};
+  for (std::size_t i = 0; i < kThreadCount; ++i) {
+    threads.emplace_back([&, i] {
+      backend::ImportedResources imported;
+      imported.dev_ptr = reinterpret_cast<void*>(0x10000 + i * 0x10);
+      imported.event = reinterpret_cast<CUevent>(0x20000 + i * 0x10);
+      ready.fetch_add(1);
+      while (!start.load()) {
+        std::this_thread::yield();
+      }
+      entries[i] = cache.insert_or_discard_duplicate(key, std::move(imported));
+    });
+  }
+  while (ready.load() != kThreadCount) {
+    std::this_thread::yield();
+  }
+  start.store(true);
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  ASSERT_EQ(cache.size(), 1u);
+  ASSERT_TRUE(entries.front());
+  for (const auto& entry : entries) {
+    ASSERT_TRUE(entry);
+    EXPECT_EQ(entry.get(), entries.front().get());
+  }
+  EXPECT_EQ(released.load(), static_cast<int>(kThreadCount - 1));
+
+  entries.clear();
+  EXPECT_EQ(released.load(), static_cast<int>(kThreadCount - 1));
+  cache.clear();
+  EXPECT_EQ(released.load(), static_cast<int>(kThreadCount));
+}
+
+TEST(IpcHandleCacheTest, CleanupIsOutsideMutexAndDoesNotPropagateExceptions) {
+  std::atomic<int> released{0};
+  std::atomic<std::size_t> observed_cache_size{999};
+  subscriber::IpcHandleCache* cache_ptr = nullptr;
+  subscriber::IpcHandleCache cache([&](const backend::ImportedResources&) {
+    released.fetch_add(1);
+    // clear() must have detached the entries before invoking the
+    // deleter; otherwise this call would try to reacquire the mutex.
+    observed_cache_size.store(cache_ptr->size());
+    throw std::runtime_error("synthetic cleanup failure");
+  });
+  cache_ptr = &cache;
+  subscriber::IpcHandleKey key{};
+  backend::ImportedResources imported;
+  imported.dev_ptr = reinterpret_cast<void*>(0xf0f0);
+  auto entry = cache.insert_or_discard_duplicate(key, std::move(imported));
+  entry.reset();
+
+  EXPECT_NO_THROW(cache.clear());
+  EXPECT_EQ(cache.size(), 0u);
+  EXPECT_EQ(observed_cache_size.load(), 0u);
+  EXPECT_EQ(released.load(), 1);
 }
 
 TEST(IpcHandleCacheTest, BufferViewCopiesShareImportedResourceOwnership) {

--- a/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
+++ b/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
@@ -10,7 +10,6 @@
 #include <cstring>
 #include <sstream>
 #include <string>
-#include <vector>
 
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_cuda_ipc_core/backend/memory_importer.hpp"
@@ -50,6 +49,7 @@ inline subscriber::IpcHandleKey make_key(
   subscriber::IpcHandleKey key{};
   key.publisher_instance_id = msg.publisher_instance_id;
   key.backend = static_cast<uint8_t>(msg.backend);
+  key.device_id = msg.device_id;
   key.mem = msg.mem_handle;
   std::memcpy(key.event.data(), msg.event_handle.data(),
               msg.event_handle.size());
@@ -81,12 +81,10 @@ inline void seed_cache_for_message(
   backend::ImportedResources imported;
   imported.dev_ptr = reinterpret_cast<void*>(ptr_seed);
   imported.event = reinterpret_cast<CUevent>(ptr_seed + 1U);
-  // The production cache is weakly owned.  Keep this synthetic resource
-  // alive for the mapper test until the test process exits.
-  static std::vector<subscriber::IpcHandleCache::Entry> test_owners;
-  test_owners.push_back(
-      subscriber::IpcHandleCache::instance().insert_or_discard_duplicate(
-          make_key(msg), std::move(imported)));
+  // The production cache strongly owns this synthetic resource until it is
+  // explicitly cleared or the process exits.
+  (void)subscriber::IpcHandleCache::instance().insert_or_discard_duplicate(
+      make_key(msg), std::move(imported));
 }
 
 inline ros2_cuda_ipc_msgs::msg::BufferCore make_seeded_buffer_core_message(


### PR DESCRIPTION
## Summary

- Change the subscriber-side `IpcHandleCache` from a weak index to an unbounded strong cache of `shared_ptr<const ImportedResources>`.
- Keep the same shared resource ownership in `BufferView`, so active views survive cache clear.
- Make duplicate insertion and cleanup exception-safe, with CUDA cleanup outside the cache mutex.
- Add cache hit, lifetime, duplicate, concurrency, and cleanup exception tests.
- Update the cache design documentation and measurement notes.

## Why

Callback-local `BufferView` instances previously released the last strong reference after every callback, causing the same slot's CUDA IPC memory and event resources to be imported again for each message.

## Validation

- Release build of `ros2_cuda_ipc_core`: passed.
- `colcon test --packages-select ros2_cuda_ipc_core`: 81 tests, 0 failures.
- Release build and tests of `multi_process_image_fanout`: passed.
- CUDA IPC fanout run on an RTX 4060 Laptop GPU with 4 slots and approximately 1400 messages per subscriber: 4 memory imports and 4 event imports per measured subscriber, with no additional imports during steady state.

The exact post-change `BufferViewMapper::map()` latency was not recorded because the example reaches the mapper through an internal `ImageViewMapper` call that the temporary timing hook could not intercept.