### PR TITLE
Prepare v0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+This document records the user-visible changes between releases of
+`ros2_cuda_ipc`.
+
+## [0.3.0] - 2026-07-25
+
+This release is primarily an internal refactoring release. The core CUDA
+implementation now uses the CUDA Driver API, which removes the core library's
+dependency on the CUDA Runtime library (`libcudart.so`).
+
+### Highlights
+
+- Migrated CUDA initialization, context handling, memory imports, IPC events,
+  and stream synchronization in `ros2_cuda_ipc_core` to the CUDA Driver API.
+- Added process-wide Driver API initialization, primary-context ownership,
+  scoped context activation, and Driver API error reporting utilities.
+- Reworked CUDA IPC and VMM-FD resource ownership around RAII, including
+  shared ownership of imported resources and deterministic cleanup of cached
+  resources.
+- Unified the public stream-facing APIs on `CUstream`, which is compatible
+  with stream handles created by the CUDA Runtime API.
+- Strengthened ownership and cleanup semantics for the IPC handle cache and
+  lease-mapping cache, and made cache keys device-aware.
+
+### Breaking changes and migration notes
+
+- `ros2_cuda_ipc_core` now links to the CUDA Driver library only; it no longer
+  links to `CUDA::cudart`. Applications that use the CUDA Runtime API must link
+  `CUDA::cudart` themselves.
+- Public stream and ready-event methods now use `CUstream` and return the
+  Driver API-oriented `ros2_cuda_ipc_core::detail::CudaResult` type instead of
+  `cudaStream_t` and `cudaError_t`.
+- Applications that create streams with the CUDA Runtime API should include
+  `<cuda_runtime_api.h>` explicitly. Runtime-created `cudaStream_t` handles
+  remain usable with the `CUstream`-based APIs.
+- Applications using the core public headers should review error handling for
+  Driver API result values and update any code that directly checks
+  `cudaError_t` return values.
+
+### Tests and documentation
+
+- Added Driver API context, ready-event, CUDA IPC memory, public stream, and
+  lease-mapping cache tests, including cross-process coverage.
+- Expanded resource-lifetime and cache cleanup coverage.
+- Updated the design, lease protocol, development, and demo documentation for
+  the Driver API-based implementation and stream API.
+- Added documentation pointing ROS 2 Lyrical users to the upstream
+  `rosidl::Buffer` CUDA buffer implementation for new projects.
+
+### Package versions
+
+All packages are bumped from `0.2.0` to `0.3.0`:
+
+- `ros2_cuda_ipc_core`
+- `ros2_cuda_ipc_msgs`
+- `multi_process_image_fanout`
+- `gpu_image_transport`
+- `cuda_ipc_poc`
+
+[0.3.0]: https://github.com/dskkato/ros2_cuda_ipc/compare/v0.2.0...v0.3.0

--- a/examples/multi_process_image_fanout/package.xml
+++ b/examples/multi_process_image_fanout/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>multi_process_image_fanout</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Primary ros2_cuda_ipc demo for one GPU image publisher fanning out to multiple processes.</description>
   <maintainer email="dskkato@example.com">dskkato</maintainer>
   <license>MIT</license>

--- a/ros2_cuda_ipc_core/package.xml
+++ b/ros2_cuda_ipc_core/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ros2_cuda_ipc_core</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Core C++ utilities for ROS 2 GPU zero-copy transport using CUDA IPC.</description>
   <maintainer email="dskkato@example.com">dskkato</maintainer>
   <license>MIT</license>

--- a/ros2_cuda_ipc_msgs/package.xml
+++ b/ros2_cuda_ipc_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ros2_cuda_ipc_msgs</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Message definitions for ROS 2 GPU zero-copy transport using CUDA IPC.</description>
   <maintainer email="dskkato@example.com">dskkato</maintainer>
   <license>MIT</license>

--- a/utils/cuda_ipc_poc/package.xml
+++ b/utils/cuda_ipc_poc/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>cuda_ipc_poc</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Test applications for CUDA IPC mechanisms (both cudaIpc and VMM-FD)</description>
   <maintainer email="dskkato@users.noreply.github.com">dskkato</maintainer>
   <license>Apache-2.0</license>

--- a/utils/gpu_image_transport/package.xml
+++ b/utils/gpu_image_transport/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>gpu_image_transport</name>
-  <version>0.2.0</version>
+  <version>0.3.0</version>
   <description>Utility nodes that map ros2_cuda_ipc GpuImage messages to CPU sensor_msgs image topics.</description>
   <maintainer email="dskkato@example.com">dskkato</maintainer>
   <license>MIT</license>


### PR DESCRIPTION
## Summary

- Prepare all ROS 2 packages for the v0.3.0 release.
- Add a standalone CHANGELOG.md covering changes since v0.2.0.
- Document the CUDA Driver API migration, public stream API changes, and migration notes.

## User impact

The core library now links to the CUDA Driver library only and no longer links to CUDA Runtime (`libcudart.so`). Applications that use the CUDA Runtime API must link `CUDA::cudart` themselves. Public stream and ready-event APIs now use `CUstream` and Driver API-oriented result values.

## Validation

- XML-validated all five package manifests at version 0.3.0.
- `git diff --check`
- `CUDACXX=/usr/local/cuda/bin/nvcc colcon build --packages-up-to ros2_cuda_ipc_core`
- Humble core tests: 14 passed, 0 failed, 1 skipped because the host has one GPU.
