### PR TITLE
Use strong ownership for LeaseMappingCache

### DIFF
--- a/doc/cache_check2.md
+++ b/doc/cache_check2.md
@@ -1,0 +1,106 @@
+## `LeaseMappingCache` strong cache
+
+Subscriber の `LeaseMappingCache` は、同じ Publisher instance の POSIX shared-memory mapping を
+message 間で再利用するため、cache value として `std::shared_ptr<LeaseMapping>` を保持する。
+callback-local な `BufferView` が破棄されても cache が mapping を所有し続けるため、定常 message で
+`LeaseMapping::attach()` と `munmap()` を繰り返さない。
+
+### Ownership
+
+```text
+LeaseMappingCache
+  -> shared_ptr<LeaseMapping>
+LeaseHandle
+  -> shared_ptr<LeaseMapping>
+BufferView
+  -> shared_ptr<LeaseHandle>
+```
+
+cache entry は `shm_name` と `publisher_instance_id` の組で識別する。同じ SHM 名でも Publisher
+instance が異なれば別 entry であり、Publisher restart 後の mapping を誤って再利用しない。
+
+`LeaseMappingCache::clear()` は map を mutex から切り離してから entry を破棄する。active な
+`LeaseHandle` が mapping を保持している場合、clear 後も slot metadata への参照は有効である。
+最後の `LeaseHandle` が解放された時点で mapping の destructor が実行される。
+
+cache entry は明示的な `clear()` または process 終了まで保持される。現時点では unbounded policy
+であり、LRU、TTL、最大 entry 数、automatic eviction、Publisher instance 単位の prune、background
+cleanup、stale process 検出は行わない。Publisher restart ごとに新しい instance entry が増える可能性がある。
+
+### `get_or_attach()` の処理
+
+1. `shm_name` と `publisher_instance_id` で cache を lookup する。
+2. entry があれば保持中の `shared_ptr` を返す。
+3. entry がなければ cache mutex の外で `LeaseMapping::attach()` を実行する。
+4. mutex 内で最初に登録された mapping を entry とし、同時に生成された候補は mutex 外で破棄する。
+
+attach failure は `nullptr` を返し、cache entry を追加しない。並列 lookup で attach が重複しても、
+cache に残る entry は key ごとに一つだけで、全 caller は最終的にその entry を受け取る。
+
+### 変更前の比較値
+
+callback-local な `BufferView` を使った変更前の probe では、1000 message に対して次の値だった。
+
+| counter | 値 |
+|---|---:|
+| `LeaseMapping::attach()` | 1000 |
+| `LeaseMapping` destroy | 1000 |
+| cache hit | 0 |
+| Subscriber 側 `shm_open`/`openat` | 1000 |
+| `fstat`/`newfstatat` | 1000 |
+| `mmap` | 1000 |
+| `close` | 1000 |
+| `munmap` | 1000 |
+
+### 変更後の検証結果
+
+`test_lease_mapping_cache` の callback-local 相当テストでは、最初の lookup を含む1001回の lookupで
+attach は1回、cache entry は1件だった。最初の lookup後の1000回は同じ mapping pointer を返し、各 iteration
+で `LeaseHandle` を取得・解放しても loop 中の mapping destroy は0回だった。cache clear 後に destroy は1回になった。
+
+同テストの concurrent duplicate attach では8 threadが同じ key を同時に lookupした。attach candidateは8個
+生成されたが、cache entryは1件に収束し、全 threadが同じ mapping pointerを受け取った。採用されなかった7個の
+candidateは mutex 外で破棄された。
+
+`get_or_attach()` の Release build timing test（attach miss 1回、hit 10000回）は次の結果だった。
+
+| 区間 | count | average | p50 | p95 | p99 | maximum |
+|---|---:|---:|---:|---:|---:|---:|
+| miss + attach | 1 | 5.950 µs | 5.950 µs | 5.950 µs | 5.950 µs | 5.950 µs |
+| cache hit | 10000 | 0.0572 µs | 0.056 µs | 0.060 µs | 0.062 µs | 3.714 µs |
+
+`BufferViewMapper::map()` 全体の専用 timing は今回の example には組み込まれていないため未計測である。
+
+### 実example / syscall 検証
+
+2026-07-24 に RTX 4060 Laptop GPU、CUDA IPC、4 slot、30 Hz、640x480、3 Subscriber
+（preview、encoder-like、inference-like）を約40秒実行した。各 Subscriber の status log は
+`received=1170` まで進み、map失敗や lease mapping attach failure は記録されなかった。
+
+SHM名 `/ros2_cuda_ipc_lease_validation_<uuid>` に対する `strace -f` の集計は次のとおりだった。
+
+| process | mapping `openat` | `newfstatat` | 96-byte `mmap` | mapping `close` | 96-byte `munmap` |
+|---|---:|---:|---:|---:|---:|
+| Publisher create | 1 (`O_CREAT`) | 0 | 1 | 1 | 1 (終了時) |
+| preview Subscriber | 1 | 1 | 1 | 1 | 1 (終了時) |
+| encoder-like Subscriber | 1 | 1 | 1 | 1 | 1 (終了時) |
+| inference-like Subscriber | 1 | 1 | 1 | 1 | 1 (終了時) |
+
+Subscriber側は各々、約1170 messageに対して attach相当の `openat`/`newfstatat`/`mmap`/`close` が
+1回だけ発生した。cache hit/destroy counterはexample本体に未実装だが、正常に処理された1170 messageを
+基準にすると各 Subscriber は attach 1、cache hit 約1169、実行中 destroy 0、終了時 destroy 1と解釈できる。
+`munmap` は timeout による SIGINT 後の process cleanup で観測した。
+
+SIGINT cleanup時にCUDA IPC resource側の `CUDA_ERROR_UNKNOWN` ログが出たが、これは既存の CUDA resource
+cleanup経路の事象であり、LeaseMappingの attach再実行やSHM mapping failureではなかった。
+
+### 関連テスト
+
+`test_lease_mapping_cache` は次を検証する。
+
+- callback-local 相当の lease を1000回取得・解放しても attach は1回で、cache entry は mapping を保持する。
+- active lease がない状態の clear では mapping が破棄される。
+- active lease がある状態の clear では mapping が生存し、lease 解放後に破棄される。
+- 同一 key の concurrent duplicate attach は一つの cache entry に収束する。
+- 異なる Publisher instance は同じ SHM 名でも別 entry になる。
+- attach failure と attach exception は cache を汚染しない。

