### PR TITLE
Replace ros2_cuda_ipc_core logging with rcutils named macros

### DIFF
--- a/examples/multi_process_image_fanout/src/gpu_image_publisher.cpp
+++ b/examples/multi_process_image_fanout/src/gpu_image_publisher.cpp
@@ -47,8 +47,7 @@ class GpuImagePublisherNode : public rclcpp::Node {
         "shm_name_prefix", "/ros2_cuda_ipc_fanout");
     const int device_index = declare_parameter<int>("device_index", 0);
     const auto backend = ros2_cuda_ipc_core::backend::parse_memory_backend(
-        declare_parameter<std::string>("memory_backend", "cuda_ipc"),
-        get_logger());
+        declare_parameter<std::string>("memory_backend", "cuda_ipc"));
     encoding_ = declare_parameter<std::string>("encoding", kDefaultEncoding);
 
     if (width <= 0 || height <= 0) {
@@ -68,8 +67,7 @@ class GpuImagePublisherNode : public rclcpp::Node {
         std::make_unique<ros2_cuda_ipc_core::publisher::GpuBufferManager>(
             ros2_cuda_ipc_core::publisher::GpuBufferManager::Config{
                 shm_name_prefix, slot_count, frame_size_bytes, device_index,
-                pending_ttl, backend},
-            get_logger().get_child("GpuBufferManager"));
+                pending_ttl, backend});
     if (!manager_->initialise()) {
       throw std::runtime_error("Failed to initialise GPU buffer manager");
     }

--- a/ros2_cuda_ipc_core/CMakeLists.txt
+++ b/ros2_cuda_ipc_core/CMakeLists.txt
@@ -10,6 +10,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(rcutils REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(ros2_cuda_ipc_msgs REQUIRED)
@@ -55,6 +56,7 @@ target_include_directories(${PROJECT_NAME}
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC
+    rcutils::rcutils
     rclcpp::rclcpp
     rcpputils::rcpputils
     ${ros2_cuda_ipc_msgs_TARGETS}
@@ -124,5 +126,5 @@ endif()
 
 ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 ament_export_include_directories(include)
-ament_export_dependencies(CUDAToolkit rclcpp rcpputils ros2_cuda_ipc_msgs rosidl_default_runtime sensor_msgs std_msgs)
+ament_export_dependencies(CUDAToolkit rcutils rclcpp rcpputils ros2_cuda_ipc_msgs rosidl_default_runtime sensor_msgs std_msgs)
 ament_package()

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp
@@ -11,8 +11,7 @@ class MemoryImporter final : public backend::MemoryImporter {
  public:
   std::optional<ImportedResources> import(
       const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-      const CUipcEventHandle& event_handle,
-      const rclcpp::Logger& logger) const override;
+      const CUipcEventHandle& event_handle) const override;
 };
 
 }  // namespace ros2_cuda_ipc_core::backend::cuda_ipc

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_backend.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_backend.hpp
@@ -9,7 +9,6 @@
 #include <memory>
 #include <vector>
 
-#include "rclcpp/logger.hpp"
 #include "ros2_cuda_ipc_core/detail/interprocess_event.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 
@@ -32,10 +31,8 @@ class MemoryBackend {
  public:
   virtual ~MemoryBackend() = default;
   virtual bool allocate(uint64_t byte_size, int device_index,
-                        std::vector<SlotResources>& slots,
-                        rclcpp::Logger logger) = 0;
-  virtual void destroy(std::vector<SlotResources>& slots,
-                       rclcpp::Logger logger) noexcept = 0;
+                        std::vector<SlotResources>& slots) = 0;
+  virtual void destroy(std::vector<SlotResources>& slots) noexcept = 0;
 };
 
 }  // namespace ros2_cuda_ipc_core::backend

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_backend_utils.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_backend_utils.hpp
@@ -3,17 +3,17 @@
 
 #pragma once
 
+#include <rcutils/logging_macros.h>
+
 #include <algorithm>
 #include <cctype>
 #include <string>
 
-#include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 
 namespace ros2_cuda_ipc_core::backend {
 
-inline transport::MemoryBackendKind parse_memory_backend(
-    std::string name, const rclcpp::Logger& logger) {
+inline transport::MemoryBackendKind parse_memory_backend(std::string name) {
   std::transform(name.begin(), name.end(), name.begin(), [](unsigned char c) {
     return static_cast<char>(std::tolower(c));
   });
@@ -24,8 +24,10 @@ inline transport::MemoryBackendKind parse_memory_backend(
     return transport::MemoryBackendKind::VMM_FD;
   }
 
-  RCLCPP_WARN(logger, "Unknown memory_backend='%s'; defaulting to CUDA IPC",
-              name.c_str());
+  RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.backend",
+                         "Unknown memory_backend='%s'; defaulting "
+                         "to CUDA IPC",
+                         name.c_str());
   return transport::MemoryBackendKind::CUDA_IPC;
 }
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_importer.hpp
@@ -10,7 +10,6 @@
 #include <optional>
 #include <utility>
 
-#include "rclcpp/logger.hpp"
 #include "ros2_cuda_ipc_core/detail/cuda_driver_context.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 #include "ros2_cuda_ipc_msgs/msg/buffer_core.hpp"
@@ -54,8 +53,7 @@ class MemoryImporter {
 
   virtual std::optional<ImportedResources> import(
       const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-      const CUipcEventHandle& event_handle,
-      const rclcpp::Logger& logger) const = 0;
+      const CUipcEventHandle& event_handle) const = 0;
 };
 
 bool release_imported_resources(const ImportedResources& imported) noexcept;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/vmm_fd/memory_importer.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/vmm_fd/memory_importer.hpp
@@ -11,8 +11,7 @@ class MemoryImporter final : public backend::MemoryImporter {
  public:
   std::optional<ImportedResources> import(
       const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-      const CUipcEventHandle& event_handle,
-      const rclcpp::Logger& logger) const override;
+      const CUipcEventHandle& event_handle) const override;
 };
 
 }  // namespace ros2_cuda_ipc_core::backend::vmm_fd

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp
@@ -10,7 +10,6 @@
 #include <optional>
 #include <string>
 
-#include "rclcpp/logger.hpp"
 #include "ros2_cuda_ipc_core/detail/cuda_driver_context.hpp"
 #include "ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp"
 #include "ros2_cuda_ipc_core/publisher/lease_manager.hpp"
@@ -116,8 +115,8 @@ class GpuBufferManager {
         transport::MemoryBackendKind::CUDA_IPC;
   };
 
-  /// Construct a manager with the given configuration and logger.
-  GpuBufferManager(Config config, rclcpp::Logger logger);
+  /// Construct a manager with the given configuration.
+  explicit GpuBufferManager(Config config);
 
   /// Release manager-owned resources.
   ~GpuBufferManager();
@@ -168,7 +167,6 @@ class GpuBufferManager {
   void cancel(const LeaseManager::Reservation& reservation) noexcept;
 
   Config config_;
-  rclcpp::Logger logger_;
   GpuBufferPool buffer_pool_;
   LeaseManager lease_manager_;
 };

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <vector>
 
-#include "rclcpp/logger.hpp"
 #include "ros2_cuda_ipc_core/backend/memory_backend.hpp"
 #include "ros2_cuda_ipc_core/detail/cuda_driver_context.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
