### PR TITLE
Simplify lease slot reuse state

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -19,14 +19,14 @@ who want to try the demo first.
 - `ros2_cuda_ipc_core::subscriber::BufferViewMapper` and `ros2_cuda_ipc_core::image::ImageViewMapper` / `ros2_cuda_ipc_core::pointcloud2::PointCloud2ViewMapper`: explicit mapping APIs from raw messages to imported views.
 - `ros2_cuda_ipc_core::lease::LeaseHandle`: process-shared slot lease accounting.
 - `ros2_cuda_ipc_core::publisher::GpuBufferPool`: publisher-side GPU resource ownership.
-- `ros2_cuda_ipc_core::publisher::LeaseManager`: publisher reservation, pending, generation, and TTL state.
+- `ros2_cuda_ipc_core::publisher::LeaseManager`: publisher reservation, generation, and grace-period state.
 - `ros2_cuda_ipc_core::publisher::GpuBufferManager`: publisher-facing buffer manager.
 - `ros2_cuda_ipc_core::publisher::PublishSlot`: one move-only publish attempt with RAII cancellation.
 
 Publisher code should follow this order:
 
 ```cpp
-auto slot = manager.acquire_for_publish(pending_count);
+auto slot = manager.acquire_for_publish();
 launch_gpu_work(slot->device_ptr(), stream);
 slot->record_ready(stream);
 auto descriptor = slot->descriptor();

--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ ros2 launch multi_process_image_fanout multi_process_image_fanout.launch.py \
   publish_rate_hz:=60.0 \
   memory_backend:=cuda_ipc \
   slot_count:=4 \
-  pending_ttl_ms:=300 \
   shm_name_prefix:=/ros2_cuda_ipc_fanout \
   device_index:=0
 ```

--- a/doc/lease_protocol.md
+++ b/doc/lease_protocol.md
@@ -56,14 +56,18 @@ slot->commit_publish();
 
 ```cpp
 struct SlotMeta {
-  uint32_t generation;
-  uint32_t refcnt;
-  uint64_t publish_timestamp_us;
+  std::atomic<uint32_t> generation;
+  std::atomic<uint32_t> refcnt;
+  std::atomic<uint64_t> publish_timestamp_us;
 };
 ```
 
-shared-memory layout version は4である。attach 時には magic、layout version、capacity、
+shared-memory layout version は5である。attach 時には magic、layout version、capacity、
 Publisher instance ID を検証する。
+
+各atomicは対象platformでlock-freeであることを要求し、Publisherがshared memoryを作成
+するときに`SlotMeta`をplacement newで構築する。Subscriberは既存のslotを再構築せずに
+attachする。
 
 `publish_timestamp_us` は `steady_clock` のマイクロ秒値で、最後に commit された publish
 時刻を表す。0 はまだ publish されていない slot を表す。

--- a/doc/lease_protocol.md
+++ b/doc/lease_protocol.md
@@ -2,407 +2,196 @@
 
 ## 1. 目的と適用範囲
 
-この文書は、`ros2_cuda_ipc`がGPU buffer slotの再利用をPublisherとSubscriberの
-複数process間で調整するために使用するlease protocolの正式仕様である。
+この文書は、`ros2_cuda_ipc` が GPU buffer slot を Publisher と Subscriber の複数
+process 間で安全に再利用するための lease protocol を定義する。
 
-このprotocolの目的は、古いmessageや処理中のSubscriberが参照するGPU bufferを
-Publisherが安全でないタイミングで再利用することを防ぐことである。対象には次を含む。
-
-- Publisherによるslotの予約とgeneration更新
-- publish後、Subscriberがleaseを取得するまでの保護
-- Subscriberによるleaseの取得と解放
-- 未完了publishのcancel
-- stale pendingのTTL回収
-- Publisher/Subscriber間の競合制御
-
-ROS middlewareによる配送保証、Subscriber processの死活監視、Publisher再起動時の
-状態引き継ぎは、このprotocolの保証範囲外である。
-
----
+この protocol は、古い message や処理中の Subscriber が参照する GPU buffer を
+Publisher が上書きすることを防ぐ。ROS middleware の配送保証、Subscriber の死活監視、
+Publisher 再起動後の状態引き継ぎは対象外である。
 
 ## 2. 用語
 
 | 用語 | 定義 |
 | --- | --- |
-| slot | Publisherが再利用する1個のGPU bufferと、そのready eventおよびlease状態の組 |
-| generation | slotがpublish用に予約されるたびに増加する世代番号 |
-| reservation | Publisherが1回のpublish試行のために取得した`slot_id`と`generation` |
-| pending | messageを受け取ってleaseを取得すると見込まれるSubscriber数 |
-| refcnt | 現在そのslotのleaseを保持しているSubscriber数 |
-| reserved | Publisherのslot選択・世代更新とSubscriber acquireを排他する一時的なflag |
-| lease | Subscriberが対象generationのslotを読み取り中であることを表す所有権 |
-| TTL | staleなpendingをPublisherが回収可能になるまでの期間 |
+| slot | GPU buffer、ready event、共有 lease metadata の組 |
+| generation | slot が publish 用に取得されるたびに増加する世代番号 |
+| reservation | Publisher が保持する `slot_id` と `generation` |
+| refcnt | Subscriber lease と Publisher reservation の合計参照数 |
+| grace period | publish 後に slot を再利用しない固定期間（100 ms） |
+| lease | Subscriber が buffer を読み取り中であることを表す RAII 所有権 |
 
-`pending_count`は通常、publish時点のROS subscription countから得る。これは配送数の
-保証値ではなく、期待値である。
+`pending` や ROS subscription count は lease protocol の状態として使用しない。実際に
+lease を取得した Subscriber だけが `refcnt` に反映される。
 
----
-
-## 3. 構成要素と責務
+## 3. 構成要素
 
 ```text
 Publisher process
   GpuBufferManager
-    GpuBufferPool       GPU allocationとready eventを所有
-    LeaseManager        reservation、pending、generation、TTLを管理
-      LeaseHandle       process-shared lease stateを操作
-    PublishSlot         1回のpublish試行を表すmove-only object
+    GpuBufferPool       GPU allocation と ready event を所有
+    LeaseManager        reservation と publish lifecycle を管理
+      LeaseHandle       process-shared metadata を操作
+    PublishSlot         1回の publish 試行を表す move-only object
 
 Subscriber process
   BufferViewMapper
-    LeaseHandle         leaseを取得
-  BufferView
-    LeaseHandle         viewの生存中leaseを保持
+    LeaseHandle         lease を取得
+  BufferView            view の生存中 lease を保持
 ```
 
-ROS messageには少なくとも次が含まれる。
-
-- shared memory名
-- 16-byte `publisher_instance_id`
-- `slot_id`
-- `generation`
-- device IDとbyte size
-- memory backend種別とmemory handle
-- ready event handle
-
-application固有の画像shape、encoding、point cloud layoutなどはlease protocolに含めない。
-
----
-
-## 4. Process-shared slot state
-
-各slotはPOSIX shared memory上に次の`uint32_t` stateを持つ。
-
-| field | 意味 | 再利用条件への影響 |
-| --- | --- | --- |
-| `generation` | 現在の世代 | messageの世代一致確認に使用 |
-| `refcnt` | activeなSubscriber lease数 | 0でなければ再利用不可 |
-| `pending` | lease取得がまだ期待される数 | 0でなければ再利用不可 |
-| `reserved` | Publisher更新中の排他flag | 0でなければPublisher reserveとSubscriber acquireを拒否 |
-
-現在のshared memory layout versionは3であり、headerに16-byte
-`publisher_instance_id`を保持する。attach時にmagic、layout version、messageから渡された
-instance IDを検証し、各APIは`slot_id`がheaderのcapacity範囲内であることを検証する。
-
-slotを再利用できる基本条件は次である。
-
-```text
-reserved == 0 && refcnt == 0 && pending == 0
-```
-
-この条件の単純な読み取りだけでは競合を防げないため、Publisherは`reserved`をCASで
-取得してから`refcnt`と`pending`を再確認する。
-
----
-
-## 5. Publisher workflow
-
-Publisherの公開APIは次の順序で使用する。
+Publisher は次の順で API を使用する。
 
 ```cpp
-auto slot = manager.acquire_for_publish(pending_count);
-
+auto slot = manager.acquire_for_publish();
 launch_gpu_work(slot->device_ptr(), stream);
 slot->record_ready(stream);
-
 auto descriptor = slot->descriptor();
 publisher->publish(make_message(*descriptor));
-
 slot->commit_publish();
 ```
 
-状態遷移は次のとおりである。
+## 4. Process-shared slot state
+
+各 slot は POSIX shared memory 上に次の metadata を持つ。
+
+```cpp
+struct SlotMeta {
+  uint32_t generation;
+  uint32_t refcnt;
+  uint64_t publish_timestamp_us;
+};
+```
+
+shared-memory layout version は4である。attach 時には magic、layout version、capacity、
+Publisher instance ID を検証する。
+
+`publish_timestamp_us` は `steady_clock` のマイクロ秒値で、最後に commit された publish
+時刻を表す。0 はまだ publish されていない slot を表す。
+
+slot の再利用条件は次である。
 
 ```text
-reserved
-  ├─ record_ready成功 ──────────────> ready_recorded
-  └─ cancel / destructor ───────────> cancelled
-
-ready_recorded
-  ├─ descriptor ────────────────────> ready_recorded
-  ├─ commit_publish ────────────────> committed
-  └─ cancel / destructor ───────────> cancelled
+refcnt == 0 &&
+(publish_timestamp_us == 0 ||
+ now_us - publish_timestamp_us >= 100000)
 ```
+
+`reserved` のような別の排他 flag は持たない。Publisher が slot を取得するときに
+`refcnt` を CAS で `0 -> 1` に変更し、その1件を Publisher reservation として扱う。
+
+## 5. Publisher workflow
 
 ### 5.1 reserve
 
-`acquire_for_publish()`は最初にTTLを超えたpendingの回収を試み、その後slotを
-round-robinで探索する。各候補slotについて次を行う。
+`acquire_for_publish()` は round-robin で候補を探索し、各 slot に対して次を行う。
 
-1. `reserved`を`0 -> 1`へCASする。
-2. `refcnt == 0 && pending == 0`を再確認する。
-3. `generation`を1増加する。
-4. `pending`を`pending_count`で初期化する。
-5. `reserved`を0へ戻す。
-6. `slot_id`と新しい`generation`をreservationとして返す。
+1. `refcnt == 0` を確認する。
+2. timestamp が0、または publish から100 ms以上経過していることを確認する。
+3. `refcnt` を CAS で `0 -> 1` に変更する。
+4. CAS に失敗したら次の候補へ進む。
+5. `generation` を1増加する。
+6. `publish_timestamp_us` を0へ戻す。
+7. reservation を返す。
 
-候補がなければacquireは失敗する。bufferを強制再利用してはならない。
+Publisher reservation が存在する間は、別の Publisher が同じ slot を取得できない。
+Subscriber は `refcnt != 0` だけを理由に拒否せず、generation の前後再確認で Publisher
+との競合を検出する。
 
-### 5.2 GPU workとready event
+### 5.2 GPU work と ready event
 
-Publisherは取得したdevice pointerへ必要なGPU workをenqueueした後、同じ依存関係を持つ
-CUDA streamで`record_ready()`を呼ぶ。ready eventはlibraryがslotごとに所有する。
+Publisher は取得した device pointer へ GPU work を enqueue し、同じ依存関係を持つ
+CUDA stream で `record_ready()` を呼ぶ。`descriptor()` は ready event 記録成功前には
+失敗する。
 
-publicな`record_ready()`と`enqueue_ready_event()`はCUDA Driver APIの
-`CUstream`を受け取る。Runtime APIを使うapplicationは
-`<cuda_runtime_api.h>`を明示的にincludeすれば、`cudaStreamCreate()`で作成した
-`cudaStream_t`をcastなしでそのまま渡せる。streamの作成・破棄とownershipは
-application側にあり、libraryは非所有参照として使用する。
+ready event の記録前に reservation が破棄された場合、`PublishSlot` の destructor が
+cancel を実行する。
 
-`descriptor()`は`record_ready()`成功前には失敗する。これにより、未記録のready eventを
-含むmessageの生成を防ぐ。
+### 5.3 commit
 
-libraryは、すべてのGPU書き込みが`record_ready()`より前にenqueueされたことまでは検証
-できない。これはcallerの契約である。
+`commit_publish()` は ROS publish API が message を middleware へ引き渡した後に呼ぶ。
 
-### 5.3 publishとcommit
+commit は次の順で処理する。
 
-`commit_publish()`は、ROS publish APIがmessageをmiddlewareへ引き渡した後に呼ぶ。
-commitは`PublishSlot`のprocess-localな状態を`committed`へ変更し、destructorによる
-cancelを無効にするだけの非失敗操作である。同じslotへの繰り返しcommitはno-opになる。
-descriptor取得成功後はstateが`ready_recorded`であるため、正常なpublish workflowでは
-外部resourceや競合に起因するcommit失敗は存在しない。
+1. reservation の generation が現在の generation と一致することを確認する。
+2. `publish_timestamp_us` を現在時刻へ更新する。
+3. Publisher reservation の `refcnt` を1減少させる。
 
-commitは次を意味しない。
-
-- GPU workの完了
-- Subscriberへの配送完了
-- Subscriberによるlease取得
-- slotが再利用可能になったこと
+commit 後も、Subscriber lease が残っていれば slot は再利用できない。commit は GPU work
+完了、Subscriber への配送完了、Subscriber の lease 取得完了を意味しない。
 
 ### 5.4 cancel
 
-未commitの`PublishSlot`を破棄するとreservationを自動的にcancelする。明示的な
-`cancel()`も同じ操作を行い、複数回呼んでも安全である。
+未commitの `PublishSlot` を破棄するか `cancel()` を呼ぶと、Publisher reservation の
+`refcnt` だけを減少させる。cancel では publish timestamp を更新しないため、未公開の
+reservation は grace period を追加で発生させない。
 
-cancelは`reserved`をCASで取得する。短いPublisher/TTL回収との競合ではbounded retryし、
-reservationのgenerationが現在も一致し、かつ`refcnt == 0`の場合だけpendingを0へ戻す。
-古いreservationから新しいgenerationのpendingを消去してはならない。retry上限、
-generation不一致、active leaseによりcancelできない場合はERRORとして記録する。
+reservation の generation が一致しない場合は新しい generation の refcount を誤って
+減らさず、エラーとして扱う。通常の API lifecycle では reservation が保持されている間
+に別 generation へ進むことはない。
 
-`GpuBufferManager::reset()`後でも、manager objectが生存している間は
-`PublishSlot`のdestructorがshared-memory reservationをcancelできる。
+## 6. Subscriber acquire と release
 
----
+Subscriber は message の `shm_name`、`publisher_instance_id`、`slot_id`、`generation`
+を使って lease を取得する。
 
-## 6. Subscriber acquireとrelease
+acquire は次を行う。
 
-Subscriberはmessageの`shm_name`、`publisher_instance_id`、`slot_id`、`generation`を
-使ってleaseを取得する。`shm_name`はresource locatorであり、publisher instanceの同一性は
-headerとmessageの`publisher_instance_id`の一致によって確認する。
+1. shared memory へ attach し、layout と slot 範囲を検証する。
+2. Publisher instance ID を検証する。
+3. message の generation と slot の generation を確認する。
+4. `refcnt` を CAS で1増加する。
+5. generation を再確認する。
+6. 再確認に失敗した場合は refcount を戻して失敗する。
+7. 成功したら `LeaseHandle` を返す。
 