--- a/doc/design.md
+++ b/doc/design.md
@@ -233,6 +233,21 @@ cache entry は明示的な `clear()` または process 終了まで保持され
 Publisher restart では publisher instance identity が変わり、異なる key の entry が追加され得る。
 現時点では entry 数の上限、eviction、Publisher instance 単位の自動 prune は行わない unbounded policy とする。
 
+Subscriber の `LeaseMappingCache` も同じ ownership 方針を採用する。cache は
+`std::unordered_map<Key, std::shared_ptr<lease::LeaseMapping>>` を保持し、POSIX shared-memory の
+mapping を message 間で再利用する。entry の `Key` は `shm_name` と `publisher_instance_id` で構成されるため、
+同じ SHM 名でも Publisher instance が異なれば別 mapping として扱う。
+
+`LeaseMappingCache` と active な `LeaseHandle` は同じ `LeaseMapping` を `shared_ptr` で shared ownership する。
+そのため callback-local な `BufferView` が破棄されても cache entry は mapping を保持し、同じ Publisher instance
+に対する次の message では attach 済み mapping を再利用できる。cache の `clear()` は entry を mutex の外で
+破棄するため、active な `LeaseHandle` が残っていれば slot metadata への参照と lease semantics は有効なままであり、
+最後の `LeaseHandle` が解放された時点で mapping が破棄される。
+
+Lease mapping cache は現時点では unbounded policy である。entry は明示的な `clear()` または process 終了まで保持され、
+LRU、TTL、最大 entry 数、Publisher instance 単位の自動 prune、background cleanup は行わない。Publisher restart
+では新しい `publisher_instance_id` の entry が追加される可能性がある。
+
 この設計により、GPU メモリの配布方法だけを MemoryBackend/MemoryImporter で差し替え、ROS 2 メッセージ形式と
 BufferView と Mapper の API を維持したまま Jetson Orin をサポートできる。
 Publisher は wire message を直接構築し、Subscriber は Mapper API で明示的に View を取得する。