@@ -21,10 +20,8 @@ class GpuBufferPool {
   using SlotResources = backend::SlotResources;
   using MemoryBackend = backend::MemoryBackend;
 
+  GpuBufferPool(std::size_t slot_count, transport::MemoryBackendKind backend);
   GpuBufferPool(std::size_t slot_count, transport::MemoryBackendKind backend,
-                rclcpp::Logger logger);
-  GpuBufferPool(std::size_t slot_count, transport::MemoryBackendKind backend,
-                rclcpp::Logger logger,
                 std::unique_ptr<MemoryBackend> memory_backend);
   ~GpuBufferPool();
 
@@ -52,7 +49,6 @@ class GpuBufferPool {
 
   std::size_t slot_count_;
   transport::MemoryBackendKind backend_kind_;
-  rclcpp::Logger logger_;
   std::vector<SlotResources> slots_;
   uint64_t byte_size_ = 0;
   int device_index_ = -1;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/lease_manager.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/lease_manager.hpp
@@ -11,7 +11,6 @@
 #include <string>
 #include <vector>
 
-#include "rclcpp/logger.hpp"
 #include "ros2_cuda_ipc_core/lease/lease_mapping.hpp"
 #include "ros2_cuda_ipc_core/publisher_instance_id.hpp"
 
@@ -28,7 +27,7 @@ class LeaseManager {
   };
 
   LeaseManager(std::string shm_name_prefix, std::size_t slot_count,
-               std::chrono::milliseconds pending_ttl, rclcpp::Logger logger);
+               std::chrono::milliseconds pending_ttl);
 
   ~LeaseManager();
 
@@ -50,7 +49,6 @@ class LeaseManager {
   PublisherInstanceId publisher_instance_id_{};
   std::size_t slot_count_;
   std::chrono::milliseconds pending_ttl_;
-  rclcpp::Logger logger_;
   mutable std::mutex deadlines_mutex_;
   std::vector<std::chrono::steady_clock::time_point> pending_deadlines_;
   std::shared_ptr<lease::LeaseMapping> mapping_;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view_mapper.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/subscriber/buffer_view_mapper.hpp
@@ -11,17 +11,11 @@
 #include <unordered_map>
 #include <utility>
 
-#include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/lease/lease_mapping.hpp"
 #include "ros2_cuda_ipc_core/subscriber/buffer_view.hpp"
 #include "ros2_cuda_ipc_msgs/msg/buffer_core.hpp"
 
 namespace ros2_cuda_ipc_core::subscriber {
-
-struct BufferViewMapperOptions {
-  rclcpp::Logger logger =
-      rclcpp::get_logger("ros2_cuda_ipc_core.BufferViewMapper");
-};
 
 /// Strongly owns subscriber mappings so they can be reused between messages.
 class LeaseMappingCache {
@@ -64,12 +58,11 @@ class LeaseMappingCache {
 
 class BufferViewMapper {
  public:
-  explicit BufferViewMapper(BufferViewMapperOptions options = {});
+  BufferViewMapper();
 
   BufferView map(const ros2_cuda_ipc_msgs::msg::BufferCore& msg) const;
 
  private:
-  BufferViewMapperOptions options_;
   std::shared_ptr<LeaseMappingCache> mapping_cache_;
 };
 

--- a/ros2_cuda_ipc_core/package.xml
+++ b/ros2_cuda_ipc_core/package.xml
@@ -9,6 +9,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>rclcpp</depend>
+  <depend>rcutils</depend>
   <depend>rcpputils</depend>
   <depend>ros2_cuda_ipc_msgs</depend>
   <depend>sensor_msgs</depend>

--- a/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_backend.cpp
+++ b/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_backend.cpp
@@ -3,12 +3,13 @@
 
 #include "ros2_cuda_ipc_core/backend/cuda_ipc/memory_backend.hpp"
 
+#include <rcutils/logging_macros.h>
+
 #include <cstdint>
 #include <cstring>
 #include <memory>
 #include <vector>
 
-#include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/detail/cuda_driver_context.hpp"
 #include "ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
@@ -18,17 +19,18 @@ namespace {
 
 class CudaIpcMemoryBackend : public publisher::GpuBufferPool::MemoryBackend {
  public:
-  bool allocate(uint64_t frame_size_bytes, int device_index,
-                std::vector<publisher::GpuBufferPool::SlotResources>& slots,
-                rclcpp::Logger logger) override {
+  bool allocate(
+      uint64_t frame_size_bytes, int device_index,
+      std::vector<publisher::GpuBufferPool::SlotResources>& slots) override {
     (void)device_index;
     for (auto& slot : slots) {
       CUdeviceptr device_ptr = 0;
       CUresult result = cuMemAlloc(&device_ptr, frame_size_bytes);
       if (result != CUDA_SUCCESS) {
-        RCLCPP_ERROR(logger, "cuMemAlloc failed: %s",
-                     detail::CudaDriverError(result).to_string().c_str());
-        destroy(slots, logger);
+        RCUTILS_LOG_ERROR_NAMED(
+            "ros2_cuda_ipc_core.backend.cuda_ipc", "cuMemAlloc failed: %s",
+            detail::CudaDriverError(result).to_string().c_str());
+        destroy(slots);
         return false;
       }
       slot.device_ptr =
@@ -37,9 +39,11 @@ class CudaIpcMemoryBackend : public publisher::GpuBufferPool::MemoryBackend {
       CUipcMemHandle handle{};
       result = cuIpcGetMemHandle(&handle, device_ptr);
       if (result != CUDA_SUCCESS) {
-        RCLCPP_ERROR(logger, "cuIpcGetMemHandle failed: %s",
-                     detail::CudaDriverError(result).to_string().c_str());
-        destroy(slots, logger);
+        RCUTILS_LOG_ERROR_NAMED(
+            "ros2_cuda_ipc_core.backend.cuda_ipc",
+            "cuIpcGetMemHandle failed: %s",
+            detail::CudaDriverError(result).to_string().c_str());
+        destroy(slots);
         return false;
       }
       std::memcpy(slot.mem_handle.data(), &handle, sizeof(handle));
@@ -49,16 +53,18 @@ class CudaIpcMemoryBackend : public publisher::GpuBufferPool::MemoryBackend {
     return true;
   }
 
-  void destroy(std::vector<publisher::GpuBufferPool::SlotResources>& slots,
-               rclcpp::Logger logger) noexcept override {
+  void destroy(std::vector<publisher::GpuBufferPool::SlotResources>&
+                   slots) noexcept override {
     for (auto& slot : slots) {
       if (slot.device_ptr) {
         const CUdeviceptr device_ptr = static_cast<CUdeviceptr>(
             reinterpret_cast<uintptr_t>(slot.device_ptr));
         const CUresult result = cuMemFree(device_ptr);
         if (result != CUDA_SUCCESS) {
-          RCLCPP_ERROR(logger, "cuMemFree failed for slot %u: %s", slot.index,
-                       detail::CudaDriverError(result).to_string().c_str());
+          RCUTILS_LOG_ERROR_NAMED(
+              "ros2_cuda_ipc_core.backend.cuda_ipc",
+              "cuMemFree failed for slot %u: %s", slot.index,
+              detail::CudaDriverError(result).to_string().c_str());
         }
         slot.device_ptr = nullptr;
       }

--- a/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/cuda_ipc/memory_importer.cpp
@@ -3,10 +3,11 @@
 
 #include "ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp"
 
+#include <rcutils/logging_macros.h>
+
 #include <cstdint>
 #include <cstring>
 
-#include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/detail/cuda_driver_context.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
 
@@ -25,19 +26,21 @@ CUipcMemHandle to_cuda_mem_handle(
 
 std::optional<ImportedResources> MemoryImporter::import(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-    const CUipcEventHandle& event_handle, const rclcpp::Logger& logger) const {
+    const CUipcEventHandle& event_handle) const {
   auto context_result = detail::CudaDeviceContext::retain_primary(
       static_cast<int>(msg.device_id));
   if (!context_result) {
-    RCLCPP_WARN(logger, "Failed to retain CUDA primary context: %s",
-                context_result.error().to_string().c_str());
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.backend.cuda_ipc",
+                           "Failed to retain CUDA primary context: %s",
+                           context_result.error().to_string().c_str());
     return std::nullopt;
   }
   auto context = std::move(context_result).value();
   auto guard_result = context->push_current();
   if (!guard_result) {
-    RCLCPP_WARN(logger, "Failed to activate CUDA context: %s",
-                guard_result.error().to_string().c_str());
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.backend.cuda_ipc",
+                           "Failed to activate CUDA context: %s",
+                           guard_result.error().to_string().c_str());
     return std::nullopt;
   }
   auto guard = std::move(guard_result).value();
@@ -47,8 +50,9 @@ std::optional<ImportedResources> MemoryImporter::import(
 
   CUresult result = cuIpcOpenEventHandle(&imported.event, event_handle);
   if (result != CUDA_SUCCESS) {
-    RCLCPP_WARN(logger, "cuIpcOpenEventHandle failed: %s",
-                detail::CudaDriverError(result).to_string().c_str());
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.backend.cuda_ipc",
+                           "cuIpcOpenEventHandle failed: %s",
+                           detail::CudaDriverError(result).to_string().c_str());
     return std::nullopt;
   }
 
@@ -57,8 +61,9 @@ std::optional<ImportedResources> MemoryImporter::import(
   result = cuIpcOpenMemHandle(&device_ptr, mem_handle,
                               CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS);
   if (result != CUDA_SUCCESS) {
-    RCLCPP_WARN(logger, "cuIpcOpenMemHandle failed: %s",
-                detail::CudaDriverError(result).to_string().c_str());
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.backend.cuda_ipc",
+                           "cuIpcOpenMemHandle failed: %s",
+                           detail::CudaDriverError(result).to_string().c_str());
     (void)cuEventDestroy(imported.event);
     imported.event = nullptr;
     return std::nullopt;

--- a/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/memory_importer.cpp
@@ -3,9 +3,10 @@
 
 #include "ros2_cuda_ipc_core/backend/memory_importer.hpp"
 
+#include <rcutils/logging_macros.h>
+
 #include <cstdint>
 
-#include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/backend/cuda_ipc/memory_importer.hpp"
 #include "ros2_cuda_ipc_core/backend/vmm_fd/memory_importer.hpp"
 #include "ros2_cuda_ipc_core/transport/memory_types.hpp"
@@ -22,24 +23,24 @@ bool release_imported_resources(const ImportedResources& imported) noexcept {
   std::optional<detail::CudaContextGuard> guard;
   auto guard_result = imported.context->push_current();
   if (!guard_result) {
-    RCLCPP_ERROR(
-        rclcpp::get_logger("ros2_cuda_ipc_core.memory_importer"),
+    RCUTILS_LOG_ERROR_NAMED(
+        "ros2_cuda_ipc_core.memory_importer",
         "Failed to activate CUDA context for imported resource cleanup: %s",
         guard_result.error().to_string().c_str());
     return false;
   }
   guard.emplace(std::move(guard_result).value());
   bool success = true;
-  const auto logger = rclcpp::get_logger("ros2_cuda_ipc_core.memory_importer");
-  const auto report_cleanup_failure = [&success, &logger](const char* operation,
-                                                          CUresult result) {
+  const auto report_cleanup_failure = [&success](const char* operation,
+                                                 CUresult result) {
     if (result == CUDA_SUCCESS) {
       return;
     }
     success = false;
-    RCLCPP_ERROR(logger, "%s failed during imported resource cleanup: %s",
-                 operation,
-                 detail::CudaDriverError(result).to_string().c_str());
+    RCUTILS_LOG_ERROR_NAMED(
+        "ros2_cuda_ipc_core.memory_importer",
+        "%s failed during imported resource cleanup: %s", operation,
+        detail::CudaDriverError(result).to_string().c_str());
   };
   if (imported.vmm_address != 0 && imported.allocation_size != 0) {
     report_cleanup_failure("cuMemUnmap", cuMemUnmap(imported.vmm_address,
@@ -58,19 +59,20 @@ bool release_imported_resources(const ImportedResources& imported) noexcept {
     const CUresult result = cuIpcCloseMemHandle(device_ptr);
     if (result != CUDA_SUCCESS) {
       success = false;
-      RCLCPP_ERROR(logger,
-                   "cuIpcCloseMemHandle failed during imported resource "
-                   "cleanup: %s",
-                   detail::CudaDriverError(result).to_string().c_str());
+      RCUTILS_LOG_ERROR_NAMED(
+          "ros2_cuda_ipc_core.memory_importer",
+          "cuIpcCloseMemHandle failed during imported resource cleanup: %s",
+          detail::CudaDriverError(result).to_string().c_str());
     }
   }
   if (imported.event != nullptr) {
     const CUresult result = cuEventDestroy(imported.event);
     if (result != CUDA_SUCCESS) {
       success = false;
-      RCLCPP_ERROR(logger,
-                   "cuEventDestroy failed during imported resource cleanup: %s",
-                   detail::CudaDriverError(result).to_string().c_str());
+      RCUTILS_LOG_ERROR_NAMED(
+          "ros2_cuda_ipc_core.memory_importer",
+          "cuEventDestroy failed during imported resource cleanup: %s",
+          detail::CudaDriverError(result).to_string().c_str());
     }
   }
   return success;

--- a/ros2_cuda_ipc_core/src/backend/vmm_fd/memory_backend.cpp
+++ b/ros2_cuda_ipc_core/src/backend/vmm_fd/memory_backend.cpp
@@ -5,6 +5,7 @@
 
 #include <cuda.h>
 #include <fcntl.h>
+#include <rcutils/logging_macros.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
@@ -20,7 +21,6 @@
 #include <utility>
 #include <vector>
 
-#include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/backend/vmm_fd/payload.hpp"
 #include "ros2_cuda_ipc_core/detail/cuda_util.hpp"
 #include "ros2_cuda_ipc_core/detail/posix_error.hpp"
@@ -57,18 +57,15 @@ class UnixFdServer {
    * @param socket_path Filesystem location (e.g.
    * `/tmp/cuda_memory_pool_x.sock`) where subscribers will connect.
    * @param fd_to_send Shareable FD returned by CUDA; must be >= 0.
-   * @param logger Logger for diagnostics.
-   *
    * Invalid descriptors are rejected up front so that clients never receive an
    * unusable FD.
    */
-  UnixFdServer(std::string socket_path, int fd_to_send, rclcpp::Logger logger)
-      : path_(std::move(socket_path)),
-        fd_(fd_to_send),
-        logger_(std::move(logger)) {
+  UnixFdServer(std::string socket_path, int fd_to_send)
+      : path_(std::move(socket_path)), fd_(fd_to_send) {
     if (fd_ < 0) {
-      RCLCPP_ERROR(logger_, "Cannot start UnixFdServer at %s with invalid fd",
-                   path_.c_str());
+      RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.backend.vmm_fd",
+                              "Cannot start UnixFdServer at %s with invalid fd",
+                              path_.c_str());
       throw std::invalid_argument("Invalid fd for UnixFdServer");
     }
   }
@@ -100,8 +97,9 @@ class UnixFdServer {
       }
     }
     if (sock < 0) {
-      RCLCPP_ERROR(logger_, "socket(AF_UNIX) failed: %s",
-                   ros2_cuda_ipc_core::detail::errno_to_string().c_str());
+      RCUTILS_LOG_ERROR_NAMED(
+          "ros2_cuda_ipc_core.backend.vmm_fd", "socket(AF_UNIX) failed: %s",
+          ros2_cuda_ipc_core::detail::errno_to_string().c_str());
       return false;
     }
 
@@ -113,16 +111,18 @@ class UnixFdServer {
     std::strncpy(addr.sun_path, path_.c_str(), sizeof(addr.sun_path) - 1);
     // bind(2): attach socket to filesystem path so subscribers can connect.
     if (::bind(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
-      RCLCPP_ERROR(logger_, "bind(%s) failed: %s", path_.c_str(),
-                   ros2_cuda_ipc_core::detail::errno_to_string().c_str());
+      RCUTILS_LOG_ERROR_NAMED(
+          "ros2_cuda_ipc_core.backend.vmm_fd", "bind(%s) failed: %s",
+          path_.c_str(), ros2_cuda_ipc_core::detail::errno_to_string().c_str());
       ::close(sock);
       return false;
     }
 
     // listen(2): enable incoming connection queue.
     if (::listen(sock, 16) < 0) {
-      RCLCPP_ERROR(logger_, "listen(%s) failed: %s", path_.c_str(),
-                   ros2_cuda_ipc_core::detail::errno_to_string().c_str());
+      RCUTILS_LOG_ERROR_NAMED(
+          "ros2_cuda_ipc_core.backend.vmm_fd", "listen(%s) failed: %s",
+          path_.c_str(), ros2_cuda_ipc_core::detail::errno_to_string().c_str());
       ::close(sock);
       return false;
     }
@@ -168,8 +168,10 @@ class UnixFdServer {
           continue;
         }
         if (running_.load(std::memory_order_acquire)) {
-          RCLCPP_WARN(logger_, "accept(%s) failed: %s", path_.c_str(),
-                      ros2_cuda_ipc_core::detail::errno_to_string().c_str());
+          RCUTILS_LOG_WARN_NAMED(
+              "ros2_cuda_ipc_core.backend.vmm_fd", "accept(%s) failed: %s",
+              path_.c_str(),
+              ros2_cuda_ipc_core::detail::errno_to_string().c_str());
         }
         continue;
       }
@@ -200,9 +202,10 @@ class UnixFdServer {
     msg.msg_controllen = sizeof(cmsg_buf);
     cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
     if (!cmsg) {
-      RCLCPP_WARN(logger_,
-                  "sendmsg setup failed for %s: missing control message header",
-                  path_.c_str());
+      RCUTILS_LOG_WARN_NAMED(
+          "ros2_cuda_ipc_core.backend.vmm_fd",
+          "sendmsg setup failed for %s: missing control message header",
+          path_.c_str());
       return;
     }
     cmsg->cmsg_level = SOL_SOCKET;
@@ -210,8 +213,9 @@ class UnixFdServer {
     cmsg->cmsg_len = CMSG_LEN(sizeof(int));
     std::memcpy(CMSG_DATA(cmsg), &fd_, sizeof(int));
     if (::sendmsg(client, &msg, 0) < 0) {
-      RCLCPP_WARN(logger_, "sendmsg failed on %s: %s", path_.c_str(),
-                  ros2_cuda_ipc_core::detail::errno_to_string().c_str());
+      RCUTILS_LOG_WARN_NAMED(
+          "ros2_cuda_ipc_core.backend.vmm_fd", "sendmsg failed on %s: %s",
+          path_.c_str(), ros2_cuda_ipc_core::detail::errno_to_string().c_str());
     }
   }
 
@@ -220,7 +224,6 @@ class UnixFdServer {
   int listen_fd_ = -1;
   std::atomic<bool> running_{false};
   std::thread worker_;
-  rclcpp::Logger logger_;
 };
 
 /**
@@ -277,10 +280,10 @@ class VmmFdMemoryBackend : public publisher::GpuBufferPool::MemoryBackend {
    *    access rights, export to FD, and spin up a UnixFdServer that hands out
    *    the FD using a randomly generated UUID.
    */
-  bool allocate(uint64_t frame_size_bytes, int device_index,
-                std::vector<publisher::GpuBufferPool::SlotResources>& slots,
-                rclcpp::Logger logger) override {
-    if (!ensure_driver(logger)) {
+  bool allocate(
+      uint64_t frame_size_bytes, int device_index,
+      std::vector<publisher::GpuBufferPool::SlotResources>& slots) override {
+    if (!ensure_driver()) {
       return false;
     }
 
@@ -296,8 +299,9 @@ class VmmFdMemoryBackend : public publisher::GpuBufferPool::MemoryBackend {
     CUresult res = cuMemGetAllocationGranularity(
         &granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM);
     if (res != CUDA_SUCCESS) {
-      RCLCPP_ERROR(
-          logger, "cuMemGetAllocationGranularity failed: %s",
+      RCUTILS_LOG_ERROR_NAMED(
+          "ros2_cuda_ipc_core.backend.vmm_fd",
+          "cuMemGetAllocationGranularity failed: %s",
           ros2_cuda_ipc_core::detail::cu_result_to_string(res).c_str());
       return false;
     }
@@ -311,10 +315,11 @@ class VmmFdMemoryBackend : public publisher::GpuBufferPool::MemoryBackend {
       // Reserve virtual address space (no backing memory yet).
       res = cuMemAddressReserve(&address, aligned_size, 0, 0, 0);
       if (res != CUDA_SUCCESS) {
-        RCLCPP_ERROR(
-            logger, "cuMemAddressReserve failed: %s",
+        RCUTILS_LOG_ERROR_NAMED(
+            "ros2_cuda_ipc_core.backend.vmm_fd",
+            "cuMemAddressReserve failed: %s",
             ros2_cuda_ipc_core::detail::cu_result_to_string(res).c_str());
-        destroy(slots, logger);
+        destroy(slots);
         return false;
       }
       state->address = address;
@@ -322,19 +327,19 @@ class VmmFdMemoryBackend : public publisher::GpuBufferPool::MemoryBackend {
       // cuMemCreate: allocate physical memory described by prop.
       res = cuMemCreate(&state->allocation, aligned_size, &prop, 0);
       if (res != CUDA_SUCCESS) {
-        RCLCPP_ERROR(
-            logger, "cuMemCreate failed: %s",
+        RCUTILS_LOG_ERROR_NAMED(
+            "ros2_cuda_ipc_core.backend.vmm_fd", "cuMemCreate failed: %s",
             ros2_cuda_ipc_core::detail::cu_result_to_string(res).c_str());
-        destroy(slots, logger);
+        destroy(slots);
         return false;
       }
 
       res = cuMemMap(address, aligned_size, 0, state->allocation, 0);
       if (res != CUDA_SUCCESS) {
-        RCLCPP_ERROR(
-            logger, "cuMemMap failed: %s",
+        RCUTILS_LOG_ERROR_NAMED(
+            "ros2_cuda_ipc_core.backend.vmm_fd", "cuMemMap failed: %s",
             ros2_cuda_ipc_core::detail::cu_result_to_string(res).c_str());
-        destroy(slots, logger);
+        destroy(slots);
         return false;
       }
 
@@ -344,10 +349,10 @@ class VmmFdMemoryBackend : public publisher::GpuBufferPool::MemoryBackend {
       access_desc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
       res = cuMemSetAccess(address, aligned_size, &access_desc, 1);
       if (res != CUDA_SUCCESS) {
-        RCLCPP_ERROR(
-            logger, "cuMemSetAccess failed: %s",
+        RCUTILS_LOG_ERROR_NAMED(
+            "ros2_cuda_ipc_core.backend.vmm_fd", "cuMemSetAccess failed: %s",
             ros2_cuda_ipc_core::detail::cu_result_to_string(res).c_str());
-        destroy(slots, logger);
+        destroy(slots);
         return false;
       }
 
@@ -357,10 +362,11 @@ class VmmFdMemoryBackend : public publisher::GpuBufferPool::MemoryBackend {
           &state->shareable_fd, state->allocation,
           CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0);
       if (res != CUDA_SUCCESS) {
-        RCLCPP_ERROR(
-            logger, "cuMemExportToShareableHandle failed: %s",
+        RCUTILS_LOG_ERROR_NAMED(
+            "ros2_cuda_ipc_core.backend.vmm_fd",
+            "cuMemExportToShareableHandle failed: %s",
             ros2_cuda_ipc_core::detail::cu_result_to_string(res).c_str());
-        destroy(slots, logger);
+        destroy(slots);
         return false;
       }
       if (state->shareable_fd >= 0) {
@@ -379,11 +385,10 @@ class VmmFdMemoryBackend : public publisher::GpuBufferPool::MemoryBackend {
       state->uuid = uuid_str;
 
       const auto socket_path = build_socket_path(state->uuid);
-      auto child_logger = logger.get_child("FdServer");
-      state->server = std::make_unique<UnixFdServer>(
-          socket_path, state->shareable_fd, child_logger);
+      state->server =
+          std::make_unique<UnixFdServer>(socket_path, state->shareable_fd);
       if (!state->server->start()) {
-        destroy(slots, logger);
+        destroy(slots);
         return false;
       }
 
@@ -393,9 +398,10 @@ class VmmFdMemoryBackend : public publisher::GpuBufferPool::MemoryBackend {
       // Store UUID bytes into the ROS message payload so subscribers know which
       // socket to contact.
       if (!encode_uuid_payload(state->uuid, slot.mem_handle)) {
-        RCLCPP_ERROR(logger, "Failed to encode UUID payload for slot %u",
-                     slot.index);
-        destroy(slots, logger);
+        RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.backend.vmm_fd",
+                                "Failed to encode UUID payload for slot %u",
+                                slot.index);
+        destroy(slots);
         return false;
       }
     }
@@ -408,9 +414,8 @@ class VmmFdMemoryBackend : public publisher::GpuBufferPool::MemoryBackend {
    * The per-slot VmmSlotState RAII cleanup tears down CUDA driver resources and
    * socket servers; here we simply drop pointers and reset bookkeeping fields.
    */
-  void destroy(std::vector<publisher::GpuBufferPool::SlotResources>& slots,
-               rclcpp::Logger logger) noexcept override {
-    (void)logger;
+  void destroy(std::vector<publisher::GpuBufferPool::SlotResources>&
+                   slots) noexcept override {
     for (auto& slot : slots) {
       slot.device_ptr = nullptr;
       if (slot.backend ==
@@ -428,13 +433,13 @@ class VmmFdMemoryBackend : public publisher::GpuBufferPool::MemoryBackend {
    *
    * Uses `std::call_once` so repeated allocate() calls do not re-run cuInit.
    */
-  bool ensure_driver(const rclcpp::Logger& logger) {
+  bool ensure_driver() {
     static std::once_flag once;
     static CUresult status = CUDA_SUCCESS;
     std::call_once(once, [&]() { status = cuInit(0); });
     if (status != CUDA_SUCCESS) {
-      RCLCPP_ERROR(
-          logger, "cuInit failed: %s",
+      RCUTILS_LOG_ERROR_NAMED(
+          "ros2_cuda_ipc_core.backend.vmm_fd", "cuInit failed: %s",
           ros2_cuda_ipc_core::detail::cu_result_to_string(status).c_str());
       return false;
     }

--- a/ros2_cuda_ipc_core/src/backend/vmm_fd/memory_importer.cpp
+++ b/ros2_cuda_ipc_core/src/backend/vmm_fd/memory_importer.cpp
@@ -4,6 +4,7 @@
 #include "ros2_cuda_ipc_core/backend/vmm_fd/memory_importer.hpp"
 
 #include <fcntl.h>
+#include <rcutils/logging_macros.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
@@ -13,7 +14,6 @@
 #include <optional>
 #include <string>
 
-#include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/backend/vmm_fd/payload.hpp"
 #include "ros2_cuda_ipc_core/detail/cuda_util.hpp"
 #include "ros2_cuda_ipc_core/detail/posix_error.hpp"
@@ -35,18 +35,17 @@ std::size_t align_up_size(std::size_t value, std::size_t alignment) {
 }
 
 std::optional<std::string> parse_vmm_payload(
-    const transport::MemoryHandlePayload& payload,
-    const rclcpp::Logger& logger) {
+    const transport::MemoryHandlePayload& payload) {
   auto uuid = decode_uuid_payload(payload);
   if (!uuid.has_value()) {
-    RCLCPP_WARN(logger, "Received invalid VMM_FD payload");
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.backend.vmm_fd",
+                           "Received invalid VMM_FD payload");
     return std::nullopt;
   }
   return uuid;
 }
 
-std::optional<int> request_fd_from_publisher(const std::string& path,
-                                             const rclcpp::Logger& logger) {
+std::optional<int> request_fd_from_publisher(const std::string& path) {
   int sock = ::socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
   if (sock < 0) {
     if (errno == EINVAL || errno == EPROTOTYPE) {
@@ -57,22 +56,25 @@ std::optional<int> request_fd_from_publisher(const std::string& path,
     }
   }
   if (sock < 0) {
-    RCLCPP_WARN(logger, "socket(AF_UNIX) failed: %s",
-                ros2_cuda_ipc_core::detail::errno_to_string().c_str());
+    RCUTILS_LOG_WARN_NAMED(
+        "ros2_cuda_ipc_core.backend.vmm_fd", "socket(AF_UNIX) failed: %s",
+        ros2_cuda_ipc_core::detail::errno_to_string().c_str());
     return std::nullopt;
   }
 
   sockaddr_un addr{};
   addr.sun_family = AF_UNIX;
   if (path.size() >= sizeof(addr.sun_path)) {
-    RCLCPP_WARN(logger, "Socket path %s is too long", path.c_str());
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.backend.vmm_fd",
+                           "Socket path %s is too long", path.c_str());
     ::close(sock);
     return std::nullopt;
   }
   std::strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
   if (::connect(sock, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
-    RCLCPP_WARN(logger, "connect(%s) failed: %s", path.c_str(),
-                ros2_cuda_ipc_core::detail::errno_to_string().c_str());
+    RCUTILS_LOG_WARN_NAMED(
+        "ros2_cuda_ipc_core.backend.vmm_fd", "connect(%s) failed: %s",
+        path.c_str(), ros2_cuda_ipc_core::detail::errno_to_string().c_str());
     ::close(sock);
     return std::nullopt;
   }
@@ -87,8 +89,9 @@ std::optional<int> request_fd_from_publisher(const std::string& path,
   msg.msg_controllen = sizeof(cmsg_buf);
   const ssize_t received = ::recvmsg(sock, &msg, 0);
   if (received <= 0) {
-    RCLCPP_WARN(logger, "recvmsg on %s failed: %s", path.c_str(),
-                ros2_cuda_ipc_core::detail::errno_to_string().c_str());
+    RCUTILS_LOG_WARN_NAMED(
+        "ros2_cuda_ipc_core.backend.vmm_fd", "recvmsg on %s failed: %s",
+        path.c_str(), ros2_cuda_ipc_core::detail::errno_to_string().c_str());
     ::close(sock);
     return std::nullopt;
   }
@@ -96,8 +99,9 @@ std::optional<int> request_fd_from_publisher(const std::string& path,
   cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
   if (!cmsg || cmsg->cmsg_level != SOL_SOCKET ||
       cmsg->cmsg_type != SCM_RIGHTS || cmsg->cmsg_len < CMSG_LEN(sizeof(int))) {
-    RCLCPP_WARN(logger, "recvmsg on %s missing SCM_RIGHTS payload",
-                path.c_str());
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.backend.vmm_fd",
+                           "recvmsg on %s missing SCM_RIGHTS payload",
+                           path.c_str());
     ::close(sock);
     return std::nullopt;
   }
@@ -106,7 +110,8 @@ std::optional<int> request_fd_from_publisher(const std::string& path,
   std::memcpy(&fd, CMSG_DATA(cmsg), sizeof(int));
   ::close(sock);
   if (fd < 0) {
-    RCLCPP_WARN(logger, "recvmsg returned invalid fd for %s", path.c_str());
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.backend.vmm_fd",
+                           "recvmsg returned invalid fd for %s", path.c_str());
     return std::nullopt;
   }
   return fd;
@@ -116,20 +121,21 @@ std::optional<int> request_fd_from_publisher(const std::string& path,
 
 std::optional<ImportedResources> MemoryImporter::import(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg,
-    const CUipcEventHandle& event_handle, const rclcpp::Logger& logger) const {
-  const auto meta = parse_vmm_payload(msg.mem_handle, logger);
+    const CUipcEventHandle& event_handle) const {
+  const auto meta = parse_vmm_payload(msg.mem_handle);
   if (!meta.has_value()) {
     return std::nullopt;
   }
 
   const std::string socket_path = build_socket_path(*meta);
   if (socket_path.size() >= sizeof(sockaddr_un::sun_path)) {
-    RCLCPP_WARN(logger, "UUID %s is too long for AF_UNIX path",
-                socket_path.c_str());
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.backend.vmm_fd",
+                           "UUID %s is too long for AF_UNIX path",
+                           socket_path.c_str());
     return std::nullopt;
   }
 
-  const auto fd_opt = request_fd_from_publisher(socket_path, logger);
+  const auto fd_opt = request_fd_from_publisher(socket_path);
   if (!fd_opt.has_value()) {
     return std::nullopt;
   }
@@ -137,16 +143,18 @@ std::optional<ImportedResources> MemoryImporter::import(
   auto context_result = detail::CudaDeviceContext::retain_primary(
       static_cast<int>(msg.device_id));
   if (!context_result) {
-    RCLCPP_WARN(logger, "Failed to retain CUDA primary context: %s",
-                context_result.error().to_string().c_str());
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.backend.vmm_fd",
+                           "Failed to retain CUDA primary context: %s",
+                           context_result.error().to_string().c_str());
     ::close(fd_opt.value());
     return std::nullopt;
   }
   auto context = std::move(context_result).value();
   auto guard_result = context->push_current();
   if (!guard_result) {
-    RCLCPP_WARN(logger, "Failed to activate CUDA context: %s",
-                guard_result.error().to_string().c_str());
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.backend.vmm_fd",
+                           "Failed to activate CUDA context: %s",
+                           guard_result.error().to_string().c_str());
     ::close(fd_opt.value());
     return std::nullopt;
   }
@@ -162,8 +170,9 @@ std::optional<ImportedResources> MemoryImporter::import(
                                      CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR);
   ::close(fd_opt.value());
   if (cu_res != CUDA_SUCCESS) {
-    RCLCPP_WARN(
-        logger, "cuMemImportFromShareableHandle failed: %s",
+    RCUTILS_LOG_WARN_NAMED(
+        "ros2_cuda_ipc_core.backend.vmm_fd",
+        "cuMemImportFromShareableHandle failed: %s",
         ros2_cuda_ipc_core::detail::cu_result_to_string(cu_res).c_str());
     return std::nullopt;
   }
@@ -177,8 +186,9 @@ std::optional<ImportedResources> MemoryImporter::import(
   cu_res = cuMemGetAllocationGranularity(&granularity, &prop,
                                          CU_MEM_ALLOC_GRANULARITY_MINIMUM);
   if (cu_res != CUDA_SUCCESS) {
-    RCLCPP_WARN(
-        logger, "cuMemGetAllocationGranularity failed: %s",
+    RCUTILS_LOG_WARN_NAMED(
+        "ros2_cuda_ipc_core.backend.vmm_fd",
+        "cuMemGetAllocationGranularity failed: %s",
         ros2_cuda_ipc_core::detail::cu_result_to_string(cu_res).c_str());
     cuMemRelease(imported.vmm_allocation);
     return std::nullopt;
@@ -193,8 +203,8 @@ std::optional<ImportedResources> MemoryImporter::import(
   cu_res = cuMemAddressReserve(&imported.vmm_address, imported.allocation_size,
                                0, 0, 0);
   if (cu_res != CUDA_SUCCESS) {
-    RCLCPP_WARN(
-        logger, "cuMemAddressReserve failed: %s",
+    RCUTILS_LOG_WARN_NAMED(
+        "ros2_cuda_ipc_core.backend.vmm_fd", "cuMemAddressReserve failed: %s",
         ros2_cuda_ipc_core::detail::cu_result_to_string(cu_res).c_str());
     cuMemRelease(imported.vmm_allocation);
     return std::nullopt;
@@ -203,8 +213,8 @@ std::optional<ImportedResources> MemoryImporter::import(
   cu_res = cuMemMap(imported.vmm_address, imported.allocation_size, 0,
                     imported.vmm_allocation, 0);
   if (cu_res != CUDA_SUCCESS) {
-    RCLCPP_WARN(
-        logger, "cuMemMap failed: %s",
+    RCUTILS_LOG_WARN_NAMED(
+        "ros2_cuda_ipc_core.backend.vmm_fd", "cuMemMap failed: %s",
         ros2_cuda_ipc_core::detail::cu_result_to_string(cu_res).c_str());
     cuMemAddressFree(imported.vmm_address, imported.allocation_size);
     cuMemRelease(imported.vmm_allocation);
@@ -217,8 +227,8 @@ std::optional<ImportedResources> MemoryImporter::import(
   cu_res = cuMemSetAccess(imported.vmm_address, imported.allocation_size,
                           &access_desc, 1);
   if (cu_res != CUDA_SUCCESS) {
-    RCLCPP_WARN(
-        logger, "cuMemSetAccess failed: %s",
+    RCUTILS_LOG_WARN_NAMED(
+        "ros2_cuda_ipc_core.backend.vmm_fd", "cuMemSetAccess failed: %s",
         ros2_cuda_ipc_core::detail::cu_result_to_string(cu_res).c_str());
     cuMemUnmap(imported.vmm_address, imported.allocation_size);
     cuMemAddressFree(imported.vmm_address, imported.allocation_size);
@@ -228,10 +238,11 @@ std::optional<ImportedResources> MemoryImporter::import(
 
   cu_res = cuIpcOpenEventHandle(&imported.event, event_handle);
   if (cu_res != CUDA_SUCCESS) {
-    RCLCPP_WARN(logger, "cuIpcOpenEventHandle failed: %s",
-                ros2_cuda_ipc_core::detail::CudaDriverError(cu_res)
-                    .to_string()
-                    .c_str());
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.backend.vmm_fd",
+                           "cuIpcOpenEventHandle failed: %s",
+                           ros2_cuda_ipc_core::detail::CudaDriverError(cu_res)
+                               .to_string()
+                               .c_str());
     cuMemUnmap(imported.vmm_address, imported.allocation_size);
     cuMemAddressFree(imported.vmm_address, imported.allocation_size);
     cuMemRelease(imported.vmm_allocation);

--- a/ros2_cuda_ipc_core/src/detail/cuda_driver_context.cpp
+++ b/ros2_cuda_ipc_core/src/detail/cuda_driver_context.cpp
@@ -3,19 +3,12 @@
 
 #include "ros2_cuda_ipc_core/detail/cuda_driver_context.hpp"
 
+#include <rcutils/logging_macros.h>
+
 #include <mutex>
 #include <string>
 
-#include "rclcpp/logging.hpp"
-
 namespace ros2_cuda_ipc_core::detail {
-namespace {
-
-rclcpp::Logger cuda_context_logger() {
-  return rclcpp::get_logger("ros2_cuda_ipc_core.cuda_context");
-}
-
-}  // namespace
 
 std::string CudaDriverError::name() const {
   const char* value = nullptr;
@@ -95,10 +88,9 @@ void CudaContextGuard::pop_noexcept() noexcept {
   }
 
   try {
-    const auto logger = cuda_context_logger();
     if (owner_thread_ != std::this_thread::get_id()) {
-      RCLCPP_ERROR(
-          logger,
+      RCUTILS_LOG_ERROR_NAMED(
+          "ros2_cuda_ipc_core.cuda_context",
           "CUDA context guard destroyed on a different thread; refusing to "
           "pop a thread-local context stack");
       active_ = false;
@@ -112,23 +104,25 @@ void CudaContextGuard::pop_noexcept() noexcept {
     active_ = false;
     context_ = nullptr;
     if (result != CUDA_SUCCESS) {
-      RCLCPP_ERROR(logger, "cuCtxPopCurrent failed: %s",
-                   CudaDriverError(result).to_string().c_str());
+      RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.cuda_context",
+                              "cuCtxPopCurrent failed: %s",
+                              CudaDriverError(result).to_string().c_str());
       return;
     }
     if (popped != expected) {
-      RCLCPP_ERROR(logger,
-                   "cuCtxPopCurrent returned an unexpected context "
-                   "(expected=%p, popped=%p)",
-                   static_cast<void*>(expected), static_cast<void*>(popped));
+      RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.cuda_context",
+                              "cuCtxPopCurrent returned an unexpected context "
+                              "(expected=%p, popped=%p)",
+                              static_cast<void*>(expected),
+                              static_cast<void*>(popped));
     }
   } catch (...) {
     active_ = false;
     context_ = nullptr;
     try {
-      RCLCPP_ERROR(cuda_context_logger(),
-                   "CUDA context guard cleanup failed while reporting an "
-                   "error");
+      RCUTILS_LOG_ERROR_NAMED(
+          "ros2_cuda_ipc_core.cuda_context",
+          "CUDA context guard cleanup failed while reporting an error");
     } catch (...) {
       // Destructors must not throw, including while reporting a cleanup error.
     }
@@ -139,15 +133,17 @@ CudaDeviceContext::~CudaDeviceContext() noexcept {
   const CUresult result = cuDevicePrimaryCtxRelease(device_);
   if (result != CUDA_SUCCESS) {
     try {
-      RCLCPP_ERROR(cuda_context_logger(),
-                   "cuDevicePrimaryCtxRelease(device_id=%d) failed: %s",
-                   device_id_, CudaDriverError(result).to_string().c_str());
+      RCUTILS_LOG_ERROR_NAMED(
+          "ros2_cuda_ipc_core.cuda_context",
+          "cuDevicePrimaryCtxRelease(device_id=%d) failed: %s", device_id_,
+          CudaDriverError(result).to_string().c_str());
     } catch (...) {
       try {
-        RCLCPP_ERROR(cuda_context_logger(),
-                     "cuDevicePrimaryCtxRelease(device_id=%d) failed with "
-                     "an unformattable CUDA Driver API error",
-                     device_id_);
+        RCUTILS_LOG_ERROR_NAMED(
+            "ros2_cuda_ipc_core.cuda_context",
+            "cuDevicePrimaryCtxRelease(device_id=%d) failed with an "
+            "unformattable CUDA Driver API error",
+            device_id_);
       } catch (...) {
         // A noexcept destructor must not throw while reporting cleanup.
       }

--- a/ros2_cuda_ipc_core/src/detail/interprocess_event.cpp
+++ b/ros2_cuda_ipc_core/src/detail/interprocess_event.cpp
@@ -3,10 +3,10 @@
 
 #include "ros2_cuda_ipc_core/detail/interprocess_event.hpp"
 
+#include <rcutils/logging_macros.h>
+
 #include <cstring>
 #include <utility>
-
-#include "rclcpp/logging.hpp"
 
 namespace ros2_cuda_ipc_core::detail {
 
@@ -88,26 +88,27 @@ void InterprocessEvent::reset_noexcept() noexcept {
   }
   try {
     if (!context_) {
-      RCLCPP_ERROR(
-          rclcpp::get_logger("ros2_cuda_ipc_core.interprocess_event"),
+      RCUTILS_LOG_ERROR_NAMED(
+          "ros2_cuda_ipc_core.interprocess_event",
           "Cannot destroy interprocess event without its CUDA context");
       event_ = nullptr;
       return;
     }
     auto guard_result = context_->push_current();
     if (!guard_result) {
-      RCLCPP_ERROR(rclcpp::get_logger("ros2_cuda_ipc_core.interprocess_event"),
-                   "Failed to activate CUDA context for event cleanup: %s",
-                   guard_result.error().to_string().c_str());
+      RCUTILS_LOG_ERROR_NAMED(
+          "ros2_cuda_ipc_core.interprocess_event",
+          "Failed to activate CUDA context for event cleanup: %s",
+          guard_result.error().to_string().c_str());
       event_ = nullptr;
       return;
     }
     auto guard = std::move(guard_result).value();
     const CUresult result = cuEventDestroy(event_);
     if (result != CUDA_SUCCESS) {
-      RCLCPP_ERROR(rclcpp::get_logger("ros2_cuda_ipc_core.interprocess_event"),
-                   "cuEventDestroy failed: %s",
-                   CudaDriverError(result).to_string().c_str());
+      RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.interprocess_event",
+                              "cuEventDestroy failed: %s",
+                              CudaDriverError(result).to_string().c_str());
     }
   } catch (...) {
     // Destruction and error reporting must not escape a noexcept boundary.

--- a/ros2_cuda_ipc_core/src/lease/lease_handle.cpp
+++ b/ros2_cuda_ipc_core/src/lease/lease_handle.cpp
@@ -3,10 +3,11 @@
 
 #include "ros2_cuda_ipc_core/lease/lease_handle.hpp"
 
+#include <rcutils/logging_macros.h>
+
 #include <atomic>
 #include <cstdint>
 #include <optional>
-#include <rclcpp/logging.hpp>
 #include <thread>
 
 namespace ros2_cuda_ipc_core::lease {
@@ -16,12 +17,6 @@ constexpr uint32_t kCancelReservationAttempts = 1024;
 
 inline std::atomic<uint32_t>& as_atomic(uint32_t& value) {
   return reinterpret_cast<std::atomic<uint32_t>&>(value);
-}
-
-rclcpp::Logger lease_logger() {
-  static rclcpp::Logger logger =
-      rclcpp::get_logger("ros2_cuda_ipc_core.LeaseHandle");
-  return logger;
 }
 
 }  // namespace
@@ -57,7 +52,8 @@ void LeaseHandle::release() noexcept {
   auto& ref = as_atomic(slot_meta_->refcnt);
   const uint32_t previous = ref.fetch_sub(1, std::memory_order_acq_rel);
   if (previous == 0) {
-    RCLCPP_ERROR(lease_logger(), "lease:refcnt_underflow slot=%u", slot_id_);
+    RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.lease_handle",
+                            "lease:refcnt_underflow slot=%u", slot_id_);
     ref.store(0, std::memory_order_release);
   }
   slot_meta_ = nullptr;
@@ -163,9 +159,10 @@ bool LeaseHandle::cancel_pending(const std::shared_ptr<LeaseMapping>& mapping,
     std::this_thread::yield();
   }
   if (!acquired) {
-    RCLCPP_ERROR(lease_logger(),
-                 "lease:cancel_reservation_contention slot=%u gen=%u", slot_id,
-                 generation);
+    RCUTILS_LOG_ERROR_NAMED(
+        "ros2_cuda_ipc_core.lease_handle",
+        "lease:cancel_reservation_contention slot=%u gen=%u", slot_id,
+        generation);
     return false;
   }
   if (as_atomic(slot.generation).load(std::memory_order_acquire) !=
@@ -194,7 +191,8 @@ LeaseHandle LeaseHandle::acquire(const std::shared_ptr<LeaseMapping>& mapping,
   uint32_t observed_ref = ref.load(std::memory_order_acquire);
   while (true) {
     if (observed_ref == UINT32_MAX) {
-      RCLCPP_ERROR(lease_logger(), "lease:ref_overflow slot=%u", slot_id);
+      RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.lease_handle",
+                              "lease:ref_overflow slot=%u", slot_id);
       return LeaseHandle{};
     }
     if (ref.compare_exchange_weak(observed_ref, observed_ref + 1,

--- a/ros2_cuda_ipc_core/src/lease/lease_mapping.cpp
+++ b/ros2_cuda_ipc_core/src/lease/lease_mapping.cpp
@@ -4,6 +4,7 @@
 #include "ros2_cuda_ipc_core/lease/lease_mapping.hpp"
 
 #include <fcntl.h>
+#include <rcutils/logging_macros.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -12,7 +13,6 @@
 #include <cerrno>
 #include <cstdint>
 #include <limits>
-#include <rclcpp/logging.hpp>
 
 namespace ros2_cuda_ipc_core::lease {
 namespace {
@@ -30,12 +30,6 @@ struct ShmHeader {
 
 inline std::atomic<uint32_t>& as_atomic(uint32_t& value) {
   return reinterpret_cast<std::atomic<uint32_t>&>(value);
-}
-
-rclcpp::Logger mapping_logger() {
-  static rclcpp::Logger logger =
-      rclcpp::get_logger("ros2_cuda_ipc_core.LeaseMapping");
-  return logger;
 }
 
 bool valid_layout(const struct stat& st, const ShmHeader& header,
@@ -74,23 +68,24 @@ std::shared_ptr<LeaseMapping> LeaseMapping::create(
       sizeof(ShmHeader) + static_cast<std::size_t>(capacity) * sizeof(SlotMeta);
   const int fd = shm_open(shm_name.c_str(), O_CREAT | O_EXCL | O_RDWR, 0660);
   if (fd < 0) {
-    RCLCPP_ERROR(mapping_logger(),
-                 "lease:create shm_open failed name=%s errno=%d",
-                 shm_name.c_str(), errno);
+    RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.lease_mapping",
+                            "lease:create shm_open failed name=%s errno=%d",
+                            shm_name.c_str(), errno);
     return nullptr;
   }
   if (ftruncate(fd, static_cast<off_t>(size)) != 0) {
-    RCLCPP_ERROR(mapping_logger(),
-                 "lease:create ftruncate failed name=%s errno=%d",
-                 shm_name.c_str(), errno);
+    RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.lease_mapping",
+                            "lease:create ftruncate failed name=%s errno=%d",
+                            shm_name.c_str(), errno);
     close(fd);
     shm_unlink(shm_name.c_str());
     return nullptr;
   }
   void* addr = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
   if (addr == MAP_FAILED) {
-    RCLCPP_ERROR(mapping_logger(), "lease:create mmap failed name=%s errno=%d",
-                 shm_name.c_str(), errno);
+    RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.lease_mapping",
+                            "lease:create mmap failed name=%s errno=%d",
+                            shm_name.c_str(), errno);
     close(fd);
     shm_unlink(shm_name.c_str());
     return nullptr;
@@ -129,29 +124,32 @@ std::shared_ptr<LeaseMapping> LeaseMapping::attach(
   }
   const int fd = shm_open(shm_name.c_str(), O_RDWR, 0660);
   if (fd < 0) {
-    RCLCPP_WARN(mapping_logger(),
-                "lease:attach shm_open failed name=%s errno=%d",
-                shm_name.c_str(), errno);
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.lease_mapping",
+                           "lease:attach shm_open failed name=%s errno=%d",
+                           shm_name.c_str(), errno);
     return nullptr;
   }
   struct stat st{};
   if (fstat(fd, &st) != 0) {
-    RCLCPP_WARN(mapping_logger(), "lease:attach fstat failed name=%s errno=%d",
-                shm_name.c_str(), errno);
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.lease_mapping",
+                           "lease:attach fstat failed name=%s errno=%d",
+                           shm_name.c_str(), errno);
     close(fd);
     return nullptr;
   }
   if (st.st_size < static_cast<off_t>(sizeof(ShmHeader))) {
-    RCLCPP_WARN(mapping_logger(), "lease:attach segment too small name=%s",
-                shm_name.c_str());
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.lease_mapping",
+                           "lease:attach segment too small name=%s",
+                           shm_name.c_str());
     close(fd);
     return nullptr;
   }
   void* addr =
       mmap(nullptr, st.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
   if (addr == MAP_FAILED) {
-    RCLCPP_WARN(mapping_logger(), "lease:attach mmap failed name=%s errno=%d",
-                shm_name.c_str(), errno);
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.lease_mapping",
+                           "lease:attach mmap failed name=%s errno=%d",
+                           shm_name.c_str(), errno);
     close(fd);
     return nullptr;
   }
@@ -161,16 +159,18 @@ std::shared_ptr<LeaseMapping> LeaseMapping::attach(
   std::size_t expected_size = 0;
   if (header->magic != kShmMagic || header->layout_version != kLayoutVersion ||
       header->publisher_instance_id != expected_instance_id) {
-    RCLCPP_WARN(mapping_logger(),
-                "lease:attach header or publisher instance mismatch name=%s "
-                "magic=%u ver=%u",
-                shm_name.c_str(), header->magic, header->layout_version);
+    RCUTILS_LOG_WARN_NAMED(
+        "ros2_cuda_ipc_core.lease_mapping",
+        "lease:attach header or publisher instance mismatch name=%s "
+        "magic=%u ver=%u",
+        shm_name.c_str(), header->magic, header->layout_version);
     munmap(addr, st.st_size);
     return nullptr;
   }
   if (!valid_layout(st, *header, &expected_size)) {
-    RCLCPP_WARN(mapping_logger(), "lease:attach invalid layout name=%s",
-                shm_name.c_str());
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.lease_mapping",
+                           "lease:attach invalid layout name=%s",
+                           shm_name.c_str());
     munmap(addr, st.st_size);
     return nullptr;
   }

--- a/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
@@ -78,13 +78,11 @@ void PublishSlot::cancel() noexcept {
   }
 }
 
-GpuBufferManager::GpuBufferManager(Config config, rclcpp::Logger logger)
+GpuBufferManager::GpuBufferManager(Config config)
     : config_(std::move(config)),
-      logger_(std::move(logger)),
-      buffer_pool_(config_.slot_count, config_.backend,
-                   logger_.get_child("GpuBufferPool")),
+      buffer_pool_(config_.slot_count, config_.backend),
       lease_manager_(config_.shm_name_prefix, config_.slot_count,
-                     config_.pending_ttl, logger_.get_child("LeaseManager")) {}
+                     config_.pending_ttl) {}
 
 GpuBufferManager::~GpuBufferManager() { reset(); }
 

--- a/ros2_cuda_ipc_core/src/publisher/gpu_buffer_pool.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/gpu_buffer_pool.cpp
@@ -3,9 +3,10 @@
 
 #include "ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp"
 
+#include <rcutils/logging_macros.h>
+
 #include <optional>
 
-#include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/backend/cuda_ipc/memory_backend.hpp"
 #include "ros2_cuda_ipc_core/backend/vmm_fd/memory_backend.hpp"
 
@@ -23,25 +24,23 @@ std::unique_ptr<GpuBufferPool::MemoryBackend> make_backend(
 }  // namespace
 
 GpuBufferPool::GpuBufferPool(std::size_t slot_count,
-                             transport::MemoryBackendKind backend,
-                             rclcpp::Logger logger)
-    : GpuBufferPool(slot_count, backend, std::move(logger), nullptr) {}
+                             transport::MemoryBackendKind backend)
+    : GpuBufferPool(slot_count, backend, nullptr) {}
 
 GpuBufferPool::GpuBufferPool(std::size_t slot_count,
                              transport::MemoryBackendKind backend,
-                             rclcpp::Logger logger,
                              std::unique_ptr<MemoryBackend> memory_backend)
     : slot_count_(slot_count),
       backend_kind_(backend),
-      logger_(std::move(logger)),
       memory_backend_(std::move(memory_backend)) {}
 
 GpuBufferPool::~GpuBufferPool() { destroy_slots(); }
 
 bool GpuBufferPool::initialise(uint64_t byte_size, int device_index) {
   if (slot_count_ == 0 || byte_size == 0) {
-    RCLCPP_ERROR(logger_,
-                 "GpuBufferPool requires slot_count and byte_size > 0");
+    RCUTILS_LOG_ERROR_NAMED(
+        "ros2_cuda_ipc_core.publisher.gpu_buffer_pool",
+        "GpuBufferPool requires slot_count and byte_size > 0");
     return false;
   }
   if (initialised_ || !slots_.empty()) {
@@ -49,8 +48,9 @@ bool GpuBufferPool::initialise(uint64_t byte_size, int device_index) {
   }
   auto context_result = detail::CudaDeviceContext::retain_primary(device_index);
   if (!context_result) {
-    RCLCPP_ERROR(logger_, "Failed to retain CUDA primary context: %s",
-                 context_result.error().to_string().c_str());
+    RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.publisher.gpu_buffer_pool",
+                            "Failed to retain CUDA primary context: %s",
+                            context_result.error().to_string().c_str());
     return false;
   }
   context_ = std::move(context_result).value();
@@ -102,7 +102,8 @@ const GpuBufferPool::SlotResources* GpuBufferPool::resources(
 
 bool GpuBufferPool::allocate_slots() {
   if (!context_) {
-    RCLCPP_ERROR(logger_, "CUDA primary context is unavailable");
+    RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.publisher.gpu_buffer_pool",
+                            "CUDA primary context is unavailable");
     return false;
   }
   if (!memory_backend_) {
@@ -114,14 +115,14 @@ bool GpuBufferPool::allocate_slots() {
   {
     auto memory_guard_result = context_->push_current();
     if (!memory_guard_result) {
-      RCLCPP_ERROR(logger_, "Failed to activate CUDA context: %s",
-                   memory_guard_result.error().to_string().c_str());
+      RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.publisher.gpu_buffer_pool",
+                              "Failed to activate CUDA context: %s",
+                              memory_guard_result.error().to_string().c_str());
       return false;
     }
     auto memory_guard = std::move(memory_guard_result).value();
-    if (!memory_backend_->allocate(byte_size_, device_index_, slots_,
-                                   logger_)) {
-      memory_backend_->destroy(slots_, logger_);
+    if (!memory_backend_->allocate(byte_size_, device_index_, slots_)) {
+      memory_backend_->destroy(slots_);
       memory_backend_.reset();
       return false;
     }
@@ -129,8 +130,9 @@ bool GpuBufferPool::allocate_slots() {
   for (auto& slot : slots_) {
     auto event_result = detail::InterprocessEvent::create(context_);
     if (!event_result) {
-      RCLCPP_ERROR(logger_, "Failed to create interprocess event: %s",
-                   event_result.error().to_string().c_str());
+      RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.publisher.gpu_buffer_pool",
+                              "Failed to create interprocess event: %s",
+                              event_result.error().to_string().c_str());
       return false;
     }
     slot.ready_event = std::move(event_result).value();
@@ -146,15 +148,16 @@ void GpuBufferPool::destroy_slots() noexcept {
   if (context_) {
     auto guard_result = context_->push_current();
     if (!guard_result) {
-      RCLCPP_ERROR(logger_,
-                   "Failed to activate CUDA context for event cleanup: %s",
-                   guard_result.error().to_string().c_str());
+      RCUTILS_LOG_ERROR_NAMED(
+          "ros2_cuda_ipc_core.publisher.gpu_buffer_pool",
+          "Failed to activate CUDA context for event cleanup: %s",
+          guard_result.error().to_string().c_str());
     } else {
       guard.emplace(std::move(guard_result).value());
     }
   }
   if (memory_backend_) {
-    memory_backend_->destroy(slots_, logger_);
+    memory_backend_->destroy(slots_);
     memory_backend_.reset();
   }
   slots_.clear();

--- a/ros2_cuda_ipc_core/src/publisher/lease_manager.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/lease_manager.cpp
@@ -4,6 +4,7 @@
 #include "ros2_cuda_ipc_core/publisher/lease_manager.hpp"
 
 #include <limits.h>
+#include <rcutils/logging_macros.h>
 #include <sys/mman.h>
 #include <uuid/uuid.h>
 
@@ -12,7 +13,6 @@
 #include <string>
 #include <utility>
 
-#include "rclcpp/logging.hpp"
 #include "ros2_cuda_ipc_core/lease/lease_handle.hpp"
 
 namespace ros2_cuda_ipc_core::publisher {
@@ -42,29 +42,30 @@ std::pair<PublisherInstanceId, std::string> make_instance_identity(
 }  // namespace
 
 LeaseManager::LeaseManager(std::string shm_name_prefix, std::size_t slot_count,
-                           std::chrono::milliseconds pending_ttl,
-                           rclcpp::Logger logger)
+                           std::chrono::milliseconds pending_ttl)
     : shm_name_prefix_(std::move(shm_name_prefix)),
       slot_count_(slot_count),
-      pending_ttl_(pending_ttl),
-      logger_(std::move(logger)) {}
+      pending_ttl_(pending_ttl) {}
 
 LeaseManager::~LeaseManager() { reset(); }
 
 bool LeaseManager::initialise() {
   reset();
   if (slot_count_ == 0 || slot_count_ > std::numeric_limits<uint32_t>::max()) {
-    RCLCPP_ERROR(logger_, "Invalid slot_count: %zu", slot_count_);
+    RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.publisher.lease_manager",
+                            "Invalid slot_count: %zu", slot_count_);
     return false;
   }
   if (!valid_prefix(shm_name_prefix_)) {
-    RCLCPP_ERROR(logger_, "Invalid shared-memory name prefix: %s",
-                 shm_name_prefix_.c_str());
+    RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.publisher.lease_manager",
+                            "Invalid shared-memory name prefix: %s",
+                            shm_name_prefix_.c_str());
     return false;
   }
   auto [instance_id, instance_name] = make_instance_identity(shm_name_prefix_);
   if (instance_name.size() > NAME_MAX) {
-    RCLCPP_ERROR(logger_, "Generated shared-memory name is too long");
+    RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.publisher.lease_manager",
+                            "Generated shared-memory name is too long");
     return false;
   }
   std::vector<Clock::time_point> pending_deadlines(slot_count_);
@@ -100,8 +101,9 @@ void LeaseManager::reset() noexcept {
     initialised_ = false;
   }
   if (!owned_name.empty() && ::shm_unlink(owned_name.c_str()) != 0) {
-    RCLCPP_WARN(logger_, "Failed to unlink lease shared memory name=%s",
-                owned_name.c_str());
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.publisher.lease_manager",
+                           "Failed to unlink lease shared memory name=%s",
+                           owned_name.c_str());
   }
   // Keep the mapping alive until after unlink. Reservations may still own it.
   owned_mapping.reset();
@@ -132,17 +134,18 @@ std::optional<LeaseManager::Reservation> LeaseManager::reserve_for_publish(
     return std::nullopt;
   }
   if (reservation->slot_id >= slot_count_) {
-    RCLCPP_ERROR(logger_,
-                 "Lease shared-memory capacity changed unexpectedly: "
-                 "slot=%u configured_count=%zu",
-                 reservation->slot_id, slot_count_);
+    RCUTILS_LOG_ERROR_NAMED(
+        "ros2_cuda_ipc_core.publisher.lease_manager",
+        "Lease shared-memory capacity changed unexpectedly: "
+        "slot=%u configured_count=%zu",
+        reservation->slot_id, slot_count_);
     const bool rolled_back = lease::LeaseHandle::cancel_pending(
         reservation->mapping, reservation->slot_id, reservation->generation);
     if (!rolled_back) {
-      RCLCPP_ERROR(logger_,
-                   "Failed to roll back out-of-range reservation slot=%u "
-                   "generation=%u",
-                   reservation->slot_id, reservation->generation);
+      RCUTILS_LOG_ERROR_NAMED(
+          "ros2_cuda_ipc_core.publisher.lease_manager",
+          "Failed to roll back out-of-range reservation slot=%u generation=%u",
+          reservation->slot_id, reservation->generation);
     }
     return std::nullopt;
   }
@@ -164,9 +167,10 @@ std::optional<LeaseManager::Reservation> LeaseManager::reserve_for_publish(
   const bool rolled_back = lease::LeaseHandle::cancel_pending(
       reservation->mapping, reservation->slot_id, reservation->generation);
   if (!rolled_back) {
-    RCLCPP_ERROR(logger_,
-                 "Failed to roll back reservation slot=%u generation=%u",
-                 reservation->slot_id, reservation->generation);
+    RCUTILS_LOG_ERROR_NAMED(
+        "ros2_cuda_ipc_core.publisher.lease_manager",
+        "Failed to roll back reservation slot=%u generation=%u",
+        reservation->slot_id, reservation->generation);
   }
   return std::nullopt;
 }
@@ -178,8 +182,10 @@ bool LeaseManager::cancel(const Reservation& reservation) noexcept {
   const bool cancelled = lease::LeaseHandle::cancel_pending(
       reservation.mapping, reservation.slot_id, reservation.generation);
   if (!cancelled) {
-    RCLCPP_ERROR(logger_, "Failed to cancel reservation slot=%u generation=%u",
-                 reservation.slot_id, reservation.generation);
+    RCUTILS_LOG_ERROR_NAMED(
+        "ros2_cuda_ipc_core.publisher.lease_manager",
+        "Failed to cancel reservation slot=%u generation=%u",
+        reservation.slot_id, reservation.generation);
   }
   if (cancelled) {
     std::lock_guard<std::mutex> lock(deadlines_mutex_);
@@ -212,9 +218,10 @@ void LeaseManager::reclaim_stale_pending() {
       continue;
     }
     if (lease::LeaseHandle::force_clear_pending(mapping_, slot_id)) {
-      RCLCPP_WARN(logger_,
-                  "Force-cleared pending lease slot=%u after %lld ms timeout",
-                  slot_id, static_cast<long long>(pending_ttl_.count()));
+      RCUTILS_LOG_WARN_NAMED(
+          "ros2_cuda_ipc_core.publisher.lease_manager",
+          "Force-cleared pending lease slot=%u after %lld ms timeout", slot_id,
+          static_cast<long long>(pending_ttl_.count()));
       deadline = {};
     }
   }

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_view_mapper.cpp
@@ -3,6 +3,8 @@
 
 #include "ros2_cuda_ipc_core/subscriber/buffer_view_mapper.hpp"
 
+#include <rcutils/logging_macros.h>
+
 #include <cstring>
 #include <memory>
 #include <utility>
@@ -100,21 +102,22 @@ std::size_t LeaseMappingCache::size() const {
   return mappings_.size();
 }
 
-BufferViewMapper::BufferViewMapper(BufferViewMapperOptions options)
-    : options_(std::move(options)),
-      mapping_cache_(std::make_shared<LeaseMappingCache>()) {}
+BufferViewMapper::BufferViewMapper()
+    : mapping_cache_(std::make_shared<LeaseMappingCache>()) {}
 
 BufferView BufferViewMapper::map(
     const ros2_cuda_ipc_msgs::msg::BufferCore& msg) const {
   if (!is_supported_backend(static_cast<uint8_t>(msg.backend))) {
-    RCLCPP_WARN(options_.logger, "Unsupported BufferCore.backend=%u",
-                static_cast<unsigned>(msg.backend));
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.subscriber.buffer_view_mapper",
+                           "Unsupported BufferCore.backend=%u",
+                           static_cast<unsigned>(msg.backend));
     return {};
   }
 
   const PublisherInstanceId instance_id = msg.publisher_instance_id;
   if (is_nil(instance_id)) {
-    RCLCPP_WARN(options_.logger, "BufferCore publisher_instance_id is nil");
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.subscriber.buffer_view_mapper",
+                           "BufferCore publisher_instance_id is nil");
     return {};
   }
 
@@ -122,9 +125,9 @@ BufferView BufferViewMapper::map(
   auto lease =
       lease::LeaseHandle::acquire(mapping, msg.slot_id, msg.generation);
   if (!lease.valid()) {
-    RCLCPP_WARN(options_.logger,
-                "Failed to acquire lease shm=%s slot=%u gen=%u",
-                msg.shm_name.c_str(), msg.slot_id, msg.generation);
+    RCUTILS_LOG_WARN_NAMED("ros2_cuda_ipc_core.subscriber.buffer_view_mapper",
+                           "Failed to acquire lease shm=%s slot=%u gen=%u",
+                           msg.shm_name.c_str(), msg.slot_id, msg.generation);
     return {};
   }
 
@@ -145,7 +148,7 @@ BufferView BufferViewMapper::map(
   if (!imported) {
     const auto& importer =
         backend::get_memory_importer(static_cast<uint8_t>(msg.backend));
-    auto opened = importer.import(msg, event_handle, options_.logger);
+    auto opened = importer.import(msg, event_handle);
     if (!opened.has_value()) {
       return {};
     }

--- a/ros2_cuda_ipc_core/test/cuda_ipc_import_helper.cpp
+++ b/ros2_cuda_ipc_core/test/cuda_ipc_import_helper.cpp
@@ -65,9 +65,7 @@ int main(int argc, char** argv) {
   std::memcpy(&event_handle, payload.event_handle.data(), sizeof(event_handle));
 
   ros2_cuda_ipc_core::backend::cuda_ipc::MemoryImporter importer;
-  auto imported = importer.import(
-      msg, event_handle,
-      rclcpp::get_logger("ros2_cuda_ipc_core.cuda_ipc_import_helper"));
+  auto imported = importer.import(msg, event_handle);
   if (!imported.has_value()) {
     return 5;
   }

--- a/ros2_cuda_ipc_core/test/test_cuda_ipc_memory_driver.cpp
+++ b/ros2_cuda_ipc_core/test/test_cuda_ipc_memory_driver.cpp
@@ -73,8 +73,7 @@ TEST(CudaIpcMemoryDriverTest, ImportsReadsAndClosesInChildProcess) {
 
   constexpr uint64_t kByteSize = 4096;
   constexpr uint8_t kExpectedValue = 0x5a;
-  GpuBufferPool pool(1, MemoryBackendKind::CUDA_IPC,
-                     rclcpp::get_logger("CudaIpcMemoryDriverTest"));
+  GpuBufferPool pool(1, MemoryBackendKind::CUDA_IPC);
   ASSERT_TRUE(pool.initialise(kByteSize, 0));
   const auto* resources = pool.resources(0);
   ASSERT_NE(resources, nullptr);

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
@@ -50,8 +50,7 @@ class GpuBufferManagerTest : public ::testing::Test {
       std::chrono::milliseconds pending_ttl = std::chrono::milliseconds(100)) {
     return GpuBufferManager(
         {shm_name_, 1, 1024, 0, pending_ttl,
-         ros2_cuda_ipc_core::transport::MemoryBackendKind::CUDA_IPC},
-        rclcpp::get_logger("GpuBufferManagerTest"));
+         ros2_cuda_ipc_core::transport::MemoryBackendKind::CUDA_IPC});
   }
   std::string shm_name_;
 };

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_pool.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_pool.cpp
@@ -24,15 +24,15 @@ class PartiallyFailingBackend
       std::shared_ptr<CleanupObservation> observation)
       : observation_(std::move(observation)) {}
 
-  bool allocate(uint64_t, int,
-                std::vector<ros2_cuda_ipc_core::backend::SlotResources>& slots,
-                rclcpp::Logger) override {
+  bool allocate(
+      uint64_t, int,
+      std::vector<ros2_cuda_ipc_core::backend::SlotResources>& slots) override {
     slots[0].device_ptr = reinterpret_cast<void*>(0x1);
     return false;
   }
 
-  void destroy(std::vector<ros2_cuda_ipc_core::backend::SlotResources>& slots,
-               rclcpp::Logger) noexcept override {
+  void destroy(std::vector<ros2_cuda_ipc_core::backend::SlotResources>&
+                   slots) noexcept override {
     ++observation_->destroy_calls;
     for (auto& slot : slots) {
       if (slot.device_ptr != nullptr) {
@@ -56,7 +56,6 @@ TEST(GpuBufferPoolTest, PartialBackendFailureIsRolledBack) {
   auto observation = std::make_shared<CleanupObservation>();
   ros2_cuda_ipc_core::publisher::GpuBufferPool pool(
       2, ros2_cuda_ipc_core::transport::MemoryBackendKind::CUDA_IPC,
-      rclcpp::get_logger("GpuBufferPoolTest"),
       std::make_unique<PartiallyFailingBackend>(observation));
   EXPECT_FALSE(pool.initialise(1024, 0));
   EXPECT_FALSE(pool.is_initialised());

--- a/ros2_cuda_ipc_core/test/test_lease_manager.cpp
+++ b/ros2_cuda_ipc_core/test/test_lease_manager.cpp
@@ -32,8 +32,7 @@ TEST(LeaseManagerTest, ResetRacingWithReserveDoesNotLeavePending) {
   for (int iteration = 0; iteration < 1000; ++iteration) {
     const std::string prefix = make_unique_shm_name();
     ros2_cuda_ipc_core::publisher::LeaseManager manager(
-        prefix, 1, std::chrono::milliseconds(100),
-        rclcpp::get_logger("LeaseManagerTest"));
+        prefix, 1, std::chrono::milliseconds(100));
     ASSERT_TRUE(manager.initialise());
     std::atomic<bool> start{false};
     std::optional<ros2_cuda_ipc_core::publisher::LeaseManager::Reservation>
@@ -69,11 +68,9 @@ TEST(LeaseManagerTest, ResetRacingWithReserveDoesNotLeavePending) {
 TEST(LeaseManagerTest, SamePrefixProducesDistinctInstances) {
   const std::string prefix = make_unique_shm_name();
   ros2_cuda_ipc_core::publisher::LeaseManager first(
-      prefix, 1, std::chrono::milliseconds(100),
-      rclcpp::get_logger("LeaseManagerTest"));
+      prefix, 1, std::chrono::milliseconds(100));
   ros2_cuda_ipc_core::publisher::LeaseManager second(
-      prefix, 2, std::chrono::milliseconds(100),
-      rclcpp::get_logger("LeaseManagerTest"));
+      prefix, 2, std::chrono::milliseconds(100));
   ASSERT_TRUE(first.initialise());
   ASSERT_TRUE(second.initialise());
   EXPECT_NE(first.shm_name(), second.shm_name());
@@ -82,8 +79,7 @@ TEST(LeaseManagerTest, SamePrefixProducesDistinctInstances) {
 
 TEST(LeaseManagerTest, ResetUnlinksAndReinitialiseChangesIdentity) {
   ros2_cuda_ipc_core::publisher::LeaseManager manager(
-      make_unique_shm_name(), 1, std::chrono::milliseconds(100),
-      rclcpp::get_logger("LeaseManagerTest"));
+      make_unique_shm_name(), 1, std::chrono::milliseconds(100));
   ASSERT_TRUE(manager.initialise());
   const std::string old_name = manager.shm_name();
   const auto old_id = manager.publisher_instance_id();
@@ -103,8 +99,7 @@ TEST(LeaseManagerTest, ResetUnlinksAndReinitialiseChangesIdentity) {
 
 TEST(LeaseManagerTest, InvalidPrefixFailsClosed) {
   ros2_cuda_ipc_core::publisher::LeaseManager manager(
-      "/invalid/prefix", 1, std::chrono::milliseconds(100),
-      rclcpp::get_logger("LeaseManagerTest"));
+      "/invalid/prefix", 1, std::chrono::milliseconds(100));
   EXPECT_FALSE(manager.initialise());
   EXPECT_TRUE(manager.shm_name().empty());
   EXPECT_TRUE(ros2_cuda_ipc_core::is_nil(manager.publisher_instance_id()));


### PR DESCRIPTION
## Summary

- Replace `RCLCPP_*` logging in `ros2_cuda_ipc_core` with `RCUTILS_LOG_*_NAMED`.
- Remove `rclcpp::Logger` instances and logger parameters from core APIs and internal backend/importer paths.
- Update the example, tests, and package dependencies accordingly.

## Motivation

The core library was carrying logger instances through multiple layers solely for diagnostics. Fixed component names with rcutils macros remove that propagation and reduce the core API's dependency on logger objects.

## Validation

- `colcon build --packages-select ros2_cuda_ipc_core --cmake-args -DBUILD_TESTING=ON`
- `colcon build --packages-select multi_process_image_fanout --cmake-args -DBUILD_TESTING=OFF`
- `ROS_LOG_DIR=/tmp/ros2_cuda_ipc_ros_log colcon test --packages-select ros2_cuda_ipc_core` (14/14 passed; CUDA-dependent tests skipped where no device was available)
- `clang-format` pre-commit hook passed

The unrelated untracked file `doc/upstream-comparison.md` is intentionally not included.