### PR TITLE
Expose native image view metadata

### DIFF
--- a/ros2_cuda_ipc_py/README.md
+++ b/ros2_cuda_ipc_py/README.md
@@ -41,11 +41,11 @@ def callback(msg):
 preserves the message's `(rows, cols, channels)` shape, byte strides, and dtype,
 and the returned array keeps the native image lease alive until it is released.
 
-`ImageView` exposes semantic image metadata such as `device_id`, `shape`,
-`strides`, `dtype`, `encoding`, and `frame_id`. GPU pointers, allocation size,
-and lease-generation fields are intentionally not view attributes. Use the
-standard `__dlpack__()` and `__dlpack_device__()` protocols for framework
-interop; `repr(image)` includes a diagnostic summary when debugging is needed.
+`ImageView` exposes the mapped allocation metadata directly, including
+`device_ptr`, `byte_size`, `device_id`, `slot_id`, `generation`, `shape`,
+`strides`, `dtype`, `encoding`, and `frame_id`. `dtype` is the public dtype
+representation; the numeric `dtype_code` is not exposed. Use the standard
+`__dlpack__()` and `__dlpack_device__()` protocols for framework interop.
 
 Framework-neutral DLPack consumers use the standard producer protocol:
 

--- a/ros2_cuda_ipc_py/examples/gpu_image_cupy_subscriber.py
+++ b/ros2_cuda_ipc_py/examples/gpu_image_cupy_subscriber.py
@@ -38,7 +38,7 @@ class GpuImageSubscriber(Node):
             self.get_logger().info(
                 f"received {image.encoding or '<unspecified>'} "
                 f"shape={array.shape} dtype={array.dtype} "
-                f"device={image.device_id}"
+                f"device_ptr=0x{image.device_ptr:x}"
             )
         except (MappingError, RuntimeError, TypeError, ValueError) as exc:
             self.get_logger().warning(f"skipping GPU image: {exc}")

--- a/ros2_cuda_ipc_py/examples/gpu_image_torch_subscriber.py
+++ b/ros2_cuda_ipc_py/examples/gpu_image_torch_subscriber.py
@@ -40,7 +40,7 @@ class GpuImageTorchSubscriber(Node):
             consumer_stream.synchronize()
             self.get_logger().info(
                 f"received shape={tuple(result.shape)} dtype={result.dtype} "
-                f"device={image.device_id}"
+                f"device_ptr=0x{image.device_ptr:x}"
             )
         except (MappingError, RuntimeError, TypeError, ValueError) as exc:
             self.get_logger().warning(f"skipping GPU image: {exc}")

--- a/ros2_cuda_ipc_py/ros2_cuda_ipc_py/_api.py
+++ b/ros2_cuda_ipc_py/ros2_cuda_ipc_py/_api.py
@@ -11,16 +11,6 @@ MappingError = _native.MappingError
 _UINTPTR_MAX = (1 << (ctypes.sizeof(ctypes.c_void_p) * 8)) - 1
 
 