--- a/ros2_cuda_ipc_core/CMakeLists.txt
+++ b/ros2_cuda_ipc_core/CMakeLists.txt
@@ -81,6 +81,8 @@ if(BUILD_TESTING)
   target_link_libraries(test_lease_handle ${PROJECT_NAME})
   ament_add_gtest(test_ipc_handle_cache test/test_ipc_handle_cache.cpp)
   target_link_libraries(test_ipc_handle_cache ${PROJECT_NAME})
+  ament_add_gtest(test_lease_mapping_cache test/test_lease_mapping_cache.cpp)
+  target_link_libraries(test_lease_mapping_cache ${PROJECT_NAME})
   # mapper tests
   ament_add_gtest(test_buffer_view_mapper test/mapper/test_buffer_view_mapper.cpp)
   target_link_libraries(test_buffer_view_mapper ${PROJECT_NAME})

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/lease/lease_mapping.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/lease/lease_mapping.hpp
@@ -24,8 +24,8 @@ struct SlotMeta {
 /// Owns one POSIX shared-memory mapping.
 ///
 /// The object deliberately has no process-global cache. Callers that need to
-/// share a mapping must retain the returned shared_ptr (or use a cache whose
-/// values are weak_ptrs).
+/// share a mapping must retain the returned shared_ptr. The subscriber's
+/// LeaseMappingCache is one such owner and retains mappings between messages.
 class LeaseMapping {
  public:
   /// Create and map a new shared-memory lease pool exclusively.

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view_mapper.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view_mapper.hpp
@@ -3,10 +3,13 @@
 
 #pragma once
 
+#include <cstddef>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 #include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/lease/lease_mapping.hpp"
@@ -20,12 +23,23 @@ struct BufferViewMapperOptions {
       rclcpp::get_logger("ros2_cuda_ipc_core.BufferViewMapper");
 };
 
-/// Reuses subscriber mappings without extending their lifetime.
+/// Strongly owns subscriber mappings so they can be reused between messages.
 class LeaseMappingCache {
  public:
+  using AttachFn = std::function<std::shared_ptr<lease::LeaseMapping>(
+      const std::string&, const PublisherInstanceId&)>;
+
+  explicit LeaseMappingCache(AttachFn attach_fn = lease::LeaseMapping::attach);
+  ~LeaseMappingCache();
+
   std::shared_ptr<lease::LeaseMapping> get_or_attach(
       const std::string& shm_name,
       const PublisherInstanceId& publisher_instance_id) const;
+
+  /// Release all cache-owned mappings without holding the cache mutex.
+  void clear() const;
+
+  std::size_t size() const;
 
  private:
   struct Key {
@@ -42,8 +56,9 @@ class LeaseMappingCache {
     std::size_t operator()(const Key& key) const noexcept;
   };
 
+  AttachFn attach_fn_;
   mutable std::mutex mutex_;
-  mutable std::unordered_map<Key, std::weak_ptr<lease::LeaseMapping>, KeyHash>
+  mutable std::unordered_map<Key, std::shared_ptr<lease::LeaseMapping>, KeyHash>
       mappings_;
 };
 

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
@@ -49,36 +49,55 @@ std::size_t LeaseMappingCache::KeyHash::operator()(
   return hash;
 }
 
+LeaseMappingCache::LeaseMappingCache(AttachFn attach_fn)
+    : attach_fn_(std::move(attach_fn)) {}
+
+LeaseMappingCache::~LeaseMappingCache() { clear(); }
+
 std::shared_ptr<lease::LeaseMapping> LeaseMappingCache::get_or_attach(
     const std::string& shm_name,
     const PublisherInstanceId& publisher_instance_id) const {
   const Key key{shm_name, publisher_instance_id};
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    auto it = mappings_.find(key);
+    const auto it = mappings_.find(key);
     if (it != mappings_.end()) {
-      if (auto mapping = it->second.lock()) {
-        return mapping;
-      }
-      mappings_.erase(it);
+      return it->second;
     }
   }
 
-  auto mapping = lease::LeaseMapping::attach(shm_name, publisher_instance_id);
-  if (!mapping) {
+  auto candidate = attach_fn_(shm_name, publisher_instance_id);
+  if (!candidate) {
     return nullptr;
   }
 
-  std::lock_guard<std::mutex> lock(mutex_);
-  auto it = mappings_.find(key);
-  if (it != mappings_.end()) {
-    if (auto existing = it->second.lock()) {
-      return existing;
-    }
-    mappings_.erase(it);
+  std::shared_ptr<lease::LeaseMapping> result;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const auto [it, inserted] = mappings_.emplace(key, candidate);
+    (void)inserted;
+    // Keep the first mapping for this key. If this was a duplicate, the
+    // candidate remains local and is released after this scope drops the
+    // cache mutex.
+    result = it->second;
   }
-  mappings_.emplace(key, mapping);
-  return mapping;
+  return result;
+}
+
+void LeaseMappingCache::clear() const {
+  decltype(mappings_) entries;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    entries.swap(mappings_);
+  }
+  // LeaseMapping destruction calls munmap(2). Do not run it while holding the
+  // cache mutex, because destruction may call code that needs this cache.
+  entries.clear();
+}
+
+std::size_t LeaseMappingCache::size() const {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return mappings_.size();
 }
 
 BufferViewMapper::BufferViewMapper(BufferViewMapperOptions options)

--- a/ros2_cuda_ipc_core/test/test_lease_mapping_cache.cpp
+++ b/ros2_cuda_ipc_core/test/test_lease_mapping_cache.cpp
@@ -1,0 +1,348 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#include <gtest/gtest.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <numeric>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "ros2_cuda_ipc_core/lease/lease_handle.hpp"
+#include "ros2_cuda_ipc_core/subscriber/buffer_view_mapper.hpp"
+#include "test_instance_id.hpp"
+
+namespace {
+
+std::string make_unique_shm_name(const std::string& prefix) {
+  static std::atomic<int> counter{0};
+  std::ostringstream oss;
+  oss << "/" << prefix << "_" << ::getpid() << "_" << counter.fetch_add(1);
+  return oss.str();
+}
+
+struct FactoryState {
+  ~FactoryState() {
+    std::lock_guard<std::mutex> lock(mutex);
+    for (const auto& shm_name : shm_names) {
+      ::shm_unlink(shm_name.c_str());
+    }
+  }
+
+  std::atomic<std::size_t> attach_count{0};
+  std::atomic<std::size_t> destroy_count{0};
+  std::atomic<std::size_t> observed_cache_size{999};
+  std::atomic<ros2_cuda_ipc_core::subscriber::LeaseMappingCache*> cache{
+      nullptr};
+  std::mutex mutex;
+  std::vector<std::string> shm_names;
+};
+
+std::shared_ptr<ros2_cuda_ipc_core::lease::LeaseMapping> make_counted_mapping(
+    const std::shared_ptr<FactoryState>& state,
+    const ros2_cuda_ipc_core::PublisherInstanceId& publisher_instance_id,
+    const std::string& prefix) {
+  const std::string shm_name = make_unique_shm_name(prefix);
+  auto owner = ros2_cuda_ipc_core::lease::LeaseMapping::create(
+      shm_name, publisher_instance_id, 1);
+  if (!owner) {
+    return nullptr;
+  }
+  {
+    std::lock_guard<std::mutex> lock(state->mutex);
+    state->shm_names.push_back(shm_name);
+  }
+
+  auto* mapping = owner.get();
+  return std::shared_ptr<ros2_cuda_ipc_core::lease::LeaseMapping>(
+      mapping, [state, owner = std::move(owner)](
+                   ros2_cuda_ipc_core::lease::LeaseMapping*) mutable noexcept {
+        if (auto* cache = state->cache.load()) {
+          state->observed_cache_size.store(cache->size());
+        }
+        state->destroy_count.fetch_add(1);
+        owner.reset();
+      });
+}
+
+ros2_cuda_ipc_core::subscriber::LeaseMappingCache::AttachFn make_factory(
+    const std::shared_ptr<FactoryState>& state, const std::string& prefix) {
+  return [state, prefix](
+             const std::string&,
+             const ros2_cuda_ipc_core::PublisherInstanceId& instance_id) {
+    state->attach_count.fetch_add(1);
+    return make_counted_mapping(state, instance_id, prefix);
+  };
+}
+
+}  // namespace
+
+namespace ros2_cuda_ipc_core {
+
+using subscriber::LeaseMappingCache;
+
+TEST(LeaseMappingCacheTest, ReusesMappingAcrossCallbackLocalLeases) {
+  auto state = std::make_shared<FactoryState>();
+  LeaseMappingCache cache(make_factory(state, "lease_cache_reuse"));
+  state->cache.store(&cache);
+
+  const std::string logical_shm_name = "/logical_lease_cache_reuse";
+  const auto instance_id = test::publisher_instance_id(logical_shm_name);
+  auto first = cache.get_or_attach(logical_shm_name, instance_id);
+  ASSERT_TRUE(first);
+
+  auto reservation = lease::LeaseHandle::reserve_for_publish(first, 0);
+  ASSERT_TRUE(reservation.has_value());
+  const auto slot_id = reservation->slot_id;
+  const auto generation = reservation->generation;
+  reservation.reset();
+
+  for (int i = 0; i < 1000; ++i) {
+    auto mapping = cache.get_or_attach(logical_shm_name, instance_id);
+    ASSERT_TRUE(mapping);
+    EXPECT_EQ(mapping.get(), first.get());
+    {
+      auto lease = lease::LeaseHandle::acquire(mapping, slot_id, generation);
+      ASSERT_TRUE(lease.valid());
+    }
+  }
+
+  EXPECT_EQ(state->attach_count.load(), 1u);
+  EXPECT_EQ(cache.size(), 1u);
+  EXPECT_EQ(state->destroy_count.load(), 0u);
+
+  first.reset();
+  cache.clear();
+  EXPECT_EQ(cache.size(), 0u);
+  EXPECT_EQ(state->destroy_count.load(), 1u);
+  EXPECT_EQ(state->observed_cache_size.load(), 0u);
+}
+
+TEST(LeaseMappingCacheTest, ClearReleasesMappingWithoutActiveLease) {
+  auto state = std::make_shared<FactoryState>();
+  LeaseMappingCache cache(make_factory(state, "lease_cache_clear"));
+  state->cache.store(&cache);
+
+  const auto instance_id = test::publisher_instance_id("clear");
+  auto mapping = cache.get_or_attach("/logical_lease_cache_clear", instance_id);
+  ASSERT_TRUE(mapping);
+  std::weak_ptr<lease::LeaseMapping> weak_mapping = mapping;
+  mapping.reset();
+
+  cache.clear();
+
+  EXPECT_EQ(cache.size(), 0u);
+  EXPECT_TRUE(weak_mapping.expired());
+  EXPECT_EQ(state->destroy_count.load(), 1u);
+  EXPECT_EQ(state->observed_cache_size.load(), 0u);
+}
+
+TEST(LeaseMappingCacheTest, ClearPreservesMappingForActiveLease) {
+  auto state = std::make_shared<FactoryState>();
+  LeaseMappingCache cache(make_factory(state, "lease_cache_active"));
+  state->cache.store(&cache);
+
+  const auto instance_id = test::publisher_instance_id("active");
+  auto mapping =
+      cache.get_or_attach("/logical_lease_cache_active", instance_id);
+  ASSERT_TRUE(mapping);
+  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping, 1);
+  ASSERT_TRUE(reservation.has_value());
+  const auto slot_id = reservation->slot_id;
+  const auto generation = reservation->generation;
+  reservation.reset();
+
+  std::weak_ptr<lease::LeaseMapping> weak_mapping = mapping;
+
+  {
+    auto active_lease =
+        lease::LeaseHandle::acquire(mapping, slot_id, generation);
+    ASSERT_TRUE(active_lease.valid());
+    mapping.reset();
+    cache.clear();
+
+    EXPECT_EQ(cache.size(), 0u);
+    EXPECT_FALSE(weak_mapping.expired());
+    EXPECT_TRUE(active_lease.valid());
+    EXPECT_EQ(state->destroy_count.load(), 0u);
+    EXPECT_EQ(state->observed_cache_size.load(), 999u);
+  }
+
+  EXPECT_TRUE(weak_mapping.expired());
+  EXPECT_EQ(state->destroy_count.load(), 1u);
+}
+
+TEST(LeaseMappingCacheTest, ConcurrentDuplicateAttachKeepsOneEntry) {
+  constexpr std::size_t kThreadCount = 8;
+  auto state = std::make_shared<FactoryState>();
+  std::atomic<std::size_t> attach_started{0};
+  std::atomic<bool> start{false};
+  std::atomic<bool> allow_attach{false};
+  LeaseMappingCache cache([state, &attach_started, &start, &allow_attach](
+                              const std::string&,
+                              const PublisherInstanceId& instance_id) {
+    while (!start.load()) {
+      std::this_thread::yield();
+    }
+    state->attach_count.fetch_add(1);
+    attach_started.fetch_add(1);
+    while (!allow_attach.load()) {
+      std::this_thread::yield();
+    }
+    return make_counted_mapping(state, instance_id, "lease_cache_duplicate");
+  });
+  state->cache.store(&cache);
+
+  const std::string logical_shm_name = "/logical_lease_cache_duplicate";
+  const auto instance_id = test::publisher_instance_id(logical_shm_name);
+  std::vector<std::shared_ptr<lease::LeaseMapping>> returned(kThreadCount);
+  std::vector<std::thread> threads;
+  threads.reserve(kThreadCount);
+  for (std::size_t i = 0; i < kThreadCount; ++i) {
+    threads.emplace_back([&, i] {
+      returned[i] = cache.get_or_attach(logical_shm_name, instance_id);
+    });
+  }
+
+  start.store(true);
+  while (attach_started.load() != kThreadCount) {
+    std::this_thread::yield();
+  }
+  allow_attach.store(true);
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  ASSERT_EQ(cache.size(), 1u);
+  ASSERT_TRUE(returned.front());
+  for (const auto& mapping : returned) {
+    ASSERT_TRUE(mapping);
+    EXPECT_EQ(mapping.get(), returned.front().get());
+  }
+  EXPECT_EQ(state->attach_count.load(), kThreadCount);
+  EXPECT_EQ(state->destroy_count.load(), kThreadCount - 1);
+  EXPECT_EQ(state->observed_cache_size.load(), 1u);
+
+  returned.clear();
+  EXPECT_EQ(state->destroy_count.load(), kThreadCount - 1);
+  cache.clear();
+  EXPECT_EQ(state->destroy_count.load(), kThreadCount);
+  EXPECT_EQ(state->observed_cache_size.load(), 0u);
+}
+
+TEST(LeaseMappingCacheTest, DifferentPublisherInstancesUseDifferentEntries) {
+  auto state = std::make_shared<FactoryState>();
+  LeaseMappingCache cache(make_factory(state, "lease_cache_instances"));
+  state->cache.store(&cache);
+
+  const std::string shm_name = "/logical_lease_cache_instances";
+  const auto first_id = test::publisher_instance_id("instance-first");
+  const auto second_id = test::publisher_instance_id("instance-second");
+  auto first = cache.get_or_attach(shm_name, first_id);
+  auto second = cache.get_or_attach(shm_name, second_id);
+  ASSERT_TRUE(first);
+  ASSERT_TRUE(second);
+
+  EXPECT_NE(first.get(), second.get());
+  EXPECT_EQ(cache.size(), 2u);
+  EXPECT_EQ(state->attach_count.load(), 2u);
+  EXPECT_EQ(cache.get_or_attach(shm_name, first_id).get(), first.get());
+}
+
+TEST(LeaseMappingCacheTest, AttachFailureDoesNotPopulateCache) {
+  std::atomic<std::size_t> attach_count{0};
+  LeaseMappingCache cache(
+      [&attach_count](const std::string&, const PublisherInstanceId&) {
+        attach_count.fetch_add(1);
+        return std::shared_ptr<lease::LeaseMapping>{};
+      });
+
+  const auto instance_id = test::publisher_instance_id("failure");
+  EXPECT_FALSE(cache.get_or_attach("/missing_lease_cache", instance_id));
+  EXPECT_FALSE(cache.get_or_attach("/missing_lease_cache", instance_id));
+  EXPECT_EQ(cache.size(), 0u);
+  EXPECT_EQ(attach_count.load(), 2u);
+}
+
+TEST(LeaseMappingCacheTest, AttachExceptionLeavesCacheUnchanged) {
+  LeaseMappingCache cache(
+      [](const std::string&,
+         const PublisherInstanceId&) -> std::shared_ptr<lease::LeaseMapping> {
+        throw std::runtime_error("synthetic attach failure");
+      });
+
+  EXPECT_THROW(cache.get_or_attach("/exception_lease_cache",
+                                   test::publisher_instance_id("exception")),
+               std::runtime_error);
+  EXPECT_EQ(cache.size(), 0u);
+}
+
+TEST(LeaseMappingCacheTest, ReportsMissAndHitLatency) {
+  const std::string shm_name = make_unique_shm_name("lease_cache_timing");
+  const auto instance_id = test::publisher_instance_id(shm_name);
+  auto publisher_mapping =
+      lease::LeaseMapping::create(shm_name, instance_id, 1);
+  ASSERT_TRUE(publisher_mapping);
+
+  LeaseMappingCache cache;
+  const auto miss_start = std::chrono::steady_clock::now();
+  auto first = cache.get_or_attach(shm_name, instance_id);
+  const auto miss_end = std::chrono::steady_clock::now();
+  ASSERT_TRUE(first);
+
+  constexpr std::size_t kHitCount = 10000;
+  std::vector<double> hit_ns;
+  hit_ns.reserve(kHitCount);
+  for (std::size_t i = 0; i < kHitCount; ++i) {
+    const auto start = std::chrono::steady_clock::now();
+    auto mapping = cache.get_or_attach(shm_name, instance_id);
+    const auto end = std::chrono::steady_clock::now();
+    ASSERT_TRUE(mapping);
+    ASSERT_EQ(mapping.get(), first.get());
+    hit_ns.push_back(
+        std::chrono::duration<double, std::nano>(end - start).count());
+  }
+
+  const auto miss_ns =
+      std::chrono::duration<double, std::nano>(miss_end - miss_start).count();
+  std::sort(hit_ns.begin(), hit_ns.end());
+  const auto percentile = [&hit_ns](double quantile) {
+    const auto index = static_cast<std::size_t>(
+        quantile * static_cast<double>(hit_ns.size() - 1));
+    return hit_ns[index];
+  };
+  const double hit_average =
+      std::accumulate(hit_ns.begin(), hit_ns.end(), 0.0) /
+      static_cast<double>(hit_ns.size());
+
+  std::cout << "[timing] LeaseMappingCache get_or_attach miss count=1"
+            << " average=" << miss_ns << "ns"
+            << " p50=" << miss_ns << "ns"
+            << " p95=" << miss_ns << "ns"
+            << " p99=" << miss_ns << "ns"
+            << " maximum=" << miss_ns << "ns\n"
+            << "[timing] LeaseMappingCache get_or_attach hit count="
+            << kHitCount << " average=" << hit_average << "ns"
+            << " p50=" << percentile(0.50) << "ns"
+            << " p95=" << percentile(0.95) << "ns"
+            << " p99=" << percentile(0.99) << "ns"
+            << " maximum=" << hit_ns.back() << "ns\n";
+
+  EXPECT_EQ(cache.size(), 1u);
+  cache.clear();
+  publisher_mapping.reset();
+  ::shm_unlink(shm_name.c_str());
+}
+
+}  // namespace ros2_cuda_ipc_core

--- a/ros2_cuda_ipc_core/test/test_lease_mapping_cache.cpp
+++ b/ros2_cuda_ipc_core/test/test_lease_mapping_cache.cpp
@@ -16,6 +16,7 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "ros2_cuda_ipc_core/lease/lease_handle.hpp"
@@ -30,6 +31,20 @@ std::string make_unique_shm_name(const std::string& prefix) {
   oss << "/" << prefix << "_" << ::getpid() << "_" << counter.fetch_add(1);
   return oss.str();
 }
+
+class ShmUnlinkGuard {
+ public:
+  explicit ShmUnlinkGuard(std::string shm_name)
+      : shm_name_(std::move(shm_name)) {}
+
+  ~ShmUnlinkGuard() { ::shm_unlink(shm_name_.c_str()); }
+
+  ShmUnlinkGuard(const ShmUnlinkGuard&) = delete;
+  ShmUnlinkGuard& operator=(const ShmUnlinkGuard&) = delete;
+
+ private:
+  std::string shm_name_;
+};
 
 struct FactoryState {
   ~FactoryState() {
@@ -290,6 +305,7 @@ TEST(LeaseMappingCacheTest, AttachExceptionLeavesCacheUnchanged) {
 
 TEST(LeaseMappingCacheTest, ReportsMissAndHitLatency) {
   const std::string shm_name = make_unique_shm_name("lease_cache_timing");
+  const ShmUnlinkGuard shm_unlink_guard(shm_name);
   const auto instance_id = test::publisher_instance_id(shm_name);
   auto publisher_mapping =
       lease::LeaseMapping::create(shm_name, instance_id, 1);
@@ -342,7 +358,6 @@ TEST(LeaseMappingCacheTest, ReportsMissAndHitLatency) {
   EXPECT_EQ(cache.size(), 1u);
   cache.clear();
   publisher_mapping.reset();
-  ::shm_unlink(shm_name.c_str());
 }
 
 }  // namespace ros2_cuda_ipc_core


### PR DESCRIPTION
## Summary

Change the subscriber-side LeaseMappingCache from a weak index to an unbounded strong cache holding shared_ptr<LeaseMapping>.

## Why

Callback-local BufferView objects released the last strong LeaseMapping reference after every message, causing repeated shm_open/fstat/mmap/close/munmap operations. The cache now retains mappings between messages for the same (shm_name, publisher_instance_id) key.

## Changes

- Store shared_ptr<LeaseMapping> in LeaseMappingCache.
- Return existing entries directly and remove expired-entry handling.
- Keep attach and duplicate candidate destruction outside the cache mutex.
- Add clear() and size(); clear swaps entries out before destruction.
- Preserve LeaseHandle's shared_ptr<LeaseMapping> ownership.
- Add cache, lifetime, failure, key isolation, concurrency, and timing tests.
- Document the strong ownership and unbounded policy.

## Validation

- ros2_cuda_ipc_core Release build: passed.
- ros2_cuda_ipc_core tests: 90 passed, 0 failures.
- multi_process_image_fanout Release build/test: passed.
- CUDA IPC example: 3 subscribers processed about 1170 messages each.
- strace: each subscriber performed one mapping openat/newfstatat/mmap/close sequence; munmap occurred once at shutdown.
- get_or_attach timing: miss 5.950 us; hit average 0.0572 us, p50 0.056 us, p95 0.060 us, p99 0.062 us, max 3.714 us.

The cache remains intentionally unbounded; entries are retained until explicit cache clear or process termination, with no LRU/TTL/automatic eviction.