-acquireは次を行う。
+有効な `LeaseHandle` の破棄または move assignment による release は `refcnt` を1減少
+させる。`BufferView` は内部で lease を保持するため、view の生存中は slot を再利用
+できない。
 
-1. shared memoryへattachし、layoutとslot範囲を検証する。
-2. headerとmessageの`publisher_instance_id`一致を検証する。
-3. `reserved == 0`を確認する。
-4. `generation`がmessageと一致することを確認する。
-5. `refcnt`をCASで1増加する。
-6. `reserved == 0`と`generation`一致を再確認する。
-7. 再確認に失敗した場合は`refcnt`を戻し、acquireを失敗させる。
-8. `pending > 0`ならCASで1減少する。
-9. 有効な`LeaseHandle`を返す。
+Subscriber が import した ready event を自身の CUDA stream で待機してから buffer を
+読み取ることは、Subscriber 側の契約である。
 
-有効な`LeaseHandle`の破棄またはmove assignmentによるreleaseは`refcnt`を1減少する。
-`BufferView`は内部で`LeaseHandle`を保持するため、viewの生存中はslotを再利用できない。
+## 7. Publisher/Subscriber 競合の安全性
 
-Subscriberはimportしたready eventを自身のCUDA streamで待ってからbufferを読み取る。
+Publisher が先に refcount を claim した場合、Subscriber が古い generation を使って
+refcount を増加できても、generation の再確認に失敗して refcount を戻す。
 
----
-
-## 7. Publisher/Subscriber競合の安全性
-
-PublisherのreserveとSubscriber acquireは、次の再確認によって競合を閉じる。
+Subscriber が先に refcount を増加した場合、Publisher の `0 -> 1` CAS が失敗する。
 
 ```text
 Publisher                              Subscriber
 
-reservedを0 -> 1へCAS
-                                        reserved == 0でなければ失敗
-refcntとpendingを再確認
-generationとpendingを更新
-reservedを0へrelease
-                                        generationを確認
-                                        refcntを増加
-                                        reservedとgenerationを再確認
+refcnt 0 -> 1 を CAS
+generation を更新
+                                        generation を確認
+                                        refcnt を増加
+                                        generation を再確認
+                                        失敗時は refcnt を減少
+publish_timestamp_us を更新
+Publisher ref を解放
 ```
 
-Subscriberが先に`refcnt`を増やした場合、Publisherは`refcnt != 0`を観測してそのslotを
-選ばない。Publisherが先にgenerationを更新した場合、古いmessageのSubscriberは
-generation再確認に失敗して`refcnt`を戻す。
+この手順により、Publisher が slot を再利用する一方で古い generation の Subscriber
+lease が成立することを防ぐ。
 
-したがって、有効なSubscriber leaseと同じslotの再利用が同時に成立してはならない。
-
----
-
-## 8. pendingとTTL
-
-`pending`は、message publish後からSubscriberがleaseを取得するまでの区間を保護する。
-Subscriber acquireが成功するたび、0より大きいpendingを1減少する。
-
-message drop、subscription countの過大見積もり、Subscriber側の処理中止などにより
-pendingが残る場合がある。Publisherはslotごとのprocess-local deadlineを使って、TTLを
-超えたpendingを回収する。
-
-TTL回収は次の条件でのみpendingを0にする。
-
-```text
-deadline reached && reservedを取得できる && refcnt == 0
-```
-
-TTL回収はbackground timerではない。次の場合に実行される。
-
-- `GpuBufferManager::acquire_for_publish()`の先頭
-- `reclaim_stale_pending()`の明示呼び出し
-
-TTLを過ぎても、slotがまだ再利用されずgenerationが一致していれば、遅延Subscriberの
-acquireが成功する場合がある。slotが再利用された後はgeneration mismatchにより安全に
-失敗する。
-
----
-
-## 9. Protocolが保証すること
-
-前提とAPI契約が守られる限り、このprotocolは次を保証する。
-
-- activeなSubscriber leaseがあるslotをPublisherが再利用しない。
-- pendingが残るslotをTTL回収前に再利用しない。
-- Publisher reserveとSubscriber acquireの競合で、両者が同じ旧generationを有効と判断しない。
-- 再利用後に届いた古いmessageをgeneration mismatchで拒否する。
-- cancelが新しいgenerationのpendingを誤って消去しない。
-- ready event記録前にPublisherがdescriptorを取得できない。
-- 未commitのpublish試行を通常のscope exitでcancelする。
-
-安全性の基本方針は、条件を確認できない場合に誤ったGPU dataを読ませるのではなく、
-acquireまたはpublish試行を失敗させることである。
-
----
-
-## 10. Protocolが保証しないこと
-
-このprotocolは次を保証しない。
-
-- ROS messageがすべてのSubscriberへ配送されること
-- すべてのSubscriberがleaseを取得できること
-- `pending_count`が実際の配送数と一致すること
-- TTL後に到着したmessageを処理できること
-- ROS publish API成功後のmiddleware障害を検出すること
-- applicationがready eventを正しいstream順序で記録すること
-- applicationがready event待機後にbufferを読むこと
-- process crash後の自動resource回復
-
-配送数の見積もり不足、TTL超過、generation mismatchなどではmessageをdropし得る。
-これは誤ったbufferを読むより安全なfailure modeとして扱う。
-
----
-
-## 11. Lifetime contract
-
-`PublishSlot`は所有元`GpuBufferManager`への非所有pointerを保持する。すべての
-`PublishSlot`は、そのmanager objectより先に破棄しなければならない。
-
-```text
-required:
-  PublishSlot destruction
-    before
-  GpuBufferManager destruction
-```
-
-この順序に反してmanagerを先に破棄することはAPI contract violationであり、libraryは
-shared ownershipによって補償しない。`reset()`はresource操作を無効にするが、manager
-objectが生存していれば未commit slotのshared-memory cancelは可能である。
-
----
-
-## 12. 既知の制約
-
-### 12.1 Subscriber crashによるrefcnt leak
-
-`refcnt`は`LeaseHandle`の正常なreleaseでのみ減少する。Subscriberが`SIGKILL`、process
-crash、machine failureなどでdestructorを通らず終了するとrefcntが残り、そのslotは
-再利用不能になる。
-
-これはmemory safety上は安全側だが、pool capacityを失うavailability上の問題である。
-現在はprocess identity、heartbeat、process death detectionを実装していない。
-
-### 12.2 Publisher restart
-
-`GpuBufferManager::initialise()`は毎回新しいUUIDを生成する。UUIDは実体SHM名へ付加され、
-同じ16-byte値がSHM headerとROS messageの`publisher_instance_id`へ格納される。正常な
-`reset()`またはdestructorは実体SHM名をunlinkするため、遅延messageからの新規attachは
-失敗する。既存mapping cacheを使用する場合にもinstance IDを照合する。
-
-Publisherが正常終了処理を通らずcrashした場合はorphan SHMが残り得る。再起動後の
-Publisherは別名・別instance IDを使用するため新instanceとの混同は起こらないが、orphanの
-列挙と回収は現在のprotocolには含まれない。
-
-### 12.3 generation wraparound
-
-wire formatとshared stateのgenerationは`uint32_t`である。長時間稼働してwraparoundすると、
-非常に古いmessageと現在のslotが同じgenerationになる可能性がある。
-
-必要に応じてwraparound前にpoolとSHM名を再生成する。`uint64_t`化はwire format変更を伴う。
-
-### 12.4 Process-shared atomicの可搬性
-
-現在の実装はshared memory上のaligned `uint32_t`を`std::atomic<uint32_t>`として操作する。
-対応architectureでのlock-free性、process-shared動作、C++ object model上の扱いには
-可搬性上の制約がある。
-
-実運用platformはLinux x86_64/aarch64とし、対象toolchainとarchitectureで32-bit atomicが
-lock-freeであることを確認する必要がある。異なるarchitecture、標準library、ABI間での
-shared memory相互運用は保証しない。
-
-### 12.5 TTLは配送保証ではない
-
-短いTTLはslot回収を早める一方、遅延messageがgeneration mismatchでdropされる可能性を
-高める。長いTTLは配送猶予を増やす一方、message drop時にslotを長く占有する。
-
-TTLは最大処理遅延、QoS、publish rate、pool sizeに合わせて設定する必要がある。
-
-### 12.6 subscription countは瞬間値
-
-ROS graphのsubscription countはpublish前後に変化し得る。新規Subscriber、切断、QoS不一致、
-middleware上のdropにより、`pending_count`と実際のlease取得数は一致しない場合がある。
-
-このprotocolは不一致を配送保証で補正せず、pendingのTTL回収とgenerationによる安全なdropで
-処理する。
-
----
-
-## 13. Failure handling
+## 8. 失敗時の挙動と既知の制約
 
 | failure | behavior |
 | --- | --- |
-| reusable slotがない | Publisher acquire失敗 |
-| GPU resource初期化失敗 | 作成済みresourceをrollback |
-| ready event記録失敗 | slotは未commitのまま残り、destructorでcancel |
-| ready記録前のdescriptor要求 | 失敗 |
-| ROS message構築またはpublish前の失敗 | destructorでcancel |
-| commit忘れ | destructorでcancelを試行。遅延Subscriberはdropし得る |
-| generation mismatch | Subscriber acquire失敗 |
-| refcnt overflow | Subscriber acquire失敗 |
-| stale pending | TTL条件を満たす場合にPublisherが回収 |
-| Subscriber crash | refcnt leak。自動回収しない |
-| SHM capacity不一致 | reservationをrollbackしてPublisher acquire失敗。並行再初期化自体は非対応 |
+| reusable slot がない | Publisher の acquire が失敗する |
+| GPU resource 初期化失敗 | 作成済み resource を rollback する |
+| ready event 記録失敗 | 未commit reservation を destructor が cancel する |
+| generation mismatch | Subscriber acquire または reservation 完了を失敗させる |
+| Subscriber process crash | refcnt が残り、slot が再利用不能になる可能性がある |
+| 100 ms を超える message 遅延 | slot 再利用後は generation mismatch で drop される可能性がある |
 
----
+固定 grace period は配送保証ではない。publish rate、最大 Subscriber 遅延、slot 数に
+応じて、遅延 message を drop し得る安全側の設計である。
 
-## 14. 検証対象
+`generation` は wire format と shared state の `uint32_t` を維持する。wraparound 時に
+非常に古い message と一致する可能性があるため、必要なら Publisher instance と shared
+memory pool を再生成する。
 
-protocol変更時は少なくとも次をテストする。
-
-- active leaseとpendingによるslot再利用防止
-- generation mismatch拒否
-- Subscriber acquireによるpending減少
-- Publisher reserveとSubscriber acquireの競合
-- 複数Publisher threadによるreserve競合
-- TTL回収と次回acquire
-- generationを照合したcancel
-- reset後の未commit reservation cancel
-- `PublishSlot`のmove、commit、cancel、destructor状態遷移
-- ready event記録前のdescriptor拒否
-- GPU backend部分初期化失敗時のrollback
-
-Publisher restart、Subscriber process crash、generation wraparound、異種platform間atomicは
-現在のunit testだけでは安全な回復を保証しない。これらは既知制約として扱う。
+shared memory 上の atomic は Linux x86_64/aarch64 と対象 toolchain に依存する。現在の
+実装は aligned な整数 field を process-shared atomic として扱うため、異なる ABI 間の
+shared-memory 相互運用は保証しない。

--- a/examples/multi_process_image_fanout/README.md
+++ b/examples/multi_process_image_fanout/README.md
@@ -71,7 +71,6 @@ ros2 launch multi_process_image_fanout multi_process_image_fanout.launch.py \
   publish_rate_hz:=60.0 \
   memory_backend:=cuda_ipc \
   slot_count:=4 \
-  pending_ttl_ms:=300 \
   shm_name_prefix:=/ros2_cuda_ipc_fanout \
   device_index:=0
 ```
@@ -84,7 +83,7 @@ ros2 launch multi_process_image_fanout multi_process_image_fanout.launch.py \
   memory_backend:=vmm_fd
 ```
 
-The `width`, `height`, `memory_backend`, `slot_count`, `pending_ttl_ms`,
+The `width`, `height`, `memory_backend`, and `slot_count`,
 `shm_name_prefix`, and `device_index` arguments are publisher-side pseudo-camera
 parameters.
 

--- a/examples/multi_process_image_fanout/launch/multi_process_image_fanout.launch.py
+++ b/examples/multi_process_image_fanout/launch/multi_process_image_fanout.launch.py
@@ -32,7 +32,6 @@ def generate_launch_description() -> LaunchDescription:
         ),
         DeclareLaunchArgument("frame_id", default_value="fanout_camera_frame"),
         DeclareLaunchArgument("slot_count", default_value="4"),
-        DeclareLaunchArgument("pending_ttl_ms", default_value="300"),
         DeclareLaunchArgument(
             "shm_name_prefix", default_value="/ros2_cuda_ipc_fanout"
         ),
@@ -72,7 +71,6 @@ def launch_setup(context) -> List[Node]:
 
     publish_rate = as_float("publish_rate_hz")
     slot_count = as_int("slot_count")
-    pending_ttl_ms = as_int("pending_ttl_ms")
     device_index = as_int("device_index")
     memory_backend = value("memory_backend")
     image_topic = value("image_topic")
@@ -106,7 +104,6 @@ def launch_setup(context) -> List[Node]:
                 "height": height_value,
                 "frame_id": value("frame_id"),
                 "slot_count": slot_count,
-                "pending_ttl_ms": pending_ttl_ms,
                 "shm_name_prefix": value("shm_name_prefix"),
                 "device_index": device_index,
                 "memory_backend": memory_backend,

--- a/examples/multi_process_image_fanout/src/gpu_image_publisher.cpp
+++ b/examples/multi_process_image_fanout/src/gpu_image_publisher.cpp
@@ -41,8 +41,6 @@ class GpuImagePublisherNode : public rclcpp::Node {
     const int width = declare_parameter<int>("width", 1920);
     const int height = declare_parameter<int>("height", 1080);
     const int slot_count_parameter = declare_parameter<int>("slot_count", 4);
-    const auto pending_ttl = std::chrono::milliseconds(
-        declare_parameter<int>("pending_ttl_ms", 300));
     const auto shm_name_prefix = declare_parameter<std::string>(
         "shm_name_prefix", "/ros2_cuda_ipc_fanout");
     const int device_index = declare_parameter<int>("device_index", 0);
@@ -67,7 +65,7 @@ class GpuImagePublisherNode : public rclcpp::Node {
         std::make_unique<ros2_cuda_ipc_core::publisher::GpuBufferManager>(
             ros2_cuda_ipc_core::publisher::GpuBufferManager::Config{
                 shm_name_prefix, slot_count, frame_size_bytes, device_index,
-                pending_ttl, backend});
+                backend});
     if (!manager_->initialise()) {
       throw std::runtime_error("Failed to initialise GPU buffer manager");
     }