-def _debug_info(native_view):
-    """Return private native diagnostics for view representations."""
-    try:
-        return native_view._debug_info()
-    except AttributeError:
-        # Keep lightweight test doubles and older private native objects usable
-        # without making diagnostics part of the public view contract.
-        return {}
-
-
 def _dlpack_stream_pointer(stream):
     """Normalize the standard CUDA DLPack stream values.
 
@@ -88,18 +78,27 @@ class BufferView:
         return self._native.valid
 
     @property
+    def device_ptr(self):
+        return self._native.device_ptr
+
+    @property
+    def byte_size(self):
+        return self._native.byte_size
+
+    @property
     def device_id(self):
         return self._native.device_id
 
+    @property
+    def slot_id(self):
+        return self._native.slot_id
+
+    @property
+    def generation(self):
+        return self._native.generation
+
     def close(self):
         self._native.close()
-
-    def __repr__(self):
-        return (
-            "BufferView("
-            f"valid={self.valid!r}, "
-            f"debug={_debug_info(self._native)!r})"
-        )
 
     def __enter__(self):
         return self
@@ -123,8 +122,24 @@ class ImageView:
         return self._native.valid
 
     @property
+    def device_ptr(self):
+        return self._native.device_ptr
+
+    @property
+    def byte_size(self):
+        return self._native.byte_size
+
+    @property
     def device_id(self):
         return self._native.device_id
+
+    @property
+    def slot_id(self):
+        return self._native.slot_id
+
+    @property
+    def generation(self):
+        return self._native.generation
 
     @property
     def shape(self):
@@ -189,18 +204,6 @@ class ImageView:
 
     def close(self):
         self._native.close()
-
-    def __repr__(self):
-        return (
-            "ImageView("
-            f"valid={self.valid!r}, "
-            f"shape={self.shape!r}, "
-            f"strides={self.strides!r}, "
-            f"dtype={self.dtype!r}, "
-            f"encoding={self.encoding!r}, "
-            f"frame_id={self.frame_id!r}, "
-            f"debug={_debug_info(self._native)!r})"
-        )
 
     def __enter__(self):
         return self

--- a/ros2_cuda_ipc_py/src/native_module.cpp
+++ b/ros2_cuda_ipc_py/src/native_module.cpp
@@ -367,17 +367,14 @@ class PyBufferView {
       : view_(std::move(view)) {}
 
   bool valid() const noexcept { return view_.valid(); }
-  int device_id() const noexcept { return view_.device_id; }
-  py::dict debug_info() const {
-    py::dict info;
-    info["device_ptr"] =
-        static_cast<uint64_t>(reinterpret_cast<uintptr_t>(view_.device_ptr()));
-    info["byte_size"] = view_.byte_size;
-    info["device_id"] = view_.device_id;
-    info["slot_id"] = view_.slot_id;
-    info["generation"] = view_.generation;
-    return info;
+  uint64_t device_ptr() const noexcept {
+    return static_cast<uint64_t>(
+        reinterpret_cast<uintptr_t>(view_.device_ptr()));
   }
+  uint64_t byte_size() const noexcept { return view_.byte_size; }
+  int device_id() const noexcept { return view_.device_id; }
+  uint32_t slot_id() const noexcept { return view_.slot_id; }
+  uint32_t generation() const noexcept { return view_.generation; }
 
   void close() noexcept { view_.reset(); }
 
@@ -391,7 +388,14 @@ class PyImageView {
       : view_(std::move(view)) {}
 
   bool valid() const noexcept { return view_.valid(); }
+  uint64_t device_ptr() const noexcept {
+    return static_cast<uint64_t>(
+        reinterpret_cast<uintptr_t>(view_.core.device_ptr()));
+  }
+  uint64_t byte_size() const noexcept { return view_.core.byte_size; }
   int device_id() const noexcept { return view_.core.device_id; }
+  uint32_t slot_id() const noexcept { return view_.core.slot_id; }
+  uint32_t generation() const noexcept { return view_.core.generation; }
   py::tuple dlpack_device() const {
     if (!view_.valid()) {
       throw MappingError("cannot export an invalid ImageView through DLPack");
@@ -421,16 +425,6 @@ class PyImageView {
     throw std::logic_error("unsupported ros2_cuda_ipc image dtype");
   }
 
-  py::dict debug_info() const {
-    py::dict info;
-    info["device_ptr"] = static_cast<uint64_t>(
-        reinterpret_cast<uintptr_t>(view_.core.device_ptr()));
-    info["byte_size"] = view_.core.byte_size;
-    info["device_id"] = view_.core.device_id;
-    info["slot_id"] = view_.core.slot_id;
-    info["generation"] = view_.core.generation;
-    return info;
-  }
   py::tuple shape() const {
     return py::make_tuple(view_.shape[0], view_.shape[1], view_.shape[2]);
   }
@@ -690,20 +684,26 @@ PYBIND11_MODULE(_native, module) {
 
   py::class_<PyBufferView>(module, "BufferView")
       .def_property_readonly("valid", &PyBufferView::valid)
+      .def_property_readonly("device_ptr", &PyBufferView::device_ptr)
+      .def_property_readonly("byte_size", &PyBufferView::byte_size)
       .def_property_readonly("device_id", &PyBufferView::device_id)
-      .def("_debug_info", &PyBufferView::debug_info)
+      .def_property_readonly("slot_id", &PyBufferView::slot_id)
+      .def_property_readonly("generation", &PyBufferView::generation)
       .def("close", &PyBufferView::close);
 
   py::class_<PyImageView>(module, "ImageView")
       .def_property_readonly("valid", &PyImageView::valid)
+      .def_property_readonly("device_ptr", &PyImageView::device_ptr)
+      .def_property_readonly("byte_size", &PyImageView::byte_size)
       .def_property_readonly("device_id", &PyImageView::device_id)
+      .def_property_readonly("slot_id", &PyImageView::slot_id)
+      .def_property_readonly("generation", &PyImageView::generation)
       .def_property_readonly("shape", &PyImageView::shape)
       .def_property_readonly("strides", &PyImageView::strides)
       .def_property_readonly("dtype", &PyImageView::dtype)
       .def_property_readonly("encoding", &PyImageView::encoding)
       .def_property_readonly("frame_id", &PyImageView::frame_id)
       .def("_dlpack_device", &PyImageView::dlpack_device)
-      .def("_debug_info", &PyImageView::debug_info)
       .def("_dlpack", &PyImageView::dlpack, py::arg("stream_ptr"),
            py::arg("synchronize"), py::arg("versioned"))
       .def("close", &PyImageView::close);

--- a/ros2_cuda_ipc_py/test/test_python_api.py
+++ b/ros2_cuda_ipc_py/test/test_python_api.py
@@ -39,45 +39,32 @@ def test_extension_imports_and_native_mapper_preserves_metadata():
     assert probe.refcount() == 0
 
 
-def test_views_hide_storage_and_lease_attributes_but_keep_debug_repr():
+def test_views_expose_storage_and_lease_metadata_without_debug_helpers():
     native_view, probe, descriptor = _fixture()
     image = ImageMapper().map(descriptor)
     buffer = BufferViewMapper().map(descriptor["core"])
-    hidden = (
-        "device_ptr",
-        "byte_size",
-        "slot_id",
-        "generation",
-        "dtype_code",
-    )
+    core = descriptor["core"]
 
-    for name in hidden:
-        assert not hasattr(image, name)
-        assert not hasattr(image._native, name)
-        assert not hasattr(native_view, name)
-        assert not hasattr(buffer, name)
-        assert not hasattr(buffer._native, name)
+    for view in (image, image._native, buffer, buffer._native):
+        assert view.device_ptr != 0
+        assert view.byte_size == core["byte_size"]
+        assert view.device_id == core["device_id"]
+        assert view.slot_id == core["slot_id"]
+        assert view.generation == core["generation"]
 
-    assert image.device_id == 0
-    assert buffer.device_id == 0
+    assert image.device_ptr == native_view.device_ptr
+    assert buffer.device_ptr == image.device_ptr
+    assert image.dtype == "uint8"
+    assert not hasattr(image, "dtype_code")
+    assert not hasattr(image._native, "dtype_code")
 
-    buffer_representation = repr(buffer)
-    assert "BufferView(" in buffer_representation
-    assert "device_id" in buffer_representation
-    assert "slot_id" in buffer_representation
-    assert "generation" in buffer_representation
+    for view in (image, image._native, buffer, buffer._native):
+        assert not hasattr(view, "_debug_info")
 
-    representation = repr(image)
-    assert "ImageView(" in representation
-    assert "shape=(2, 3, 4)" in representation
-    assert "dtype='uint8'" in representation
-    assert "device_id" in representation
-    assert "slot_id" in representation
-    assert "generation" in representation
+    assert type(image).__repr__ is object.__repr__
 
     image.close()
     buffer.close()
-    assert "valid=False" in repr(image)
     del image, buffer, native_view
     gc.collect()
     assert probe.refcount() == 0
@@ -264,6 +251,7 @@ def test_torch_from_dlpack_is_zero_copy_and_retains_lease():
     del native_view
     tensor = torch.from_dlpack(image)
     assert tensor.is_cuda
+    assert tensor.data_ptr() == image.device_ptr
     assert tuple(tensor.shape) == image.shape
     assert tuple(tensor.stride()) == (12, 4, 1)
     assert str(tensor.dtype) == "torch.uint8"
@@ -314,6 +302,7 @@ def test_cupy_from_dlpack_is_zero_copy_and_retains_lease_when_available():
     image = ImageView._from_native(native_view)
     del native_view
     array = cp.from_dlpack(image)
+    assert array.data.ptr == image.device_ptr
     assert array.shape == image.shape
     assert array.strides == image.strides
     assert str(array.dtype) == "uint8"


### PR DESCRIPTION
## Summary

- Restore direct access to `device_ptr`, `byte_size`, `device_id`, `slot_id`, and `generation` on `BufferView` and `ImageView`.
- Keep `dtype` as the public dtype representation and remove `dtype_code`.
- Remove the added debug information and custom `__repr__` surfaces.
- Keep `ImageView.__dlpack_device__()` forwarding to the native implementation.

## Validation

- `colcon build --symlink-install --packages-select ros2_cuda_ipc_py`
- `colcon test --packages-select ros2_cuda_ipc_py`
- Package result: 14 passed, 3 skipped because CUDA/CuPy were unavailable.
- `git diff --check`