@@ -117,11 +115,10 @@ class GpuImagePublisherNode : public rclcpp::Node {
   void on_timer() {
     NvtxScopedRange timer_range("GpuImagePublisherNode::on_timer");
 
-    const std::size_t subscribers = publisher_->get_subscription_count();
     std::optional<ros2_cuda_ipc_core::publisher::PublishSlot> slot;
     {
       NvtxScopedRange acquire_range("GpuImagePublisherNode::acquire_slot");
-      slot = manager_->acquire_for_publish(static_cast<uint32_t>(subscribers));
+      slot = manager_->acquire_for_publish();
     }
     if (!slot) {
       RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/lease/lease_handle.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/lease/lease_handle.hpp
@@ -15,7 +15,7 @@ namespace ros2_cuda_ipc_core::lease {
 /// counting and generation checks.
 class LeaseHandle {
  public:
-  /// Holds the mapping needed to cancel a Publisher reservation later.
+  /// Holds the mapping needed to complete a Publisher reservation later.
   struct PublisherReservation {
     std::shared_ptr<LeaseMapping> mapping;
     uint32_t slot_id = 0;
@@ -31,7 +31,8 @@ class LeaseHandle {
   static std::optional<uint32_t> current_generation(
       const std::shared_ptr<LeaseMapping>& mapping, uint32_t slot_id);
 
-  /// Read the current reference count for a slot.
+  /// Read the current reference count for a slot. The count includes the
+  /// temporary Publisher reservation while a publish attempt is in progress.
   ///
   /// @param mapping Shared-memory mapping containing the slot metadata.
   /// @param slot_id Slot index inside the mapping.
@@ -40,42 +41,34 @@ class LeaseHandle {
   static std::optional<uint32_t> current_refcount(
       const std::shared_ptr<LeaseMapping>& mapping, uint32_t slot_id);
 
-  /// Atomically claim an idle slot, advance its generation, and seed pending.
+  /// Read the current publication timestamp for a slot.
+  static std::optional<uint64_t> current_publish_timestamp_us(
+      const std::shared_ptr<LeaseMapping>& mapping, uint32_t slot_id);
+
+  /// Atomically claim an idle slot and advance its generation.
   ///
   /// The returned reservation retains the mapping so it can be cancelled even
   /// after the Publisher's current mapping has been reset.
   ///
   /// @param mapping Shared-memory mapping on which to reserve a slot.
-  /// @param pending Number of expected Subscriber acquisitions.
   /// @return Reservation when a slot is available; std::nullopt otherwise.
   static std::optional<PublisherReservation> reserve_for_publish(
-      const std::shared_ptr<LeaseMapping>& mapping, uint32_t pending);
+      const std::shared_ptr<LeaseMapping>& mapping);
 
-  /// Read the current pending count for a slot.
+  /// Mark a Publisher reservation as published and release its temporary
+  /// reference.
   ///
   /// @param mapping Shared-memory mapping containing the slot metadata.
   /// @param slot_id Slot index inside the mapping.
-  /// @return Pending count, or std::nullopt when the mapping is null or the
-  /// slot is out of range.
-  static std::optional<uint32_t> current_pending(
-      const std::shared_ptr<LeaseMapping>& mapping, uint32_t slot_id);
+  static bool commit_publish(const std::shared_ptr<LeaseMapping>& mapping,
+                             uint32_t slot_id, uint32_t generation) noexcept;
 
-  /// Clear pending when the slot is idle and has no active references.
+  /// Cancel a Publisher reservation and release its temporary reference.
   ///
   /// @param mapping Shared-memory mapping containing the slot metadata.
   /// @param slot_id Slot index inside the mapping.
-  /// @return true when pending was cleared or was already zero.
-  static bool force_clear_pending(const std::shared_ptr<LeaseMapping>& mapping,
-                                  uint32_t slot_id);
-
-  /// Clear pending only when the slot still belongs to the given generation.
-  ///
-  /// @param mapping Shared-memory mapping containing the slot metadata.
-  /// @param slot_id Slot index inside the mapping.
-  /// @param generation Expected generation for the reservation.
-  /// @return true when the reservation was cancelled.
-  static bool cancel_pending(const std::shared_ptr<LeaseMapping>& mapping,
-                             uint32_t slot_id, uint32_t generation);
+  static bool cancel_publish(const std::shared_ptr<LeaseMapping>& mapping,
+                             uint32_t slot_id, uint32_t generation) noexcept;
 
   /// Acquire a lease when the slot generation matches and increment its
   /// reference count.

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/lease/lease_mapping.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/lease/lease_mapping.hpp
@@ -15,13 +15,15 @@ namespace ros2_cuda_ipc_core::lease {
 
 /// Metadata for one slot in the shared-memory lease pool.
 struct SlotMeta {
-  uint32_t generation;
-  uint32_t refcnt;
-  uint64_t publish_timestamp_us;
+  std::atomic<uint32_t> generation{0};
+  std::atomic<uint32_t> refcnt{0};
+  std::atomic<uint64_t> publish_timestamp_us{0};
 };
 
+static_assert(std::atomic<uint32_t>::is_always_lock_free);
+static_assert(std::atomic<uint64_t>::is_always_lock_free);
 static_assert(sizeof(SlotMeta) == 16);
-static_assert(alignof(SlotMeta) >= alignof(uint64_t));
+static_assert(alignof(SlotMeta) >= alignof(std::atomic<uint64_t>));
 
 /// Owns one POSIX shared-memory mapping.
 ///

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/lease/lease_mapping.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/lease/lease_mapping.hpp
@@ -17,9 +17,11 @@ namespace ros2_cuda_ipc_core::lease {
 struct SlotMeta {
   uint32_t generation;
   uint32_t refcnt;
-  uint32_t pending;
-  uint32_t reserved;
+  uint64_t publish_timestamp_us;
 };
+
+static_assert(sizeof(SlotMeta) == 16);
+static_assert(alignof(SlotMeta) >= alignof(uint64_t));
 
 /// Owns one POSIX shared-memory mapping.
 ///

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp
@@ -59,7 +59,10 @@ class PublishSlot {
   ///
   /// Requires a successful record_ready() call. Repeated calls after commit
   /// are harmless.
-  void commit_publish() noexcept;
+  ///
+  /// @return true when the Publisher reservation was committed; false when
+  /// the reservation could not be committed.
+  bool commit_publish() noexcept;
 
   /// Cancel the reservation when it has not been committed.
   void cancel() noexcept;
@@ -154,8 +157,8 @@ class GpuBufferManager {
       const LeaseManager::Reservation& reservation, CUstream stream) noexcept;
   std::optional<transport::BufferDescriptor> descriptor(
       const LeaseManager::Reservation& reservation) const;
-  void commit(const LeaseManager::Reservation& reservation) noexcept;
-  void cancel(const LeaseManager::Reservation& reservation) noexcept;
+  bool commit(const LeaseManager::Reservation& reservation) noexcept;
+  bool cancel(const LeaseManager::Reservation& reservation) noexcept;
 
   Config config_;
   GpuBufferPool buffer_pool_;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp
@@ -5,7 +5,6 @@
 
 #include <cuda.h>
 
-#include <chrono>
 #include <cstdint>
 #include <optional>
 #include <string>
@@ -107,9 +106,6 @@ class GpuBufferManager {
     /// CUDA device index on which the buffers are allocated.
     int device_index = 0;
 
-    /// Age after which stale pending reservations may be reclaimed.
-    std::chrono::milliseconds pending_ttl{0};
-
     /// Memory backend used to allocate and export the buffers.
     transport::MemoryBackendKind backend =
         transport::MemoryBackendKind::CUDA_IPC;
@@ -144,15 +140,9 @@ class GpuBufferManager {
   PublisherInstanceId publisher_instance_id() const;
 
   /// Reserve a slot for a new publish attempt.
-  ///
-  /// @param pending_count Number of subscribers that are expected to consume
-  /// the published payload.
   /// @return A publish slot when a reservation is available; std::nullopt
   /// otherwise.
-  std::optional<PublishSlot> acquire_for_publish(uint32_t pending_count);
-
-  /// Reclaim pending reservations that have exceeded the configured TTL.
-  void reclaim_stale_pending();
+  std::optional<PublishSlot> acquire_for_publish();
 
  private:
   /// Allow a slot to delegate resource operations to its owning manager
@@ -164,6 +154,7 @@ class GpuBufferManager {
       const LeaseManager::Reservation& reservation, CUstream stream) noexcept;
   std::optional<transport::BufferDescriptor> descriptor(
       const LeaseManager::Reservation& reservation) const;
+  void commit(const LeaseManager::Reservation& reservation) noexcept;
   void cancel(const LeaseManager::Reservation& reservation) noexcept;
 
   Config config_;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/lease_manager.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/lease_manager.hpp
@@ -3,13 +3,11 @@
 
 #pragma once
 
-#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
-#include <vector>
 
 #include "ros2_cuda_ipc_core/lease/lease_mapping.hpp"
 #include "ros2_cuda_ipc_core/publisher_instance_id.hpp"
@@ -26,31 +24,26 @@ class LeaseManager {
     PublisherInstanceId publisher_instance_id{};
   };
 
-  LeaseManager(std::string shm_name_prefix, std::size_t slot_count,
-               std::chrono::milliseconds pending_ttl);
+  LeaseManager(std::string shm_name_prefix, std::size_t slot_count);
 
   ~LeaseManager();
 
   bool initialise();
   void reset() noexcept;
   bool is_initialised() const noexcept;
-  std::optional<Reservation> reserve_for_publish(uint32_t pending_count);
+  std::optional<Reservation> reserve_for_publish();
+  bool commit(const Reservation& reservation) noexcept;
   bool cancel(const Reservation& reservation) noexcept;
-  void reclaim_stale_pending();
 
   std::string shm_name() const;
   PublisherInstanceId publisher_instance_id() const;
-  std::chrono::steady_clock::time_point pending_deadline(
-      uint32_t slot_id) const noexcept;
 
  private:
   std::string shm_name_prefix_;
   std::string shm_name_;
   PublisherInstanceId publisher_instance_id_{};
   std::size_t slot_count_;
-  std::chrono::milliseconds pending_ttl_;
-  mutable std::mutex deadlines_mutex_;
-  std::vector<std::chrono::steady_clock::time_point> pending_deadlines_;
+  mutable std::mutex mutex_;
   std::shared_ptr<lease::LeaseMapping> mapping_;
   bool initialised_ = false;
 };

--- a/ros2_cuda_ipc_core/src/lease/lease_handle.cpp
+++ b/ros2_cuda_ipc_core/src/lease/lease_handle.cpp
@@ -6,17 +6,56 @@
 #include <rcutils/logging_macros.h>
 
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <optional>
-#include <thread>
 
 namespace ros2_cuda_ipc_core::lease {
 namespace {
 
-constexpr uint32_t kCancelReservationAttempts = 1024;
+constexpr uint64_t kGracePeriodUs = 100000;
 
 inline std::atomic<uint32_t>& as_atomic(uint32_t& value) {
   return reinterpret_cast<std::atomic<uint32_t>&>(value);
+}
+
+inline std::atomic<uint64_t>& as_atomic(uint64_t& value) {
+  return reinterpret_cast<std::atomic<uint64_t>&>(value);
+}
+
+uint64_t now_us() {
+  return static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::microseconds>(
+          std::chrono::steady_clock::now().time_since_epoch())
+          .count());
+}
+
+bool release_publisher_reservation(const std::shared_ptr<LeaseMapping>& mapping,
+                                   uint32_t slot_id, uint32_t generation,
+                                   bool published) noexcept {
+  if (!mapping || slot_id >= mapping->capacity()) return false;
+  SlotMeta& slot = *mapping->slot(slot_id);
+  if (as_atomic(slot.generation).load(std::memory_order_acquire) !=
+      generation) {
+    RCUTILS_LOG_ERROR_NAMED(
+        "ros2_cuda_ipc_core.lease_handle",
+        "lease:publisher_reservation_generation_mismatch slot=%u gen=%u",
+        slot_id, generation);
+    return false;
+  }
+  if (published) {
+    as_atomic(slot.publish_timestamp_us)
+        .store(now_us(), std::memory_order_release);
+  }
+  auto& ref = as_atomic(slot.refcnt);
+  const uint32_t previous = ref.fetch_sub(1, std::memory_order_acq_rel);
+  if (previous == 0) {
+    RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.lease_handle",
+                            "lease:refcnt_underflow slot=%u", slot_id);
+    ref.store(0, std::memory_order_release);
+    return false;
+  }
+  return true;
 }
 
 }  // namespace
@@ -76,16 +115,15 @@ std::optional<uint32_t> LeaseHandle::current_refcount(
       .load(std::memory_order_acquire);
 }
 
-std::optional<uint32_t> LeaseHandle::current_pending(
+std::optional<uint64_t> LeaseHandle::current_publish_timestamp_us(
     const std::shared_ptr<LeaseMapping>& mapping, uint32_t slot_id) {
   if (!mapping || slot_id >= mapping->capacity()) return std::nullopt;
-  return as_atomic(mapping->slot(slot_id)->pending)
+  return as_atomic(mapping->slot(slot_id)->publish_timestamp_us)
       .load(std::memory_order_acquire);
 }
 
 std::optional<LeaseHandle::PublisherReservation>
-LeaseHandle::reserve_for_publish(const std::shared_ptr<LeaseMapping>& mapping,
-                                 uint32_t pending_count) {
+LeaseHandle::reserve_for_publish(const std::shared_ptr<LeaseMapping>& mapping) {
   if (!mapping || mapping->capacity() == 0) return std::nullopt;
   const uint32_t capacity = mapping->capacity();
   const uint32_t start =
@@ -94,25 +132,21 @@ LeaseHandle::reserve_for_publish(const std::shared_ptr<LeaseMapping>& mapping,
     const uint32_t slot_id = (start + offset) % capacity;
     SlotMeta& slot = *mapping->slot(slot_id);
     auto& ref = as_atomic(slot.refcnt);
-    auto& pending = as_atomic(slot.pending);
-    if (ref.load(std::memory_order_acquire) != 0 ||
-        pending.load(std::memory_order_acquire) != 0)
+    if (ref.load(std::memory_order_acquire) != 0) continue;
+    const uint64_t published_at =
+        as_atomic(slot.publish_timestamp_us).load(std::memory_order_acquire);
+    const uint64_t now = now_us();
+    if (published_at != 0 &&
+        (now < published_at || now - published_at < kGracePeriodUs))
       continue;
-    auto& reserved = as_atomic(slot.reserved);
     uint32_t expected = 0;
-    if (!reserved.compare_exchange_strong(
-            expected, 1, std::memory_order_acq_rel, std::memory_order_acquire))
+    if (!ref.compare_exchange_strong(expected, 1, std::memory_order_acq_rel,
+                                     std::memory_order_acquire))
       continue;
-    if (ref.load(std::memory_order_acquire) != 0 ||
-        pending.load(std::memory_order_acquire) != 0) {
-      reserved.store(0, std::memory_order_release);
-      continue;
-    }
     auto& generation = as_atomic(slot.generation);
     const uint32_t next = generation.load(std::memory_order_relaxed) + 1;
     generation.store(next, std::memory_order_release);
-    pending.store(pending_count, std::memory_order_release);
-    reserved.store(0, std::memory_order_release);
+    as_atomic(slot.publish_timestamp_us).store(0, std::memory_order_release);
     mapping->next_slot().store((slot_id + 1) % capacity,
                                std::memory_order_relaxed);
     return PublisherReservation{mapping, slot_id, next};
@@ -120,60 +154,16 @@ LeaseHandle::reserve_for_publish(const std::shared_ptr<LeaseMapping>& mapping,
   return std::nullopt;
 }
 
-bool LeaseHandle::force_clear_pending(
-    const std::shared_ptr<LeaseMapping>& mapping, uint32_t slot_id) {
-  if (!mapping || slot_id >= mapping->capacity()) return false;
-  SlotMeta* slot = mapping->slot(slot_id);
-  auto& reserved = as_atomic(slot->reserved);
-  uint32_t expected = 0;
-  if (!reserved.compare_exchange_strong(expected, 1, std::memory_order_acq_rel,
-                                        std::memory_order_acquire))
-    return false;
-  auto& pending = as_atomic(slot->pending);
-  if (pending.load(std::memory_order_acquire) == 0) {
-    reserved.store(0, std::memory_order_release);
-    return true;
-  }
-  if (as_atomic(slot->refcnt).load(std::memory_order_acquire) != 0) {
-    reserved.store(0, std::memory_order_release);
-    return false;
-  }
-  pending.store(0, std::memory_order_release);
-  reserved.store(0, std::memory_order_release);
-  return true;
+bool LeaseHandle::commit_publish(const std::shared_ptr<LeaseMapping>& mapping,
+                                 uint32_t slot_id,
+                                 uint32_t generation) noexcept {
+  return release_publisher_reservation(mapping, slot_id, generation, true);
 }
 
-bool LeaseHandle::cancel_pending(const std::shared_ptr<LeaseMapping>& mapping,
-                                 uint32_t slot_id, uint32_t generation) {
-  if (!mapping || slot_id >= mapping->capacity()) return false;
-  SlotMeta& slot = *mapping->slot(slot_id);
-  auto& reserved = as_atomic(slot.reserved);
-  bool acquired = false;
-  for (uint32_t attempt = 0; attempt < kCancelReservationAttempts; ++attempt) {
-    uint32_t expected = 0;
-    if (reserved.compare_exchange_strong(expected, 1, std::memory_order_acq_rel,
-                                         std::memory_order_acquire)) {
-      acquired = true;
-      break;
-    }
-    std::this_thread::yield();
-  }
-  if (!acquired) {
-    RCUTILS_LOG_ERROR_NAMED(
-        "ros2_cuda_ipc_core.lease_handle",
-        "lease:cancel_reservation_contention slot=%u gen=%u", slot_id,
-        generation);
-    return false;
-  }
-  if (as_atomic(slot.generation).load(std::memory_order_acquire) !=
-          generation ||
-      as_atomic(slot.refcnt).load(std::memory_order_acquire) != 0) {
-    reserved.store(0, std::memory_order_release);
-    return false;
-  }
-  as_atomic(slot.pending).store(0, std::memory_order_release);
-  reserved.store(0, std::memory_order_release);
-  return true;
+bool LeaseHandle::cancel_publish(const std::shared_ptr<LeaseMapping>& mapping,
+                                 uint32_t slot_id,
+                                 uint32_t generation) noexcept {
+  return release_publisher_reservation(mapping, slot_id, generation, false);
 }
 
 LeaseHandle LeaseHandle::acquire(const std::shared_ptr<LeaseMapping>& mapping,
@@ -182,11 +172,7 @@ LeaseHandle LeaseHandle::acquire(const std::shared_ptr<LeaseMapping>& mapping,
   SlotMeta* slot = mapping->slot(slot_id);
   auto& gen = as_atomic(slot->generation);
   auto& ref = as_atomic(slot->refcnt);
-  auto& pending = as_atomic(slot->pending);
-  auto& reserved = as_atomic(slot->reserved);
-  if (reserved.load(std::memory_order_acquire) != 0 ||
-      gen.load(std::memory_order_acquire) != generation)
-    return LeaseHandle{};
+  if (gen.load(std::memory_order_acquire) != generation) return LeaseHandle{};
 
   uint32_t observed_ref = ref.load(std::memory_order_acquire);
   while (true) {
@@ -201,17 +187,9 @@ LeaseHandle LeaseHandle::acquire(const std::shared_ptr<LeaseMapping>& mapping,
       break;
   }
   const uint32_t recheck_gen = gen.load(std::memory_order_acquire);
-  if (reserved.load(std::memory_order_acquire) != 0 ||
-      recheck_gen != generation) {
+  if (recheck_gen != generation) {
     ref.fetch_sub(1, std::memory_order_acq_rel);
     return LeaseHandle{};
-  }
-  uint32_t observed_pending = pending.load(std::memory_order_acquire);
-  while (observed_pending != 0) {
-    if (pending.compare_exchange_weak(observed_pending, observed_pending - 1,
-                                      std::memory_order_acq_rel,
-                                      std::memory_order_acquire))
-      break;
   }
   return LeaseHandle(mapping, slot, slot_id, generation);
 }

--- a/ros2_cuda_ipc_core/src/lease/lease_handle.cpp
+++ b/ros2_cuda_ipc_core/src/lease/lease_handle.cpp
@@ -15,14 +15,6 @@ namespace {
 
 constexpr uint64_t kGracePeriodUs = 100000;
 
-inline std::atomic<uint32_t>& as_atomic(uint32_t& value) {
-  return reinterpret_cast<std::atomic<uint32_t>&>(value);
-}
-
-inline std::atomic<uint64_t>& as_atomic(uint64_t& value) {
-  return reinterpret_cast<std::atomic<uint64_t>&>(value);
-}
-
 uint64_t now_us() {
   return static_cast<uint64_t>(
       std::chrono::duration_cast<std::chrono::microseconds>(
@@ -35,8 +27,7 @@ bool release_publisher_reservation(const std::shared_ptr<LeaseMapping>& mapping,
                                    bool published) noexcept {
   if (!mapping || slot_id >= mapping->capacity()) return false;
   SlotMeta& slot = *mapping->slot(slot_id);
-  if (as_atomic(slot.generation).load(std::memory_order_acquire) !=
-      generation) {
+  if (slot.generation.load(std::memory_order_acquire) != generation) {
     RCUTILS_LOG_ERROR_NAMED(
         "ros2_cuda_ipc_core.lease_handle",
         "lease:publisher_reservation_generation_mismatch slot=%u gen=%u",
@@ -44,15 +35,13 @@ bool release_publisher_reservation(const std::shared_ptr<LeaseMapping>& mapping,
     return false;
   }
   if (published) {
-    as_atomic(slot.publish_timestamp_us)
-        .store(now_us(), std::memory_order_release);
+    slot.publish_timestamp_us.store(now_us(), std::memory_order_release);
   }
-  auto& ref = as_atomic(slot.refcnt);
-  const uint32_t previous = ref.fetch_sub(1, std::memory_order_acq_rel);
+  const uint32_t previous = slot.refcnt.fetch_sub(1, std::memory_order_acq_rel);
   if (previous == 0) {
     RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.lease_handle",
                             "lease:refcnt_underflow slot=%u", slot_id);
-    ref.store(0, std::memory_order_release);
+    slot.refcnt.store(0, std::memory_order_release);
     return false;
   }
   return true;
@@ -88,12 +77,12 @@ LeaseHandle::~LeaseHandle() { release(); }
 
 void LeaseHandle::release() noexcept {
   if (!slot_meta_) return;
-  auto& ref = as_atomic(slot_meta_->refcnt);
-  const uint32_t previous = ref.fetch_sub(1, std::memory_order_acq_rel);
+  const uint32_t previous =
+      slot_meta_->refcnt.fetch_sub(1, std::memory_order_acq_rel);
   if (previous == 0) {
     RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.lease_handle",
                             "lease:refcnt_underflow slot=%u", slot_id_);
-    ref.store(0, std::memory_order_release);
+    slot_meta_->refcnt.store(0, std::memory_order_release);
   }
   slot_meta_ = nullptr;
   slot_id_ = 0;
@@ -104,22 +93,20 @@ void LeaseHandle::release() noexcept {
 std::optional<uint32_t> LeaseHandle::current_generation(
     const std::shared_ptr<LeaseMapping>& mapping, uint32_t slot_id) {
   if (!mapping || slot_id >= mapping->capacity()) return std::nullopt;
-  return as_atomic(mapping->slot(slot_id)->generation)
-      .load(std::memory_order_acquire);
+  return mapping->slot(slot_id)->generation.load(std::memory_order_acquire);
 }
 
 std::optional<uint32_t> LeaseHandle::current_refcount(
     const std::shared_ptr<LeaseMapping>& mapping, uint32_t slot_id) {
   if (!mapping || slot_id >= mapping->capacity()) return std::nullopt;
-  return as_atomic(mapping->slot(slot_id)->refcnt)
-      .load(std::memory_order_acquire);
+  return mapping->slot(slot_id)->refcnt.load(std::memory_order_acquire);
 }
 
 std::optional<uint64_t> LeaseHandle::current_publish_timestamp_us(
     const std::shared_ptr<LeaseMapping>& mapping, uint32_t slot_id) {
   if (!mapping || slot_id >= mapping->capacity()) return std::nullopt;
-  return as_atomic(mapping->slot(slot_id)->publish_timestamp_us)
-      .load(std::memory_order_acquire);
+  return mapping->slot(slot_id)->publish_timestamp_us.load(
+      std::memory_order_acquire);
 }
 
 std::optional<LeaseHandle::PublisherReservation>
@@ -131,22 +118,20 @@ LeaseHandle::reserve_for_publish(const std::shared_ptr<LeaseMapping>& mapping) {
   for (uint32_t offset = 0; offset < capacity; ++offset) {
     const uint32_t slot_id = (start + offset) % capacity;
     SlotMeta& slot = *mapping->slot(slot_id);
-    auto& ref = as_atomic(slot.refcnt);
-    if (ref.load(std::memory_order_acquire) != 0) continue;
+    if (slot.refcnt.load(std::memory_order_acquire) != 0) continue;
     const uint64_t published_at =
-        as_atomic(slot.publish_timestamp_us).load(std::memory_order_acquire);
+        slot.publish_timestamp_us.load(std::memory_order_acquire);
     const uint64_t now = now_us();
     if (published_at != 0 &&
         (now < published_at || now - published_at < kGracePeriodUs))
       continue;
     uint32_t expected = 0;
-    if (!ref.compare_exchange_strong(expected, 1, std::memory_order_acq_rel,
-                                     std::memory_order_acquire))
+    if (!slot.refcnt.compare_exchange_strong(
+            expected, 1, std::memory_order_acq_rel, std::memory_order_acquire))
       continue;
-    auto& generation = as_atomic(slot.generation);
-    const uint32_t next = generation.load(std::memory_order_relaxed) + 1;
-    generation.store(next, std::memory_order_release);
-    as_atomic(slot.publish_timestamp_us).store(0, std::memory_order_release);
+    const uint32_t next = slot.generation.load(std::memory_order_relaxed) + 1;
+    slot.generation.store(next, std::memory_order_release);
+    slot.publish_timestamp_us.store(0, std::memory_order_release);
     mapping->next_slot().store((slot_id + 1) % capacity,
                                std::memory_order_relaxed);
     return PublisherReservation{mapping, slot_id, next};
@@ -170,25 +155,24 @@ LeaseHandle LeaseHandle::acquire(const std::shared_ptr<LeaseMapping>& mapping,
                                  uint32_t slot_id, uint32_t generation) {
   if (!mapping || slot_id >= mapping->capacity()) return LeaseHandle{};
   SlotMeta* slot = mapping->slot(slot_id);
-  auto& gen = as_atomic(slot->generation);
-  auto& ref = as_atomic(slot->refcnt);
-  if (gen.load(std::memory_order_acquire) != generation) return LeaseHandle{};
+  if (slot->generation.load(std::memory_order_acquire) != generation)
+    return LeaseHandle{};
 
-  uint32_t observed_ref = ref.load(std::memory_order_acquire);
+  uint32_t observed_ref = slot->refcnt.load(std::memory_order_acquire);
   while (true) {
     if (observed_ref == UINT32_MAX) {
       RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.lease_handle",
                               "lease:ref_overflow slot=%u", slot_id);
       return LeaseHandle{};
     }
-    if (ref.compare_exchange_weak(observed_ref, observed_ref + 1,
-                                  std::memory_order_acq_rel,
-                                  std::memory_order_acquire))
+    if (slot->refcnt.compare_exchange_weak(observed_ref, observed_ref + 1,
+                                           std::memory_order_acq_rel,
+                                           std::memory_order_acquire))
       break;
   }
-  const uint32_t recheck_gen = gen.load(std::memory_order_acquire);
+  const uint32_t recheck_gen = slot->generation.load(std::memory_order_acquire);
   if (recheck_gen != generation) {
-    ref.fetch_sub(1, std::memory_order_acq_rel);
+    slot->refcnt.fetch_sub(1, std::memory_order_acq_rel);
     return LeaseHandle{};
   }
   return LeaseHandle(mapping, slot, slot_id, generation);

--- a/ros2_cuda_ipc_core/src/lease/lease_handle.cpp
+++ b/ros2_cuda_ipc_core/src/lease/lease_handle.cpp
@@ -115,13 +115,13 @@ LeaseHandle::reserve_for_publish(const std::shared_ptr<LeaseMapping>& mapping) {
   const uint32_t capacity = mapping->capacity();
   const uint32_t start =
       mapping->next_slot().fetch_add(1, std::memory_order_relaxed) % capacity;
+  const uint64_t now = now_us();
   for (uint32_t offset = 0; offset < capacity; ++offset) {
     const uint32_t slot_id = (start + offset) % capacity;
     SlotMeta& slot = *mapping->slot(slot_id);
     if (slot.refcnt.load(std::memory_order_acquire) != 0) continue;
     const uint64_t published_at =
         slot.publish_timestamp_us.load(std::memory_order_acquire);
-    const uint64_t now = now_us();
     if (published_at != 0 &&
         (now < published_at || now - published_at < kGracePeriodUs))
       continue;

--- a/ros2_cuda_ipc_core/src/lease/lease_mapping.cpp
+++ b/ros2_cuda_ipc_core/src/lease/lease_mapping.cpp
@@ -18,7 +18,7 @@ namespace ros2_cuda_ipc_core::lease {
 namespace {
 
 constexpr uint32_t kShmMagic = 0x4C534531;  // 'LSE1'
-constexpr uint32_t kLayoutVersion = 3;
+constexpr uint32_t kLayoutVersion = 4;
 
 struct ShmHeader {
   uint32_t magic;
@@ -30,6 +30,10 @@ struct ShmHeader {
 
 inline std::atomic<uint32_t>& as_atomic(uint32_t& value) {
   return reinterpret_cast<std::atomic<uint32_t>&>(value);
+}
+
+inline std::atomic<uint64_t>& as_atomic(uint64_t& value) {
+  return reinterpret_cast<std::atomic<uint64_t>&>(value);
 }
 
 bool valid_layout(const struct stat& st, const ShmHeader& header,
@@ -102,8 +106,8 @@ std::shared_ptr<LeaseMapping> LeaseMapping::create(
   for (uint32_t i = 0; i < capacity; ++i) {
     as_atomic(slots[i].generation).store(0u, std::memory_order_relaxed);
     as_atomic(slots[i].refcnt).store(0u, std::memory_order_relaxed);
-    as_atomic(slots[i].pending).store(0u, std::memory_order_relaxed);
-    as_atomic(slots[i].reserved).store(0u, std::memory_order_relaxed);
+    as_atomic(slots[i].publish_timestamp_us)
+        .store(0u, std::memory_order_relaxed);
   }
 
   auto mapping = std::shared_ptr<LeaseMapping>(new LeaseMapping);

--- a/ros2_cuda_ipc_core/src/lease/lease_mapping.cpp
+++ b/ros2_cuda_ipc_core/src/lease/lease_mapping.cpp
@@ -13,12 +13,13 @@
 #include <cerrno>
 #include <cstdint>
 #include <limits>
+#include <new>
 
 namespace ros2_cuda_ipc_core::lease {
 namespace {
 
 constexpr uint32_t kShmMagic = 0x4C534531;  // 'LSE1'
-constexpr uint32_t kLayoutVersion = 4;
+constexpr uint32_t kLayoutVersion = 5;
 
 struct ShmHeader {
   uint32_t magic;
@@ -27,14 +28,6 @@ struct ShmHeader {
   uint32_t consumer_count;
   PublisherInstanceId publisher_instance_id;
 };
-
-inline std::atomic<uint32_t>& as_atomic(uint32_t& value) {
-  return reinterpret_cast<std::atomic<uint32_t>&>(value);
-}
-
-inline std::atomic<uint64_t>& as_atomic(uint64_t& value) {
-  return reinterpret_cast<std::atomic<uint64_t>&>(value);
-}
 
 bool valid_layout(const struct stat& st, const ShmHeader& header,
                   std::size_t* expected_size) {
@@ -102,13 +95,11 @@ std::shared_ptr<LeaseMapping> LeaseMapping::create(
   header->capacity = capacity;
   header->consumer_count = 0;
   header->publisher_instance_id = instance_id;
-  auto* slots = reinterpret_cast<SlotMeta*>(header + 1);
+  auto* slot_storage = static_cast<std::byte*>(addr) + sizeof(ShmHeader);
   for (uint32_t i = 0; i < capacity; ++i) {
-    as_atomic(slots[i].generation).store(0u, std::memory_order_relaxed);
-    as_atomic(slots[i].refcnt).store(0u, std::memory_order_relaxed);
-    as_atomic(slots[i].publish_timestamp_us)
-        .store(0u, std::memory_order_relaxed);
+    ::new (static_cast<void*>(slot_storage + i * sizeof(SlotMeta))) SlotMeta{};
   }
+  auto* slots = reinterpret_cast<SlotMeta*>(slot_storage);
 
   auto mapping = std::shared_ptr<LeaseMapping>(new LeaseMapping);
   mapping->shm_name_ = shm_name;

--- a/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
@@ -66,6 +66,7 @@ void PublishSlot::commit_publish() noexcept {
   assert(owner_ != nullptr);
   assert(state_ == State::ready_recorded || state_ == State::committed);
   if (owner_ != nullptr && state_ == State::ready_recorded) {
+    owner_->commit(reservation_);
     state_ = State::committed;
   }
 }
@@ -81,8 +82,7 @@ void PublishSlot::cancel() noexcept {
 GpuBufferManager::GpuBufferManager(Config config)
     : config_(std::move(config)),
       buffer_pool_(config_.slot_count, config_.backend),
-      lease_manager_(config_.shm_name_prefix, config_.slot_count,
-                     config_.pending_ttl) {}
+      lease_manager_(config_.shm_name_prefix, config_.slot_count) {}
 
 GpuBufferManager::~GpuBufferManager() { reset(); }
 
@@ -115,21 +115,15 @@ PublisherInstanceId GpuBufferManager::publisher_instance_id() const {
   return lease_manager_.publisher_instance_id();
 }
 
-std::optional<PublishSlot> GpuBufferManager::acquire_for_publish(
-    uint32_t pending_count) {
+std::optional<PublishSlot> GpuBufferManager::acquire_for_publish() {
   if (!is_initialised()) {
     return std::nullopt;
   }
-  lease_manager_.reclaim_stale_pending();
-  auto reservation = lease_manager_.reserve_for_publish(pending_count);
+  auto reservation = lease_manager_.reserve_for_publish();
   if (!reservation) {
     return std::nullopt;
   }
   return PublishSlot(this, *reservation);
-}
-
-void GpuBufferManager::reclaim_stale_pending() {
-  lease_manager_.reclaim_stale_pending();
 }
 
 void* GpuBufferManager::device_ptr(
@@ -175,6 +169,11 @@ std::optional<transport::BufferDescriptor> GpuBufferManager::descriptor(
   result.memory_handle = resources->mem_handle;
   result.ready_event_handle = resources->ready_event->ipc_handle();
   return result;
+}
+
+void GpuBufferManager::commit(
+    const LeaseManager::Reservation& reservation) noexcept {
+  lease_manager_.commit(reservation);
 }
 
 void GpuBufferManager::cancel(

--- a/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
@@ -62,20 +62,34 @@ std::optional<transport::BufferDescriptor> PublishSlot::descriptor() const {
   return owner_->descriptor(reservation_);
 }
 
-void PublishSlot::commit_publish() noexcept {
+bool PublishSlot::commit_publish() noexcept {
   assert(owner_ != nullptr);
   assert(state_ == State::ready_recorded || state_ == State::committed);
-  if (owner_ != nullptr && state_ == State::ready_recorded) {
-    owner_->commit(reservation_);
-    state_ = State::committed;
+  if (owner_ == nullptr) {
+    return false;
   }
+  if (state_ == State::committed) {
+    return true;
+  }
+  if (state_ == State::ready_recorded && owner_->commit(reservation_)) {
+    state_ = State::committed;
+    return true;
+  }
+  // A failed commit must not make the slot inert while its reservation is
+  // still active. The cancel path is generation-checked as well, so it is
+  // safe to attempt even when the commit failed due to a stale reservation.
+  if (owner_->cancel(reservation_)) {
+    state_ = State::cancelled;
+  }
+  return false;
 }
 
 void PublishSlot::cancel() noexcept {
   if (owner_ != nullptr &&
       (state_ == State::reserved || state_ == State::ready_recorded)) {
-    owner_->cancel(reservation_);
-    state_ = State::cancelled;
+    if (owner_->cancel(reservation_)) {
+      state_ = State::cancelled;
+    }
   }
 }
 
@@ -171,14 +185,14 @@ std::optional<transport::BufferDescriptor> GpuBufferManager::descriptor(
   return result;
 }
 
-void GpuBufferManager::commit(
+bool GpuBufferManager::commit(
     const LeaseManager::Reservation& reservation) noexcept {
-  lease_manager_.commit(reservation);
+  return lease_manager_.commit(reservation);
 }
 
-void GpuBufferManager::cancel(
+bool GpuBufferManager::cancel(
     const LeaseManager::Reservation& reservation) noexcept {
-  lease_manager_.cancel(reservation);
+  return lease_manager_.cancel(reservation);
 }
 
 }  // namespace ros2_cuda_ipc_core::publisher

--- a/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
@@ -3,7 +3,6 @@
 
 #include "ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp"
 
-#include <cassert>
 #include <utility>
 
 namespace ros2_cuda_ipc_core::publisher {
@@ -63,15 +62,16 @@ std::optional<transport::BufferDescriptor> PublishSlot::descriptor() const {
 }
 
 bool PublishSlot::commit_publish() noexcept {
-  assert(owner_ != nullptr);
-  assert(state_ == State::ready_recorded || state_ == State::committed);
   if (owner_ == nullptr) {
     return false;
   }
   if (state_ == State::committed) {
     return true;
   }
-  if (state_ == State::ready_recorded && owner_->commit(reservation_)) {
+  if (state_ != State::ready_recorded) {
+    return false;
+  }
+  if (owner_->commit(reservation_)) {
     state_ = State::committed;
     return true;
   }

--- a/ros2_cuda_ipc_core/src/publisher/lease_manager.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/lease_manager.cpp
@@ -17,13 +17,6 @@
 
 namespace ros2_cuda_ipc_core::publisher {
 namespace {
-using Clock = std::chrono::steady_clock;
-
-bool deadline_reached(const Clock::time_point& deadline,
-                      const Clock::time_point& now) {
-  return deadline.time_since_epoch().count() != 0 && now >= deadline;
-}
-
 bool valid_prefix(const std::string& prefix) {
   return prefix.size() > 1 && prefix.front() == '/' &&
          prefix.find('/', 1) == std::string::npos;
@@ -41,11 +34,8 @@ std::pair<PublisherInstanceId, std::string> make_instance_identity(
 }
 }  // namespace
 
-LeaseManager::LeaseManager(std::string shm_name_prefix, std::size_t slot_count,
-                           std::chrono::milliseconds pending_ttl)
-    : shm_name_prefix_(std::move(shm_name_prefix)),
-      slot_count_(slot_count),
-      pending_ttl_(pending_ttl) {}
+LeaseManager::LeaseManager(std::string shm_name_prefix, std::size_t slot_count)
+    : shm_name_prefix_(std::move(shm_name_prefix)), slot_count_(slot_count) {}
 
 LeaseManager::~LeaseManager() { reset(); }
 
@@ -68,17 +58,15 @@ bool LeaseManager::initialise() {
                             "Generated shared-memory name is too long");
     return false;
   }
-  std::vector<Clock::time_point> pending_deadlines(slot_count_);
   auto mapping = lease::LeaseMapping::create(
       instance_name, instance_id, static_cast<uint32_t>(slot_count_));
   if (!mapping) {
     return false;
   }
   {
-    std::lock_guard<std::mutex> lock(deadlines_mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     shm_name_ = std::move(instance_name);
     publisher_instance_id_ = instance_id;
-    pending_deadlines_ = std::move(pending_deadlines);
     mapping_ = std::move(mapping);
     initialised_ = true;
   }
@@ -89,7 +77,7 @@ void LeaseManager::reset() noexcept {
   std::string owned_name;
   std::shared_ptr<lease::LeaseMapping> owned_mapping;
   {
-    std::lock_guard<std::mutex> lock(deadlines_mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     if (initialised_) {
       owned_name = std::move(shm_name_);
       owned_mapping = std::move(mapping_);
@@ -97,7 +85,6 @@ void LeaseManager::reset() noexcept {
     shm_name_.clear();
     publisher_instance_id_ = {};
     mapping_.reset();
-    pending_deadlines_.clear();
     initialised_ = false;
   }
   if (!owned_name.empty() && ::shm_unlink(owned_name.c_str()) != 0) {
@@ -110,17 +97,16 @@ void LeaseManager::reset() noexcept {
 }
 
 bool LeaseManager::is_initialised() const noexcept {
-  std::lock_guard<std::mutex> lock(deadlines_mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
   return initialised_;
 }
 
-std::optional<LeaseManager::Reservation> LeaseManager::reserve_for_publish(
-    uint32_t pending_count) {
+std::optional<LeaseManager::Reservation> LeaseManager::reserve_for_publish() {
   std::string shm_name;
   PublisherInstanceId instance_id{};
   std::shared_ptr<lease::LeaseMapping> mapping;
   {
-    std::lock_guard<std::mutex> lock(deadlines_mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     if (!initialised_) {
       return std::nullopt;
     }
@@ -128,8 +114,7 @@ std::optional<LeaseManager::Reservation> LeaseManager::reserve_for_publish(
     instance_id = publisher_instance_id_;
     mapping = mapping_;
   }
-  const auto reservation =
-      lease::LeaseHandle::reserve_for_publish(mapping, pending_count);
+  const auto reservation = lease::LeaseHandle::reserve_for_publish(mapping);
   if (!reservation) {
     return std::nullopt;
   }
@@ -139,7 +124,7 @@ std::optional<LeaseManager::Reservation> LeaseManager::reserve_for_publish(
         "Lease shared-memory capacity changed unexpectedly: "
         "slot=%u configured_count=%zu",
         reservation->slot_id, slot_count_);
-    const bool rolled_back = lease::LeaseHandle::cancel_pending(
+    const bool rolled_back = lease::LeaseHandle::cancel_publish(
         reservation->mapping, reservation->slot_id, reservation->generation);
     if (!rolled_back) {
       RCUTILS_LOG_ERROR_NAMED(
@@ -150,21 +135,15 @@ std::optional<LeaseManager::Reservation> LeaseManager::reserve_for_publish(
     return std::nullopt;
   }
   {
-    std::lock_guard<std::mutex> lock(deadlines_mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     if (initialised_ && shm_name_ == shm_name &&
-        publisher_instance_id_ == instance_id &&
-        reservation->slot_id < pending_deadlines_.size()) {
-      if (pending_count > 0 && pending_ttl_.count() > 0) {
-        pending_deadlines_[reservation->slot_id] = Clock::now() + pending_ttl_;
-      } else {
-        pending_deadlines_[reservation->slot_id] = {};
-      }
+        publisher_instance_id_ == instance_id) {
       return Reservation{reservation->mapping, reservation->slot_id,
                          reservation->generation, shm_name, instance_id};
     }
   }
 
-  const bool rolled_back = lease::LeaseHandle::cancel_pending(
+  const bool rolled_back = lease::LeaseHandle::cancel_publish(
       reservation->mapping, reservation->slot_id, reservation->generation);
   if (!rolled_back) {
     RCUTILS_LOG_ERROR_NAMED(
@@ -175,11 +154,23 @@ std::optional<LeaseManager::Reservation> LeaseManager::reserve_for_publish(
   return std::nullopt;
 }
 
+bool LeaseManager::commit(const Reservation& reservation) noexcept {
+  const bool committed = lease::LeaseHandle::commit_publish(
+      reservation.mapping, reservation.slot_id, reservation.generation);
+  if (!committed) {
+    RCUTILS_LOG_ERROR_NAMED(
+        "ros2_cuda_ipc_core.publisher.lease_manager",
+        "Failed to commit reservation slot=%u generation=%u",
+        reservation.slot_id, reservation.generation);
+  }
+  return committed;
+}
+
 bool LeaseManager::cancel(const Reservation& reservation) noexcept {
   if (reservation.slot_id >= slot_count_) {
     return false;
   }
-  const bool cancelled = lease::LeaseHandle::cancel_pending(
+  const bool cancelled = lease::LeaseHandle::cancel_publish(
       reservation.mapping, reservation.slot_id, reservation.generation);
   if (!cancelled) {
     RCUTILS_LOG_ERROR_NAMED(
@@ -187,62 +178,16 @@ bool LeaseManager::cancel(const Reservation& reservation) noexcept {
         "Failed to cancel reservation slot=%u generation=%u",
         reservation.slot_id, reservation.generation);
   }
-  if (cancelled) {
-    std::lock_guard<std::mutex> lock(deadlines_mutex_);
-    if (reservation.shm_name == shm_name_ &&
-        reservation.publisher_instance_id == publisher_instance_id_ &&
-        reservation.slot_id < pending_deadlines_.size()) {
-      pending_deadlines_[reservation.slot_id] = {};
-    }
-  }
   return cancelled;
 }
 
-void LeaseManager::reclaim_stale_pending() {
-  std::lock_guard<std::mutex> lock(deadlines_mutex_);
-  if (!initialised_ || pending_ttl_.count() <= 0) {
-    return;
-  }
-  const auto now = Clock::now();
-  for (uint32_t slot_id = 0; slot_id < pending_deadlines_.size(); ++slot_id) {
-    auto& deadline = pending_deadlines_[slot_id];
-    if (!deadline_reached(deadline, now)) {
-      continue;
-    }
-    const auto pending = lease::LeaseHandle::current_pending(mapping_, slot_id);
-    if (!pending) {
-      continue;
-    }
-    if (*pending == 0) {
-      deadline = {};
-      continue;
-    }
-    if (lease::LeaseHandle::force_clear_pending(mapping_, slot_id)) {
-      RCUTILS_LOG_WARN_NAMED(
-          "ros2_cuda_ipc_core.publisher.lease_manager",
-          "Force-cleared pending lease slot=%u after %lld ms timeout", slot_id,
-          static_cast<long long>(pending_ttl_.count()));
-      deadline = {};
-    }
-  }
-}
-
-Clock::time_point LeaseManager::pending_deadline(
-    uint32_t slot_id) const noexcept {
-  std::lock_guard<std::mutex> lock(deadlines_mutex_);
-  if (slot_id >= pending_deadlines_.size()) {
-    return {};
-  }
-  return pending_deadlines_[slot_id];
-}
-
 std::string LeaseManager::shm_name() const {
-  std::lock_guard<std::mutex> lock(deadlines_mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
   return shm_name_;
 }
 
 PublisherInstanceId LeaseManager::publisher_instance_id() const {
-  std::lock_guard<std::mutex> lock(deadlines_mutex_);
+  std::lock_guard<std::mutex> lock(mutex_);
   return publisher_instance_id_;
 }
 

--- a/ros2_cuda_ipc_core/test/mapper/test_buffer_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/test/mapper/test_buffer_view_mapper.cpp
@@ -51,7 +51,7 @@ TEST_F(BufferViewMapperTest, PublisherInstanceMismatchRejectsMessage) {
   const auto owner_id = test::publisher_instance_id(shm_name);
   auto mapping = lease::LeaseMapping::create(shm_name, owner_id, 1);
   ASSERT_TRUE(mapping);
-  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping, 1);
+  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping);
   ASSERT_TRUE(reservation.has_value());
 
   auto msg = test::make_cached_buffer_core_message(
@@ -62,7 +62,9 @@ TEST_F(BufferViewMapperTest, PublisherInstanceMismatchRejectsMessage) {
   EXPECT_FALSE(mapper.map(msg).valid());
   auto refcnt = lease::LeaseHandle::current_refcount(mapping, 0);
   ASSERT_TRUE(refcnt.has_value());
-  EXPECT_EQ(*refcnt, 0u);
+  EXPECT_EQ(*refcnt, 1u);
+  ASSERT_TRUE(lease::LeaseHandle::cancel_publish(mapping, reservation->slot_id,
+                                                 reservation->generation));
   ::shm_unlink(shm_name.c_str());
 }
 
@@ -72,7 +74,7 @@ TEST_F(BufferViewMapperTest, UnsupportedBackendReturnsInvalid) {
   auto mapping = lease::LeaseMapping::create(
       shm_name, test::publisher_instance_id(shm_name), 1);
   ASSERT_TRUE(mapping);
-  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping, 0);
+  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping);
   ASSERT_TRUE(reservation.has_value());
 
   ros2_cuda_ipc_msgs::msg::BufferCore msg;
@@ -90,7 +92,9 @@ TEST_F(BufferViewMapperTest, UnsupportedBackendReturnsInvalid) {
 
   auto refcnt = lease::LeaseHandle::current_refcount(mapping, 0);
   ASSERT_TRUE(refcnt.has_value());
-  EXPECT_EQ(refcnt.value(), 0u);
+  EXPECT_EQ(refcnt.value(), 1u);
+  ASSERT_TRUE(lease::LeaseHandle::cancel_publish(mapping, reservation->slot_id,
+                                                 reservation->generation));
 
   ::shm_unlink(shm_name.c_str());
 }
@@ -101,7 +105,7 @@ TEST_F(BufferViewMapperTest, InvalidVmmPayloadReturnsInvalid) {
   auto mapping = lease::LeaseMapping::create(
       shm_name, test::publisher_instance_id(shm_name), 1);
   ASSERT_TRUE(mapping);
-  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping, 1);
+  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping);
   ASSERT_TRUE(reservation.has_value());
 
   ros2_cuda_ipc_msgs::msg::BufferCore msg;
@@ -121,7 +125,9 @@ TEST_F(BufferViewMapperTest, InvalidVmmPayloadReturnsInvalid) {
 
   auto refcnt = lease::LeaseHandle::current_refcount(mapping, 0);
   ASSERT_TRUE(refcnt.has_value());
-  EXPECT_EQ(refcnt.value(), 0u);
+  EXPECT_EQ(refcnt.value(), 1u);
+  ASSERT_TRUE(lease::LeaseHandle::cancel_publish(mapping, reservation->slot_id,
+                                                 reservation->generation));
 
   ::shm_unlink(shm_name.c_str());
 }
@@ -132,7 +138,7 @@ TEST_F(BufferViewMapperTest, MissingVmmSocketReturnsInvalidAndReleasesLease) {
   auto mapping = lease::LeaseMapping::create(
       shm_name, test::publisher_instance_id(shm_name), 1);
   ASSERT_TRUE(mapping);
-  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping, 1);
+  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping);
   ASSERT_TRUE(reservation.has_value());
 
   ros2_cuda_ipc_msgs::msg::BufferCore msg;
@@ -153,7 +159,9 @@ TEST_F(BufferViewMapperTest, MissingVmmSocketReturnsInvalidAndReleasesLease) {
 
   auto refcnt = lease::LeaseHandle::current_refcount(mapping, 0);
   ASSERT_TRUE(refcnt.has_value());
-  EXPECT_EQ(refcnt.value(), 0u);
+  EXPECT_EQ(refcnt.value(), 1u);
+  ASSERT_TRUE(lease::LeaseHandle::cancel_publish(mapping, reservation->slot_id,
+                                                 reservation->generation));
 
   ::shm_unlink(shm_name.c_str());
 }

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
@@ -127,6 +127,33 @@ TEST_F(GpuBufferManagerTest, CommittedDestructionKeepsGracePeriod) {
   EXPECT_TRUE(manager.acquire_for_publish().has_value());
 }
 
+TEST_F(GpuBufferManagerTest, FailedCommitDoesNotMarkSlotCommitted) {
+  auto manager = make_manager();
+  ASSERT_TRUE(manager.initialise());
+  auto slot = manager.acquire_for_publish();
+  ASSERT_TRUE(slot.has_value());
+  ASSERT_TRUE(slot->record_ready(nullptr));
+
+  auto mapping = ros2_cuda_ipc_core::lease::LeaseMapping::attach(
+      manager.shm_name(), manager.publisher_instance_id());
+  ASSERT_TRUE(mapping);
+  const auto generation =
+      ros2_cuda_ipc_core::lease::LeaseHandle::current_generation(mapping, 0);
+  ASSERT_TRUE(generation.has_value());
+
+  mapping->slot(0)->generation.store(*generation + 1,
+                                     std::memory_order_release);
+  EXPECT_FALSE(slot->commit_publish());
+  EXPECT_TRUE(slot->valid());
+
+  // Restore the reservation generation so its cancellation can release the
+  // temporary Publisher reference after the failed-commit check.
+  mapping->slot(0)->generation.store(*generation, std::memory_order_release);
+  slot->cancel();
+  EXPECT_FALSE(slot->valid());
+  EXPECT_TRUE(manager.acquire_for_publish().has_value());
+}
+
 TEST_F(GpuBufferManagerTest, MovedFromSlotIsInert) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
@@ -46,10 +46,9 @@ class GpuBufferManagerTest : public ::testing::Test {
     }
     shm_name_ = unique_name();
   }
-  GpuBufferManager make_manager(
-      std::chrono::milliseconds pending_ttl = std::chrono::milliseconds(100)) {
+  GpuBufferManager make_manager() {
     return GpuBufferManager(
-        {shm_name_, 1, 1024, 0, pending_ttl,
+        {shm_name_, 1, 1024, 0,
          ros2_cuda_ipc_core::transport::MemoryBackendKind::CUDA_IPC});
   }
   std::string shm_name_;
@@ -59,7 +58,7 @@ TEST_F(GpuBufferManagerTest, DescriptorIsGatedByReadyRecording) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
   const auto instance_id = manager.publisher_instance_id();
-  auto slot = manager.acquire_for_publish(1);
+  auto slot = manager.acquire_for_publish();
   ASSERT_TRUE(slot.has_value());
   EXPECT_EQ(slot->descriptor(), std::nullopt);
   ASSERT_TRUE(slot->record_ready(nullptr));
@@ -79,7 +78,7 @@ TEST_F(GpuBufferManagerTest, DescriptorIsGatedByReadyRecording) {
 TEST_F(GpuBufferManagerTest, RuntimeCreatedStreamCanRecordReady) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
-  auto slot = manager.acquire_for_publish(1);
+  auto slot = manager.acquire_for_publish();
   ASSERT_TRUE(slot.has_value());
 
   cudaStream_t stream = nullptr;
@@ -93,7 +92,7 @@ TEST_F(GpuBufferManagerTest, RuntimeCreatedStreamCanRecordReady) {
 TEST_F(GpuBufferManagerTest, DriverCreatedStreamCanRecordReady) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
-  auto slot = manager.acquire_for_publish(1);
+  auto slot = manager.acquire_for_publish();
   ASSERT_TRUE(slot.has_value());
 
   CUstream stream = nullptr;
@@ -108,28 +107,30 @@ TEST_F(GpuBufferManagerTest, UncommittedDestructionCancelsReservation) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
   {
-    auto slot = manager.acquire_for_publish(1);
+    auto slot = manager.acquire_for_publish();
     ASSERT_TRUE(slot.has_value());
   }
-  EXPECT_TRUE(manager.acquire_for_publish(1).has_value());
+  EXPECT_TRUE(manager.acquire_for_publish().has_value());
 }
 
-TEST_F(GpuBufferManagerTest, CommittedDestructionKeepsPending) {
+TEST_F(GpuBufferManagerTest, CommittedDestructionKeepsGracePeriod) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
   {
-    auto slot = manager.acquire_for_publish(1);
+    auto slot = manager.acquire_for_publish();
     ASSERT_TRUE(slot.has_value());
     ASSERT_TRUE(slot->record_ready(nullptr));
     slot->commit_publish();
   }
-  EXPECT_FALSE(manager.acquire_for_publish(1).has_value());
+  EXPECT_FALSE(manager.acquire_for_publish().has_value());
+  std::this_thread::sleep_for(std::chrono::milliseconds(105));
+  EXPECT_TRUE(manager.acquire_for_publish().has_value());
 }
 
 TEST_F(GpuBufferManagerTest, MovedFromSlotIsInert) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
-  auto source = manager.acquire_for_publish(1);
+  auto source = manager.acquire_for_publish();
   ASSERT_TRUE(source.has_value());
   PublishSlot destination(std::move(*source));
   EXPECT_FALSE(source->valid());
@@ -138,7 +139,7 @@ TEST_F(GpuBufferManagerTest, MovedFromSlotIsInert) {
   destination.cancel();
   destination.cancel();
   EXPECT_FALSE(destination.valid());
-  EXPECT_TRUE(manager.acquire_for_publish(1).has_value());
+  EXPECT_TRUE(manager.acquire_for_publish().has_value());
 }
 
 TEST_F(GpuBufferManagerTest, ResetDoesNotPreventReservationCancellation) {
@@ -146,23 +147,23 @@ TEST_F(GpuBufferManagerTest, ResetDoesNotPreventReservationCancellation) {
   ASSERT_TRUE(manager.initialise());
   const std::string actual_name = manager.shm_name();
   const auto instance_id = manager.publisher_instance_id();
-  auto slot = manager.acquire_for_publish(1);
+  auto slot = manager.acquire_for_publish();
   ASSERT_TRUE(slot.has_value());
   auto mapping =
       ros2_cuda_ipc_core::lease::LeaseMapping::attach(actual_name, instance_id);
   ASSERT_TRUE(mapping);
-  const auto pending_before =
-      ros2_cuda_ipc_core::lease::LeaseHandle::current_pending(mapping, 0);
-  ASSERT_TRUE(pending_before.has_value());
-  ASSERT_EQ(*pending_before, 1u);
+  const auto ref_before =
+      ros2_cuda_ipc_core::lease::LeaseHandle::current_refcount(mapping, 0);
+  ASSERT_TRUE(ref_before.has_value());
+  ASSERT_EQ(*ref_before, 1u);
 
   manager.reset();
   slot.reset();
 
-  const auto pending_after =
-      ros2_cuda_ipc_core::lease::LeaseHandle::current_pending(mapping, 0);
-  ASSERT_TRUE(pending_after.has_value());
-  EXPECT_EQ(*pending_after, 0u);
+  const auto ref_after =
+      ros2_cuda_ipc_core::lease::LeaseHandle::current_refcount(mapping, 0);
+  ASSERT_TRUE(ref_after.has_value());
+  EXPECT_EQ(*ref_after, 0u);
 
   // The name itself is nevertheless gone immediately after manager reset.
   const int fd = ::shm_open(actual_name.c_str(), O_RDWR, 0660);
@@ -172,16 +173,16 @@ TEST_F(GpuBufferManagerTest, ResetDoesNotPreventReservationCancellation) {
   }
 }
 
-TEST_F(GpuBufferManagerTest, AcquireAutomaticallyReclaimsExpiredPending) {
-  auto manager = make_manager(std::chrono::milliseconds(1));
+TEST_F(GpuBufferManagerTest, AcquireAfterGracePeriod) {
+  auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
   {
-    auto slot = manager.acquire_for_publish(1);
+    auto slot = manager.acquire_for_publish();
     ASSERT_TRUE(slot.has_value());
     ASSERT_TRUE(slot->record_ready(nullptr));
     slot->commit_publish();
   }
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(5));
-  EXPECT_TRUE(manager.acquire_for_publish(1).has_value());
+  std::this_thread::sleep_for(std::chrono::milliseconds(105));
+  EXPECT_TRUE(manager.acquire_for_publish().has_value());
 }

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
@@ -70,9 +70,25 @@ TEST_F(GpuBufferManagerTest, DescriptorIsGatedByReadyRecording) {
   EXPECT_EQ(descriptor->publisher_instance_id, instance_id);
   EXPECT_EQ(descriptor->byte_size, 1024u);
   EXPECT_FALSE(slot->record_ready(nullptr));
-  slot->commit_publish();
-  slot->commit_publish();
+  EXPECT_TRUE(slot->commit_publish());
+  EXPECT_TRUE(slot->commit_publish());
   EXPECT_FALSE(slot->valid());
+}
+
+TEST_F(GpuBufferManagerTest, CommitBeforeReadyHasNoSideEffects) {
+  auto manager = make_manager();
+  ASSERT_TRUE(manager.initialise());
+  auto slot = manager.acquire_for_publish();
+  ASSERT_TRUE(slot.has_value());
+
+  EXPECT_FALSE(slot->commit_publish());
+  EXPECT_TRUE(slot->valid());
+  EXPECT_NE(slot->device_ptr(), nullptr);
+  EXPECT_FALSE(manager.acquire_for_publish().has_value());
+
+  slot->cancel();
+  EXPECT_FALSE(slot->valid());
+  EXPECT_TRUE(manager.acquire_for_publish().has_value());
 }
 
 TEST_F(GpuBufferManagerTest, RuntimeCreatedStreamCanRecordReady) {
@@ -162,6 +178,7 @@ TEST_F(GpuBufferManagerTest, MovedFromSlotIsInert) {
   PublishSlot destination(std::move(*source));
   EXPECT_FALSE(source->valid());
   EXPECT_EQ(source->device_ptr(), nullptr);
+  EXPECT_FALSE(source->commit_publish());
   EXPECT_TRUE(destination.valid());
   destination.cancel();
   destination.cancel();

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
@@ -123,7 +123,7 @@ TEST_F(GpuBufferManagerTest, CommittedDestructionKeepsGracePeriod) {
     slot->commit_publish();
   }
   EXPECT_FALSE(manager.acquire_for_publish().has_value());
-  std::this_thread::sleep_for(std::chrono::milliseconds(105));
+  std::this_thread::sleep_for(std::chrono::milliseconds(150));
   EXPECT_TRUE(manager.acquire_for_publish().has_value());
 }
 

--- a/ros2_cuda_ipc_core/test/test_lease_handle.cpp
+++ b/ros2_cuda_ipc_core/test/test_lease_handle.cpp
@@ -225,7 +225,7 @@ TEST(LeaseHandleTest, CommitAppliesFixedGracePeriod) {
   EXPECT_NE(*timestamp, 0u);
   EXPECT_FALSE(lease::LeaseHandle::reserve_for_publish(mapping).has_value());
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(105));
+  std::this_thread::sleep_for(std::chrono::milliseconds(150));
   auto next = lease::LeaseHandle::reserve_for_publish(mapping);
   ASSERT_TRUE(next.has_value());
   cancel(mapping, next);

--- a/ros2_cuda_ipc_core/test/test_lease_handle.cpp
+++ b/ros2_cuda_ipc_core/test/test_lease_handle.cpp
@@ -6,6 +6,7 @@
 #include <unistd.h>
 
 #include <atomic>
+#include <chrono>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -23,41 +24,59 @@ std::string make_unique_shm_name(const std::string& prefix) {
   return oss.str();
 }
 
+void cancel(
+    const std::shared_ptr<ros2_cuda_ipc_core::lease::LeaseMapping>& mapping,
+    const std::optional<
+        ros2_cuda_ipc_core::lease::LeaseHandle::PublisherReservation>&
+        reservation) {
+  if (reservation) {
+    EXPECT_TRUE(ros2_cuda_ipc_core::lease::LeaseHandle::cancel_publish(
+        mapping, reservation->slot_id, reservation->generation));
+  }
+}
+
 }  // namespace
 
 namespace ros2_cuda_ipc_core {
+
 TEST(LeaseHandleTest, AcquireReleaseLifecycle) {
   const std::string shm_name = make_unique_shm_name("lease_ut");
   auto mapping = lease::LeaseMapping::create(
       shm_name, test::publisher_instance_id(shm_name), 2);
   ASSERT_TRUE(mapping);
 
-  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping, 0);
+  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping);
   ASSERT_TRUE(reservation.has_value());
+  EXPECT_EQ(lease::LeaseHandle::current_refcount(mapping, reservation->slot_id),
+            std::optional<uint32_t>(1));
 
+  std::optional<lease::LeaseHandle::PublisherReservation> other;
   {
     auto lease = lease::LeaseHandle::acquire(mapping, reservation->slot_id,
                                              reservation->generation);
     ASSERT_TRUE(lease.valid());
 
-    auto other = lease::LeaseHandle::reserve_for_publish(mapping, 0);
+    other = lease::LeaseHandle::reserve_for_publish(mapping);
     ASSERT_TRUE(other.has_value());
     EXPECT_NE(other->slot_id, reservation->slot_id);
 
     auto ref =
         lease::LeaseHandle::current_refcount(mapping, reservation->slot_id);
     ASSERT_TRUE(ref.has_value());
-    EXPECT_EQ(ref.value(), 1u);
+    EXPECT_EQ(ref.value(), 2u);
   }
 
   auto ref_after =
       lease::LeaseHandle::current_refcount(mapping, reservation->slot_id);
   ASSERT_TRUE(ref_after.has_value());
-  EXPECT_EQ(ref_after.value(), 0u);
+  EXPECT_EQ(ref_after.value(), 1u);
 
-  auto reservation_after = lease::LeaseHandle::reserve_for_publish(mapping, 0);
+  cancel(mapping, reservation);
+  cancel(mapping, other);
+  auto reservation_after = lease::LeaseHandle::reserve_for_publish(mapping);
   ASSERT_TRUE(reservation_after.has_value());
   EXPECT_EQ(reservation_after->slot_id, reservation->slot_id);
+  cancel(mapping, reservation_after);
 
   ::shm_unlink(shm_name.c_str());
 }
@@ -68,12 +87,12 @@ TEST(LeaseHandleTest, GenerationMismatchReturnsInvalid) {
       shm_name, test::publisher_instance_id(shm_name), 1);
   ASSERT_TRUE(mapping);
 
-  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping, 0);
+  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping);
   ASSERT_TRUE(reservation.has_value());
-
   auto lease = lease::LeaseHandle::acquire(mapping, reservation->slot_id,
                                            reservation->generation + 1);
   EXPECT_FALSE(lease.valid());
+  cancel(mapping, reservation);
 
   ::shm_unlink(shm_name.c_str());
 }
@@ -84,14 +103,14 @@ TEST(LeaseHandleTest, PublisherInstanceMismatchReturnsInvalid) {
   const auto other_id = test::publisher_instance_id(shm_name + "_other");
   auto mapping = lease::LeaseMapping::create(shm_name, owner_id, 1);
   ASSERT_TRUE(mapping);
-  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping, 1);
+  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping);
   ASSERT_TRUE(reservation.has_value());
 
-  auto wrong_mapping = lease::LeaseMapping::attach(shm_name, other_id);
-  EXPECT_FALSE(wrong_mapping);
-  auto pending = lease::LeaseHandle::current_pending(mapping, 0);
-  ASSERT_TRUE(pending.has_value());
-  EXPECT_EQ(*pending, 1u);
+  EXPECT_FALSE(lease::LeaseMapping::attach(shm_name, other_id));
+  auto ref = lease::LeaseHandle::current_refcount(mapping, 0);
+  ASSERT_TRUE(ref.has_value());
+  EXPECT_EQ(*ref, 1u);
+  cancel(mapping, reservation);
   ::shm_unlink(shm_name.c_str());
 }
 
@@ -102,9 +121,6 @@ TEST(LeaseHandleTest, HeaderPublisherInstanceMismatchReturnsInvalid) {
   const auto other_id = test::publisher_instance_id(shm_name + "_other");
   auto mapping = lease::LeaseMapping::create(shm_name, owner_id, 1);
   ASSERT_TRUE(mapping);
-
-  // Generation zero is valid in a newly-created slot. No mapping has been
-  // cached yet, so this exercises validation against the mapped header.
   EXPECT_FALSE(lease::LeaseMapping::attach(shm_name, other_id));
   ::shm_unlink(shm_name.c_str());
 }
@@ -118,17 +134,19 @@ TEST(LeaseHandleTest, SameSlotAndGenerationAreSeparatedByInstance) {
   auto second_mapping = lease::LeaseMapping::create(second_name, second_id, 1);
   ASSERT_TRUE(first_mapping);
   ASSERT_TRUE(second_mapping);
-  auto first = lease::LeaseHandle::reserve_for_publish(first_mapping, 1);
-  auto second = lease::LeaseHandle::reserve_for_publish(second_mapping, 1);
+  auto first = lease::LeaseHandle::reserve_for_publish(first_mapping);
+  auto second = lease::LeaseHandle::reserve_for_publish(second_mapping);
   ASSERT_TRUE(first.has_value());
   ASSERT_TRUE(second.has_value());
   ASSERT_EQ(first->slot_id, second->slot_id);
   ASSERT_EQ(first->generation, second->generation);
 
   EXPECT_FALSE(lease::LeaseMapping::attach(first_name, second_id));
-  EXPECT_TRUE(lease::LeaseHandle::acquire(first_mapping, first->slot_id,
-                                          first->generation)
-                  .valid());
+  auto lease = lease::LeaseHandle::acquire(first_mapping, first->slot_id,
+                                           first->generation);
+  EXPECT_TRUE(lease.valid());
+  cancel(first_mapping, first);
+  cancel(second_mapping, second);
   ::shm_unlink(first_name.c_str());
   ::shm_unlink(second_name.c_str());
 }
@@ -144,8 +162,6 @@ TEST(LeaseHandleTest, ExplicitMappingSeparatesReusedNameByInstance) {
   ASSERT_TRUE(new_mapping);
 
   EXPECT_TRUE(lease::LeaseHandle::acquire(new_mapping, 0, 0).valid());
-  // The old mapping remains usable because its owner still holds it; the new
-  // instance is a separate mapping even though the POSIX name was reused.
   EXPECT_TRUE(lease::LeaseHandle::acquire(old_mapping, 0, 0).valid());
   old_mapping.reset();
   new_mapping.reset();
@@ -158,7 +174,7 @@ TEST(LeaseHandleTest, MappingLifetimeFollowsUsersAfterUnlink) {
   auto mapping = lease::LeaseMapping::create(shm_name, instance_id, 1);
   ASSERT_TRUE(mapping);
   std::weak_ptr<lease::LeaseMapping> weak_mapping = mapping;
-  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping, 1);
+  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping);
   ASSERT_TRUE(reservation);
   {
     auto lease = lease::LeaseHandle::acquire(mapping, reservation->slot_id,
@@ -168,105 +184,90 @@ TEST(LeaseHandleTest, MappingLifetimeFollowsUsersAfterUnlink) {
     mapping.reset();
     EXPECT_FALSE(weak_mapping.expired());
   }
+  EXPECT_TRUE(lease::LeaseHandle::cancel_publish(
+      reservation->mapping, reservation->slot_id, reservation->generation));
   reservation.reset();
   EXPECT_TRUE(weak_mapping.expired());
 }
 
-TEST(LeaseHandleTest, PendingPreventsSlotReuse) {
-  const std::string shm_name = make_unique_shm_name("lease_pending");
+TEST(LeaseHandleTest, PublisherReservationUsesReferenceCount) {
+  const std::string shm_name = make_unique_shm_name("lease_reservation_ref");
   auto mapping = lease::LeaseMapping::create(
       shm_name, test::publisher_instance_id(shm_name), 1);
   ASSERT_TRUE(mapping);
 
-  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping, 2);
+  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping);
   ASSERT_TRUE(reservation.has_value());
+  EXPECT_EQ(lease::LeaseHandle::current_refcount(mapping, 0),
+            std::optional<uint32_t>(1));
+  EXPECT_FALSE(lease::LeaseHandle::reserve_for_publish(mapping).has_value());
+  cancel(mapping, reservation);
+  EXPECT_EQ(lease::LeaseHandle::current_refcount(mapping, 0),
+            std::optional<uint32_t>(0));
+  ::shm_unlink(shm_name.c_str());
+}
 
-  auto next = lease::LeaseHandle::reserve_for_publish(mapping, 0);
-  EXPECT_FALSE(next.has_value());
+TEST(LeaseHandleTest, CommitAppliesFixedGracePeriod) {
+  const std::string shm_name = make_unique_shm_name("lease_grace");
+  auto mapping = lease::LeaseMapping::create(
+      shm_name, test::publisher_instance_id(shm_name), 1);
+  ASSERT_TRUE(mapping);
 
-  EXPECT_TRUE(lease::LeaseHandle::force_clear_pending(mapping, 0));
+  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping);
+  ASSERT_TRUE(reservation.has_value());
+  ASSERT_TRUE(lease::LeaseHandle::commit_publish(mapping, reservation->slot_id,
+                                                 reservation->generation));
+  EXPECT_EQ(lease::LeaseHandle::current_refcount(mapping, 0),
+            std::optional<uint32_t>(0));
+  const auto timestamp =
+      lease::LeaseHandle::current_publish_timestamp_us(mapping, 0);
+  ASSERT_TRUE(timestamp.has_value());
+  EXPECT_NE(*timestamp, 0u);
+  EXPECT_FALSE(lease::LeaseHandle::reserve_for_publish(mapping).has_value());
 
-  next = lease::LeaseHandle::reserve_for_publish(mapping, 0);
+  std::this_thread::sleep_for(std::chrono::milliseconds(105));
+  auto next = lease::LeaseHandle::reserve_for_publish(mapping);
   ASSERT_TRUE(next.has_value());
-  EXPECT_EQ(next->slot_id, reservation->slot_id);
-
+  cancel(mapping, next);
   ::shm_unlink(shm_name.c_str());
 }
 
-TEST(LeaseHandleTest, PendingDecrementedOnAcquire) {
-  const std::string shm_name = make_unique_shm_name("lease_pending_dec");
+TEST(LeaseHandleTest, ActiveLeaseBlocksReuseAfterGracePeriod) {
+  const std::string shm_name = make_unique_shm_name("lease_active");
   auto mapping = lease::LeaseMapping::create(
       shm_name, test::publisher_instance_id(shm_name), 1);
   ASSERT_TRUE(mapping);
 
-  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping, 2);
+  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping);
   ASSERT_TRUE(reservation.has_value());
-
-  {
-    auto lease = lease::LeaseHandle::acquire(mapping, reservation->slot_id,
-                                             reservation->generation);
-    ASSERT_TRUE(lease.valid());
-    auto pending =
-        lease::LeaseHandle::current_pending(mapping, reservation->slot_id);
-    ASSERT_TRUE(pending.has_value());
-    EXPECT_EQ(pending.value(), 1u);
-  }
-
-  {
-    auto lease = lease::LeaseHandle::acquire(mapping, reservation->slot_id,
-                                             reservation->generation);
-    ASSERT_TRUE(lease.valid());
-    auto pending =
-        lease::LeaseHandle::current_pending(mapping, reservation->slot_id);
-    ASSERT_TRUE(pending.has_value());
-    EXPECT_EQ(pending.value(), 0u);
-  }
-
-  {
-    auto lease = lease::LeaseHandle::acquire(mapping, reservation->slot_id,
-                                             reservation->generation);
-    ASSERT_TRUE(lease.valid());
-    auto pending =
-        lease::LeaseHandle::current_pending(mapping, reservation->slot_id);
-    ASSERT_TRUE(pending.has_value());
-    EXPECT_EQ(pending.value(), 0u);
-  }
-
+  ASSERT_TRUE(lease::LeaseHandle::commit_publish(mapping, reservation->slot_id,
+                                                 reservation->generation));
+  std::optional<lease::LeaseHandle> lease;
+  lease.emplace(lease::LeaseHandle::acquire(mapping, reservation->slot_id,
+                                            reservation->generation));
+  ASSERT_TRUE(lease->valid());
+  std::this_thread::sleep_for(std::chrono::milliseconds(105));
+  EXPECT_FALSE(lease::LeaseHandle::reserve_for_publish(mapping).has_value());
+  lease.reset();
+  auto next = lease::LeaseHandle::reserve_for_publish(mapping);
+  ASSERT_TRUE(next.has_value());
+  cancel(mapping, next);
   ::shm_unlink(shm_name.c_str());
 }
 
-TEST(LeaseHandleTest, ForceClearPendingResetsCounterWhenIdle) {
-  const std::string shm_name = make_unique_shm_name("lease_force_clear");
-  auto mapping = lease::LeaseMapping::create(
-      shm_name, test::publisher_instance_id(shm_name), 1);
-  ASSERT_TRUE(mapping);
-
-  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping, 2);
-  ASSERT_TRUE(reservation.has_value());
-
-  auto pending = lease::LeaseHandle::current_pending(mapping, 0);
-  ASSERT_TRUE(pending.has_value());
-  EXPECT_EQ(pending.value(), 2u);
-
-  EXPECT_TRUE(lease::LeaseHandle::force_clear_pending(mapping, 0));
-
-  pending = lease::LeaseHandle::current_pending(mapping, 0);
-  ASSERT_TRUE(pending.has_value());
-  EXPECT_EQ(pending.value(), 0u);
-
-  ::shm_unlink(shm_name.c_str());
-}
-
-TEST(LeaseHandleTest, AtomicPublisherReservationExcludesSubscriberAcquire) {
+TEST(LeaseHandleTest, PublisherAndSubscriberRaceIsGenerationSafe) {
   const std::string shm_name = make_unique_shm_name("lease_reserve_race");
   auto mapping = lease::LeaseMapping::create(
       shm_name, test::publisher_instance_id(shm_name), 1);
   ASSERT_TRUE(mapping);
 
-  for (int iteration = 0; iteration < 1000; ++iteration) {
-    auto initial = lease::LeaseHandle::reserve_for_publish(mapping, 0);
-    ASSERT_TRUE(initial.has_value());
+  auto initial = lease::LeaseHandle::reserve_for_publish(mapping);
+  ASSERT_TRUE(initial.has_value());
+  ASSERT_TRUE(lease::LeaseHandle::commit_publish(mapping, initial->slot_id,
+                                                 initial->generation));
+  std::this_thread::sleep_for(std::chrono::milliseconds(105));
 
+  for (int iteration = 0; iteration < 1000; ++iteration) {
     std::atomic<bool> start{false};
     std::optional<lease::LeaseHandle::PublisherReservation> publisher;
     std::optional<lease::LeaseHandle> subscriber;
@@ -274,7 +275,7 @@ TEST(LeaseHandleTest, AtomicPublisherReservationExcludesSubscriberAcquire) {
       while (!start.load(std::memory_order_acquire)) {
         std::this_thread::yield();
       }
-      publisher = lease::LeaseHandle::reserve_for_publish(mapping, 0);
+      publisher = lease::LeaseHandle::reserve_for_publish(mapping);
     });
     std::thread subscriber_thread([&]() {
       while (!start.load(std::memory_order_acquire)) {
@@ -288,6 +289,10 @@ TEST(LeaseHandleTest, AtomicPublisherReservationExcludesSubscriberAcquire) {
     subscriber_thread.join();
 
     EXPECT_FALSE(publisher.has_value() && subscriber->valid());
+    if (publisher) {
+      cancel(mapping, publisher);
+    }
+    subscriber.reset();
   }
   ::shm_unlink(shm_name.c_str());
 }
@@ -304,75 +309,20 @@ TEST(LeaseHandleTest, OnlyOnePublisherCanReserveSingleSlot) {
     while (!start.load(std::memory_order_acquire)) {
       std::this_thread::yield();
     }
-    first = lease::LeaseHandle::reserve_for_publish(mapping, 1);
+    first = lease::LeaseHandle::reserve_for_publish(mapping);
   });
   std::thread b([&]() {
     while (!start.load(std::memory_order_acquire)) {
       std::this_thread::yield();
     }
-    second = lease::LeaseHandle::reserve_for_publish(mapping, 1);
+    second = lease::LeaseHandle::reserve_for_publish(mapping);
   });
   start.store(true, std::memory_order_release);
   a.join();
   b.join();
   EXPECT_NE(first.has_value(), second.has_value());
-  ::shm_unlink(shm_name.c_str());
-}
-
-TEST(LeaseHandleTest, CancelDoesNotClearNewerGeneration) {
-  const std::string shm_name = make_unique_shm_name("lease_cancel_generation");
-  auto mapping = lease::LeaseMapping::create(
-      shm_name, test::publisher_instance_id(shm_name), 1);
-  ASSERT_TRUE(mapping);
-  auto old = lease::LeaseHandle::reserve_for_publish(mapping, 0);
-  ASSERT_TRUE(old.has_value());
-  auto current = lease::LeaseHandle::reserve_for_publish(mapping, 1);
-  ASSERT_TRUE(current.has_value());
-
-  EXPECT_FALSE(lease::LeaseHandle::cancel_pending(mapping, old->slot_id,
-                                                  old->generation));
-  auto pending = lease::LeaseHandle::current_pending(mapping, 0);
-  ASSERT_TRUE(pending.has_value());
-  EXPECT_EQ(*pending, 1u);
-  ::shm_unlink(shm_name.c_str());
-}
-
-TEST(LeaseHandleTest, CancelRetriesTransientReservationContention) {
-  const std::string shm_name = make_unique_shm_name("lease_cancel_contention");
-  auto mapping = lease::LeaseMapping::create(
-      shm_name, test::publisher_instance_id(shm_name), 1);
-  ASSERT_TRUE(mapping);
-
-  for (int iteration = 0; iteration < 1000; ++iteration) {
-    auto reservation = lease::LeaseHandle::reserve_for_publish(mapping, 1);
-    ASSERT_TRUE(reservation.has_value());
-
-    std::atomic<bool> start{false};
-    bool cancelled = false;
-    std::thread cancel_thread([&]() {
-      while (!start.load(std::memory_order_acquire)) {
-        std::this_thread::yield();
-      }
-      cancelled = lease::LeaseHandle::cancel_pending(
-          mapping, reservation->slot_id, reservation->generation);
-    });
-    std::thread reclaim_thread([&]() {
-      while (!start.load(std::memory_order_acquire)) {
-        std::this_thread::yield();
-      }
-      lease::LeaseHandle::force_clear_pending(mapping, reservation->slot_id);
-    });
-
-    start.store(true, std::memory_order_release);
-    cancel_thread.join();
-    reclaim_thread.join();
-    EXPECT_TRUE(cancelled);
-
-    const auto pending =
-        lease::LeaseHandle::current_pending(mapping, reservation->slot_id);
-    ASSERT_TRUE(pending.has_value());
-    EXPECT_EQ(*pending, 0u);
-  }
+  cancel(mapping, first);
+  cancel(mapping, second);
   ::shm_unlink(shm_name.c_str());
 }
 

--- a/ros2_cuda_ipc_core/test/test_lease_manager.cpp
+++ b/ros2_cuda_ipc_core/test/test_lease_manager.cpp
@@ -31,8 +31,7 @@ std::string make_unique_shm_name() {
 TEST(LeaseManagerTest, ResetRacingWithReserveDoesNotLeavePending) {
   for (int iteration = 0; iteration < 1000; ++iteration) {
     const std::string prefix = make_unique_shm_name();
-    ros2_cuda_ipc_core::publisher::LeaseManager manager(
-        prefix, 1, std::chrono::milliseconds(100));
+    ros2_cuda_ipc_core::publisher::LeaseManager manager(prefix, 1);
     ASSERT_TRUE(manager.initialise());
     std::atomic<bool> start{false};
     std::optional<ros2_cuda_ipc_core::publisher::LeaseManager::Reservation>
@@ -41,7 +40,7 @@ TEST(LeaseManagerTest, ResetRacingWithReserveDoesNotLeavePending) {
       while (!start.load(std::memory_order_acquire)) {
         std::this_thread::yield();
       }
-      reservation = manager.reserve_for_publish(1);
+      reservation = manager.reserve_for_publish();
     });
     std::thread reset_thread([&]() {
       while (!start.load(std::memory_order_acquire)) {
@@ -56,21 +55,19 @@ TEST(LeaseManagerTest, ResetRacingWithReserveDoesNotLeavePending) {
 
     if (reservation) {
       manager.cancel(*reservation);
-      const auto pending =
-          ros2_cuda_ipc_core::lease::LeaseHandle::current_pending(
+      const auto refcount =
+          ros2_cuda_ipc_core::lease::LeaseHandle::current_refcount(
               reservation->mapping, 0);
-      ASSERT_TRUE(pending.has_value());
-      EXPECT_EQ(*pending, 0u);
+      ASSERT_TRUE(refcount.has_value());
+      EXPECT_EQ(*refcount, 0u);
     }
   }
 }
 
 TEST(LeaseManagerTest, SamePrefixProducesDistinctInstances) {
   const std::string prefix = make_unique_shm_name();
-  ros2_cuda_ipc_core::publisher::LeaseManager first(
-      prefix, 1, std::chrono::milliseconds(100));
-  ros2_cuda_ipc_core::publisher::LeaseManager second(
-      prefix, 2, std::chrono::milliseconds(100));
+  ros2_cuda_ipc_core::publisher::LeaseManager first(prefix, 1);
+  ros2_cuda_ipc_core::publisher::LeaseManager second(prefix, 2);
   ASSERT_TRUE(first.initialise());
   ASSERT_TRUE(second.initialise());
   EXPECT_NE(first.shm_name(), second.shm_name());
@@ -78,8 +75,8 @@ TEST(LeaseManagerTest, SamePrefixProducesDistinctInstances) {
 }
 
 TEST(LeaseManagerTest, ResetUnlinksAndReinitialiseChangesIdentity) {
-  ros2_cuda_ipc_core::publisher::LeaseManager manager(
-      make_unique_shm_name(), 1, std::chrono::milliseconds(100));
+  ros2_cuda_ipc_core::publisher::LeaseManager manager(make_unique_shm_name(),
+                                                      1);
   ASSERT_TRUE(manager.initialise());
   const std::string old_name = manager.shm_name();
   const auto old_id = manager.publisher_instance_id();
@@ -98,8 +95,7 @@ TEST(LeaseManagerTest, ResetUnlinksAndReinitialiseChangesIdentity) {
 }
 
 TEST(LeaseManagerTest, InvalidPrefixFailsClosed) {
-  ros2_cuda_ipc_core::publisher::LeaseManager manager(
-      "/invalid/prefix", 1, std::chrono::milliseconds(100));
+  ros2_cuda_ipc_core::publisher::LeaseManager manager("/invalid/prefix", 1);
   EXPECT_FALSE(manager.initialise());
   EXPECT_TRUE(manager.shm_name().empty());
   EXPECT_TRUE(ros2_cuda_ipc_core::is_nil(manager.publisher_instance_id()));

--- a/ros2_cuda_ipc_core/test/test_lease_mapping_cache.cpp
+++ b/ros2_cuda_ipc_core/test/test_lease_mapping_cache.cpp
@@ -116,10 +116,11 @@ TEST(LeaseMappingCacheTest, ReusesMappingAcrossCallbackLocalLeases) {
   auto first = cache.get_or_attach(logical_shm_name, instance_id);
   ASSERT_TRUE(first);
 
-  auto reservation = lease::LeaseHandle::reserve_for_publish(first, 0);
+  auto reservation = lease::LeaseHandle::reserve_for_publish(first);
   ASSERT_TRUE(reservation.has_value());
   const auto slot_id = reservation->slot_id;
   const auto generation = reservation->generation;
+  ASSERT_TRUE(lease::LeaseHandle::commit_publish(first, slot_id, generation));
   reservation.reset();
 
   for (int i = 0; i < 1000; ++i) {
@@ -171,10 +172,11 @@ TEST(LeaseMappingCacheTest, ClearPreservesMappingForActiveLease) {
   auto mapping =
       cache.get_or_attach("/logical_lease_cache_active", instance_id);
   ASSERT_TRUE(mapping);
-  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping, 1);
+  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping);
   ASSERT_TRUE(reservation.has_value());
   const auto slot_id = reservation->slot_id;
   const auto generation = reservation->generation;
+  ASSERT_TRUE(lease::LeaseHandle::commit_publish(mapping, slot_id, generation));
   reservation.reset();
 
   std::weak_ptr<lease::LeaseMapping> weak_mapping = mapping;

--- a/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
+++ b/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
@@ -106,6 +106,10 @@ inline ros2_cuda_ipc_msgs::msg::BufferCore make_seeded_buffer_core_message(
   if (!lease::LeaseHandle::commit_publish(mapping, reservation->slot_id,
                                           reservation->generation)) {
     ADD_FAILURE() << "LeaseHandle::commit_publish failed for " << shm_name;
+    (void)lease::LeaseHandle::cancel_publish(mapping, reservation->slot_id,
+                                             reservation->generation);
+    (void)::shm_unlink(shm_name.c_str());
+    return ros2_cuda_ipc_msgs::msg::BufferCore{};
   }
   seed_cache_for_message(msg, static_cast<uintptr_t>(0x1000 + key_seed * 0x10));
   return msg;

--- a/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
+++ b/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
@@ -96,13 +96,17 @@ inline ros2_cuda_ipc_msgs::msg::BufferCore make_seeded_buffer_core_message(
     ADD_FAILURE() << "LeaseMapping::create failed for " << shm_name;
     return ros2_cuda_ipc_msgs::msg::BufferCore{};
   }
-  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping, 1);
+  auto reservation = lease::LeaseHandle::reserve_for_publish(mapping);
   if (!reservation.has_value()) {
     ADD_FAILURE() << "LeaseHandle::reserve_for_publish failed for " << shm_name;
     return ros2_cuda_ipc_msgs::msg::BufferCore{};
   }
   auto msg = make_cached_buffer_core_message(shm_name, reservation->slot_id,
                                              reservation->generation, key_seed);
+  if (!lease::LeaseHandle::commit_publish(mapping, reservation->slot_id,
+                                          reservation->generation)) {
+    ADD_FAILURE() << "LeaseHandle::commit_publish failed for " << shm_name;
+  }
   seed_cache_for_message(msg, static_cast<uintptr_t>(0x1000 + key_seed * 0x10));
   return msg;
 }

--- a/ros2_cuda_ipc_py/src/native_module.cpp
+++ b/ros2_cuda_ipc_py/src/native_module.cpp
@@ -596,7 +596,7 @@ py::tuple make_test_image() {
     throw std::runtime_error("test LeaseMapping::create failed");
   }
   const auto reservation =
-      ros2_cuda_ipc_core::lease::LeaseHandle::reserve_for_publish(mapping, 1);
+      ros2_cuda_ipc_core::lease::LeaseHandle::reserve_for_publish(mapping);
   if (!reservation) {
     throw std::runtime_error("test LeaseHandle::reserve_for_publish failed");
   }
@@ -636,6 +636,10 @@ py::tuple make_test_image() {
   auto view = mapper.map(message);
   if (!view.valid() || !view.sanity_check()) {
     throw std::runtime_error("test ImageViewMapper fixture failed");
+  }
+  if (!ros2_cuda_ipc_core::lease::LeaseHandle::commit_publish(
+          mapping, reservation->slot_id, reservation->generation)) {
+    throw std::runtime_error("test LeaseHandle::commit_publish failed");
   }
 
   py::dict core;

--- a/ros2_cuda_ipc_py/src/native_module.cpp
+++ b/ros2_cuda_ipc_py/src/native_module.cpp
@@ -639,6 +639,9 @@ py::tuple make_test_image() {
   }
   if (!ros2_cuda_ipc_core::lease::LeaseHandle::commit_publish(
           mapping, reservation->slot_id, reservation->generation)) {
+    (void)ros2_cuda_ipc_core::lease::LeaseHandle::cancel_publish(
+        mapping, reservation->slot_id, reservation->generation);
+    (void)::shm_unlink(shm_name.c_str());
     throw std::runtime_error("test LeaseHandle::commit_publish failed");
   }
 


### PR DESCRIPTION
## Summary

- replace pending/reserved lease metadata with generation, refcnt, and publish timestamp
- use the Publisher reservation as a temporary refcount and enforce a fixed 100 ms grace period
- remove pending_ttl configuration/APIs and update the Publisher, examples, tests, and lease protocol documentation

## Why

The Publisher cannot reliably observe Subscriber delivery context, so pending accounting and pending TTL deadlines are removed. Generation rechecks preserve race safety while refcnt protects active leases and the grace period prevents immediate slot reuse.

## Validation

- `colcon build --symlink-install --packages-up-to ros2_cuda_ipc_core ros2_cuda_ipc_py multi_process_image_fanout`
- `ctest --test-dir build/ros2_cuda_ipc_core --output-on-failure` — 14 passed
- `colcon test --packages-select ros2_cuda_ipc_py` — 13 passed, 1 skipped

Only `doc/upstream-comparison.md` is intentionally excluded from this PR.