### PR TITLE
Add RAII publisher write handle

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -21,27 +21,33 @@ who want to try the demo first.
 - `ros2_cuda_ipc_core::publisher::GpuBufferPool`: publisher-side GPU resource ownership.
 - `ros2_cuda_ipc_core::publisher::LeaseManager`: publisher reservation, generation, and grace-period state.
 - `ros2_cuda_ipc_core::publisher::GpuBufferManager`: publisher-facing buffer manager.
-- `ros2_cuda_ipc_core::publisher::PublishSlot`: one move-only publish attempt with RAII cancellation.
+- `ros2_cuda_ipc_core::publisher::PublishSlot`: one move-only publish attempt with RAII reservation release.
+- `ros2_cuda_ipc_core::publisher::WriteHandle`: scoped device access that records the ready event on destruction.
 
 Publisher code should follow this order:
 
 ```cpp
 auto slot = manager.acquire_for_publish();
-launch_gpu_work(slot->device_ptr(), stream);
-slot->record_ready(stream);
+{
+  auto write = slot->write(stream);
+  launch_gpu_work(write->data(), stream);
+}
 auto descriptor = slot->descriptor();
 publisher->publish(make_message(*descriptor));
-slot->commit_publish();
 ```
 
 The public ready-event APIs use the CUDA Driver API stream type `CUstream`.
 Applications that use the CUDA Runtime API include
 `<cuda_runtime_api.h>` themselves; a Runtime-created `cudaStream_t` can be
-passed directly to `record_ready()` and `enqueue_ready_event()`. The stream is
+passed directly to `write()` and `enqueue_ready_event()`. The stream is
 owned by the application and is only borrowed by the core library.
 
-Destroying an uncommitted `PublishSlot` cancels its reservation. Descriptor
-creation is rejected until the ready event has been recorded successfully.
+Destroying a `WriteHandle` records the ready event. The parent `PublishSlot`
+must outlive the handle and must not be moved while the handle is active.
+Destroying the slot starts the reuse grace period and releases its Publisher
+reservation, including on early returns where no message was published.
+Descriptor creation is rejected until the ready event has been recorded
+successfully; `ready_error()` reports recording failures.
 The protocol guarantees and known limitations are specified in
 [doc/lease_protocol.md](doc/lease_protocol.md).
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,10 @@ The public ready-event APIs use the CUDA Driver API stream type `CUstream`:
 cudaStream_t stream = nullptr;
 cudaStreamCreate(&stream);
 
-slot.record_ready(stream);
+{
+  auto write = slot.write(stream);
+  launch_gpu_work(write->data(), stream);
+}
 view.enqueue_ready_event(stream);
 ```
 

--- a/doc/lease_protocol.md
+++ b/doc/lease_protocol.md
@@ -17,8 +17,9 @@ Publisher 再起動後の状態引き継ぎは対象外である。
 | generation | slot が publish 用に取得されるたびに増加する世代番号 |
 | reservation | Publisher が保持する `slot_id` と `generation` |
 | refcnt | Subscriber lease と Publisher reservation の合計参照数 |
-| grace period | publish 後に slot を再利用しない固定期間（100 ms） |
+| grace period | Publisher reservation 解放後に slot を再利用しない固定期間（100 ms） |
 | lease | Subscriber が buffer を読み取り中であることを表す RAII 所有権 |
+| write handle | device pointer への一時的な書き込み権。破棄時に ready event を記録する |
 
 `pending` や ROS subscription count は lease protocol の状態として使用しない。実際に
 lease を取得した Subscriber だけが `refcnt` に反映される。
@@ -32,6 +33,7 @@ Publisher process
     LeaseManager        reservation と publish lifecycle を管理
       LeaseHandle       process-shared metadata を操作
     PublishSlot         1回の publish 試行を表す move-only object
+      WriteHandle       CUDA stream と device pointer の scoped access
 
 Subscriber process
   BufferViewMapper
@@ -43,11 +45,12 @@ Publisher は次の順で API を使用する。
 
 ```cpp
 auto slot = manager.acquire_for_publish();
-launch_gpu_work(slot->device_ptr(), stream);
-slot->record_ready(stream);
+{
+  auto write = slot->write(stream);
+  launch_gpu_work(write->data(), stream);
+}
 auto descriptor = slot->descriptor();
 publisher->publish(make_message(*descriptor));
-slot->commit_publish();
 ```
 
 ## 4. Process-shared slot state
@@ -69,8 +72,10 @@ Publisher instance ID を検証する。
 するときに`SlotMeta`をplacement newで構築する。Subscriberは既存のslotを再構築せずに
 attachする。
 
-`publish_timestamp_us` は `steady_clock` のマイクロ秒値で、最後に commit された publish
-時刻を表す。0 はまだ publish されていない slot を表す。
+`publish_timestamp_us` は `steady_clock` のマイクロ秒値で、Publisher reservation
+解放時に開始した再利用抑止期間の起点を表す。0 は grace period が設定されていない
+slot を表す。publish 前の早期終了にも grace period を適用するため、実際の ROS publish
+時刻とは限らない。
 
 slot の再利用条件は次である。
 
@@ -90,7 +95,7 @@ refcnt == 0 &&
 `acquire_for_publish()` は round-robin で候補を探索し、各 slot に対して次を行う。
 
 1. `refcnt == 0` を確認する。
-2. timestamp が0、または publish から100 ms以上経過していることを確認する。
+2. timestamp が0、または publish 開始から100 ms以上経過していることを確認する。
 3. `refcnt` を CAS で `0 -> 1` に変更する。
 4. CAS に失敗したら次の候補へ進む。
 5. `generation` を1増加する。
@@ -103,35 +108,30 @@ Subscriber は `refcnt != 0` だけを理由に拒否せず、generation の前�
 
 ### 5.2 GPU work と ready event
 
-Publisher は取得した device pointer へ GPU work を enqueue し、同じ依存関係を持つ
-CUDA stream で `record_ready()` を呼ぶ。`descriptor()` は ready event 記録成功前には
-失敗する。
+Publisher は `slot->write(stream)` で move-only `WriteHandle` を取得し、その
+`data()` から得た device pointer へ GPU work を enqueue する。WriteHandle の
+destructor は同じ CUDA stream へ ready event を記録する。
 
-ready event の記録前に reservation が破棄された場合、`PublishSlot` の destructor が
-cancel を実行する。
+WriteHandle は親 PublishSlot を借用する。PublishSlot は handle より長生きし、handle が
+有効な間は move してはならない。1つの PublishSlot から取得できる WriteHandle は1回
+だけである。`descriptor()` は handle の破棄と ready event 記録成功前には失敗する。
+event 記録失敗は `ready_error()` から取得できる。
 
-### 5.3 commit
+### 5.3 reservation release
 
-`commit_publish()` は ROS publish API が message を middleware へ引き渡した後に呼ぶ。
-
-commit は次の順で処理する。
+`PublishSlot` の destructor は、ROS publish の実行有無にかかわらず次を行う。
 
 1. reservation の generation が現在の generation と一致することを確認する。
 2. `publish_timestamp_us` を現在時刻へ更新する。
 3. Publisher reservation の `refcnt` を1減少させる。
 
-commit 後も、Subscriber lease が残っていれば slot は再利用できない。commit は GPU work
-完了、Subscriber への配送完了、Subscriber の lease 取得完了を意味しない。
+Subscriber lease が残っていれば slot は再利用できない。slot の破棄は GPU work 完了、
+Subscriber への配送完了、Subscriber の lease 取得完了を意味しない。
 
-### 5.4 cancel
-
-未commitの `PublishSlot` を破棄するか `cancel()` を呼ぶと、Publisher reservation の
-`refcnt` だけを減少させる。cancel では publish timestamp を更新しないため、未公開の
-reservation は grace period を追加で発生させない。
-
-reservation の generation が一致しない場合は新しい generation の refcount を誤って
-減らさず、エラーとして扱う。通常の API lifecycle では reservation が保持されている間
-に別 generation へ進むことはない。
+publish 前の早期 return や ready event 記録失敗でも grace period を適用する。これに
+より未公開 slot にも一時的な backpressure が発生するが、明示的な commit/cancel の
+呼び忘れを排除する。reservation 取得処理自体の rollback では内部 cancel を使用し、
+grace period を開始しない。
 
 ## 6. Subscriber acquire と release
 
@@ -184,7 +184,7 @@ lease が成立することを防ぐ。
 | --- | --- |
 | reusable slot がない | Publisher の acquire が失敗する |
 | GPU resource 初期化失敗 | 作成済み resource を rollback する |
-| ready event 記録失敗 | 未commit reservation を destructor が cancel する |
+| ready event 記録失敗 | descriptor を無効にし、slot 破棄時に grace period 付きで reservation を解放する |
 | generation mismatch | Subscriber acquire または reservation 完了を失敗させる |
 | Subscriber process crash | refcnt が残り、slot が再利用不能になる可能性がある |
 | 100 ms を超える message 遅延 | slot 再利用後は generation mismatch で drop される可能性がある |

--- a/examples/multi_process_image_fanout/README.md
+++ b/examples/multi_process_image_fanout/README.md
@@ -39,8 +39,9 @@ results.
 ## CUDA stream API
 
 The example uses CUDA Runtime API streams for its kernels and passes the same
-`cudaStream_t` values directly to the core's `record_ready()` and
-`enqueue_ready_event()` APIs. Each application source includes
+`cudaStream_t` values directly to the core's scoped `write()` and
+`enqueue_ready_event()` APIs. Destroying the write handle records the ready
+event. Each application source includes
 `<cuda_runtime_api.h>` explicitly. The core API is declared in terms of
 `CUstream`, and the application remains responsible for stream ownership.
 

--- a/examples/multi_process_image_fanout/src/gpu_image_publisher.cpp
+++ b/examples/multi_process_image_fanout/src/gpu_image_publisher.cpp
@@ -130,8 +130,13 @@ class GpuImagePublisherNode : public rclcpp::Node {
     {
       NvtxScopedRange kernel_range(
           "GpuImagePublisherNode::generate_rgba_pattern_kernel");
+      auto write = slot->write(stream_);
+      if (!write) {
+        RCLCPP_ERROR(get_logger(), "Failed to acquire GPU write handle");
+        return;
+      }
       error = launch_generate_rgba_pattern_kernel(
-          static_cast<uint8_t*>(slot->device_ptr()), static_cast<int>(width_),
+          write->data<uint8_t>(), static_cast<int>(width_),
           static_cast<int>(height_), width_ * kBytesPerPixel, frame_index_,
           stream_);
     }
@@ -140,18 +145,12 @@ class GpuImagePublisherNode : public rclcpp::Node {
       return;
     }
 
-    {
-      NvtxScopedRange event_range("GpuImagePublisherNode::record_ready");
-      auto result = slot->record_ready(stream_);
-      if (!result) {
-        RCLCPP_WARN(get_logger(), "record_ready failed: %s",
-                    result.error().to_string().c_str());
-        return;
-      }
-    }
-
     const auto descriptor = slot->descriptor();
     if (!descriptor) {
+      if (const auto ready_error = slot->ready_error()) {
+        RCLCPP_WARN(get_logger(), "ready event recording failed: %s",
+                    ready_error->to_string().c_str());
+      }
       RCLCPP_ERROR(get_logger(), "Failed to create GPU buffer descriptor");
       return;
     }
@@ -167,7 +166,6 @@ class GpuImagePublisherNode : public rclcpp::Node {
     message.header.frame_id = frame_id_;
 
     publisher_->publish(message);
-    slot->commit_publish();
     ++frame_index_;
   }
 

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/lease/lease_handle.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/lease/lease_handle.hpp
@@ -55,8 +55,7 @@ class LeaseHandle {
   static std::optional<PublisherReservation> reserve_for_publish(
       const std::shared_ptr<LeaseMapping>& mapping);
 
-  /// Mark a Publisher reservation as published and release its temporary
-  /// reference.
+  /// Start the reuse grace period and release a Publisher reservation.
   ///
   /// @param mapping Shared-memory mapping containing the slot metadata.
   /// @param slot_id Slot index inside the mapping.

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp
@@ -18,54 +18,81 @@
 namespace ros2_cuda_ipc_core::publisher {
 
 class GpuBufferManager;
+class PublishSlot;
+
+/// Provides scoped write access to one reserved GPU buffer.
+///
+/// The associated PublishSlot must outlive this handle and must not be moved
+/// while the handle is active. Destruction records the ready event on the
+/// borrowed CUDA stream.
+class WriteHandle {
+ public:
+  WriteHandle(WriteHandle&& other) noexcept;
+  WriteHandle& operator=(WriteHandle&& other) noexcept;
+
+  WriteHandle(const WriteHandle&) = delete;
+  WriteHandle& operator=(const WriteHandle&) = delete;
+
+  ~WriteHandle() noexcept;
+
+  /// Return the device pointer while this handle owns the write scope.
+  void* data() const noexcept;
+
+  /// Return the device pointer cast to the requested element type.
+  template <typename T>
+  T* data() const noexcept {
+    return static_cast<T*>(data());
+  }
+
+  /// Check whether this handle owns an active write scope.
+  bool valid() const noexcept { return slot_ != nullptr; }
+
+ private:
+  friend class PublishSlot;
+
+  WriteHandle(PublishSlot* slot, CUstream stream) noexcept;
+  void finish() noexcept;
+
+  PublishSlot* slot_ = nullptr;
+  CUstream stream_ = nullptr;
+};
 
 /// Represents one active publish attempt.
 ///
 /// The owning GpuBufferManager must outlive every PublishSlot created from
 /// it. Calling GpuBufferManager::reset() invalidates slot resource
-/// operations, but slot destruction can still cancel its shared-memory
+/// operations, but slot destruction can still release its shared-memory
 /// reservation while the manager object remains alive.
 class PublishSlot {
  public:
   /// Move a publish slot while transferring ownership of its reservation.
   PublishSlot(PublishSlot&& other) noexcept;
 
-  /// Cancel the current reservation, if any, before taking ownership of other.
+  /// Complete the current reservation, if any, before taking ownership of
+  /// other.
   PublishSlot& operator=(PublishSlot&& other) noexcept;
 
   PublishSlot(const PublishSlot&) = delete;
   PublishSlot& operator=(const PublishSlot&) = delete;
 
-  /// Cancel an uncommitted reservation on destruction.
+  /// Record the publish timestamp and release the Publisher reservation.
   ~PublishSlot();
 
-  /// Return the device pointer associated with the reserved slot.
+  /// Begin one scoped write on the given stream.
   ///
-  /// @return Device pointer when the slot is usable; nullptr otherwise.
-  void* device_ptr() const noexcept;
-
-  /// Record that the slot's GPU payload is ready on the given stream.
+  /// The returned handle borrows this PublishSlot. This slot must outlive the
+  /// handle and must not be moved while the handle is active.
   ///
-  /// @return A Driver API result. A failed result is returned when the slot
-  /// is not in the reserved state or the event cannot be recorded.
-  detail::CudaResult<void> record_ready(CUstream stream) noexcept;
+  /// @return A write handle when the slot is reserved; std::nullopt otherwise.
+  std::optional<WriteHandle> write(CUstream stream) noexcept;
 
   /// Build the transport descriptor after the ready event has been recorded.
   ///
   /// @return Descriptor when the slot is ready; std::nullopt otherwise.
   std::optional<transport::BufferDescriptor> descriptor() const;
 
-  /// Mark the descriptor as handed to the middleware.
-  ///
-  /// Requires a successful record_ready() call. Repeated calls after commit
-  /// are harmless.
-  ///
-  /// @return true when the Publisher reservation was committed; false when
-  /// the reservation could not be committed.
-  bool commit_publish() noexcept;
-
-  /// Cancel the reservation when it has not been committed.
-  void cancel() noexcept;
+  /// Return the ready-event recording error, when recording failed.
+  std::optional<detail::CudaDriverError> ready_error() const noexcept;
 
   /// Check whether the slot can still be used for publishing.
   bool valid() const noexcept;
@@ -73,22 +100,28 @@ class PublishSlot {
  private:
   /// Allow the manager to construct slots only from valid reservations.
   friend class GpuBufferManager;
+  friend class WriteHandle;
 
   enum class State {
     reserved,
+    writing,
     ready_recorded,
-    committed,
-    cancelled,
+    ready_failed,
+    released,
     moved_from
   };
 
   PublishSlot(GpuBufferManager* owner,
               LeaseManager::Reservation reservation) noexcept;
   void move_from(PublishSlot&& other) noexcept;
+  void* write_data() const noexcept;
+  void finish_write(CUstream stream) noexcept;
+  void release() noexcept;
 
   GpuBufferManager* owner_ = nullptr;
   LeaseManager::Reservation reservation_{};
   State state_ = State::moved_from;
+  std::optional<detail::CudaDriverError> ready_error_;
 };
 
 /// Owns the GPU buffer pool and shared-memory slot reservations used for
@@ -158,7 +191,6 @@ class GpuBufferManager {
   std::optional<transport::BufferDescriptor> descriptor(
       const LeaseManager::Reservation& reservation) const;
   bool commit(const LeaseManager::Reservation& reservation) noexcept;
-  bool cancel(const LeaseManager::Reservation& reservation) noexcept;
 
   Config config_;
   GpuBufferPool buffer_pool_;

--- a/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
@@ -7,9 +7,45 @@
 
 namespace ros2_cuda_ipc_core::publisher {
 
+WriteHandle::WriteHandle(PublishSlot* slot, CUstream stream) noexcept
+    : slot_(slot), stream_(stream) {}
+
+WriteHandle::WriteHandle(WriteHandle&& other) noexcept
+    : slot_(other.slot_), stream_(other.stream_) {
+  other.slot_ = nullptr;
+  other.stream_ = nullptr;
+}
+
+WriteHandle& WriteHandle::operator=(WriteHandle&& other) noexcept {
+  if (this != &other) {
+    finish();
+    slot_ = other.slot_;
+    stream_ = other.stream_;
+    other.slot_ = nullptr;
+    other.stream_ = nullptr;
+  }
+  return *this;
+}
+
+WriteHandle::~WriteHandle() noexcept { finish(); }
+
+void* WriteHandle::data() const noexcept {
+  return slot_ != nullptr ? slot_->write_data() : nullptr;
+}
+
+void WriteHandle::finish() noexcept {
+  if (slot_ != nullptr) {
+    slot_->finish_write(stream_);
+    slot_ = nullptr;
+    stream_ = nullptr;
+  }
+}
+
 PublishSlot::PublishSlot(GpuBufferManager* owner,
                          LeaseManager::Reservation reservation) noexcept
-    : owner_(owner), reservation_(reservation), state_(State::reserved) {}
+    : owner_(owner),
+      reservation_(std::move(reservation)),
+      state_(State::reserved) {}
 
 PublishSlot::PublishSlot(PublishSlot&& other) noexcept {
   move_from(std::move(other));
@@ -17,41 +53,58 @@ PublishSlot::PublishSlot(PublishSlot&& other) noexcept {
 
 PublishSlot& PublishSlot::operator=(PublishSlot&& other) noexcept {
   if (this != &other) {
-    cancel();
+    release();
     move_from(std::move(other));
   }
   return *this;
 }
 
-PublishSlot::~PublishSlot() { cancel(); }
+PublishSlot::~PublishSlot() { release(); }
 
 void PublishSlot::move_from(PublishSlot&& other) noexcept {
   owner_ = other.owner_;
-  reservation_ = other.reservation_;
+  reservation_ = std::move(other.reservation_);
   state_ = other.state_;
+  ready_error_ = std::move(other.ready_error_);
   other.owner_ = nullptr;
   other.state_ = State::moved_from;
+  other.ready_error_.reset();
 }
 
 bool PublishSlot::valid() const noexcept {
   return owner_ != nullptr &&
-         (state_ == State::reserved || state_ == State::ready_recorded);
+         (state_ == State::reserved || state_ == State::writing ||
+          state_ == State::ready_recorded);
 }
 
-void* PublishSlot::device_ptr() const noexcept {
-  return valid() ? owner_->device_ptr(reservation_) : nullptr;
-}
-
-detail::CudaResult<void> PublishSlot::record_ready(CUstream stream) noexcept {
+std::optional<WriteHandle> PublishSlot::write(CUstream stream) noexcept {
   if (owner_ == nullptr || state_ != State::reserved) {
-    return detail::CudaResult<void>::failure(
-        detail::CudaDriverError(CUDA_ERROR_INVALID_HANDLE));
+    return std::nullopt;
   }
+  state_ = State::writing;
+  return WriteHandle(this, stream);
+}
+
+void* PublishSlot::write_data() const noexcept {
+  if (owner_ == nullptr || state_ != State::writing) {
+    return nullptr;
+  }
+  return owner_->device_ptr(reservation_);
+}
+
+void PublishSlot::finish_write(CUstream stream) noexcept {
+  if (owner_ == nullptr || state_ != State::writing) {
+    return;
+  }
+
   auto result = owner_->record_ready(reservation_, stream);
   if (result) {
     state_ = State::ready_recorded;
+    ready_error_.reset();
+  } else {
+    ready_error_ = result.error();
+    state_ = State::ready_failed;
   }
-  return result;
 }
 
 std::optional<transport::BufferDescriptor> PublishSlot::descriptor() const {
@@ -61,35 +114,16 @@ std::optional<transport::BufferDescriptor> PublishSlot::descriptor() const {
   return owner_->descriptor(reservation_);
 }
 
-bool PublishSlot::commit_publish() noexcept {
-  if (owner_ == nullptr) {
-    return false;
-  }
-  if (state_ == State::committed) {
-    return true;
-  }
-  if (state_ != State::ready_recorded) {
-    return false;
-  }
-  if (owner_->commit(reservation_)) {
-    state_ = State::committed;
-    return true;
-  }
-  // A failed commit must not make the slot inert while its reservation is
-  // still active. The cancel path is generation-checked as well, so it is
-  // safe to attempt even when the commit failed due to a stale reservation.
-  if (owner_->cancel(reservation_)) {
-    state_ = State::cancelled;
-  }
-  return false;
+std::optional<detail::CudaDriverError> PublishSlot::ready_error()
+    const noexcept {
+  return ready_error_;
 }
 
-void PublishSlot::cancel() noexcept {
-  if (owner_ != nullptr &&
-      (state_ == State::reserved || state_ == State::ready_recorded)) {
-    if (owner_->cancel(reservation_)) {
-      state_ = State::cancelled;
-    }
+void PublishSlot::release() noexcept {
+  if (owner_ != nullptr && state_ != State::released &&
+      state_ != State::moved_from) {
+    owner_->commit(reservation_);
+    state_ = State::released;
   }
 }
 
@@ -137,7 +171,7 @@ std::optional<PublishSlot> GpuBufferManager::acquire_for_publish() {
   if (!reservation) {
     return std::nullopt;
   }
-  return PublishSlot(this, *reservation);
+  return PublishSlot(this, std::move(*reservation));
 }
 
 void* GpuBufferManager::device_ptr(
@@ -188,11 +222,6 @@ std::optional<transport::BufferDescriptor> GpuBufferManager::descriptor(
 bool GpuBufferManager::commit(
     const LeaseManager::Reservation& reservation) noexcept {
   return lease_manager_.commit(reservation);
-}
-
-bool GpuBufferManager::cancel(
-    const LeaseManager::Reservation& reservation) noexcept {
-  return lease_manager_.cancel(reservation);
 }
 
 }  // namespace ros2_cuda_ipc_core::publisher

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
@@ -30,11 +30,16 @@ std::string unique_name() {
 
 using ros2_cuda_ipc_core::publisher::GpuBufferManager;
 using ros2_cuda_ipc_core::publisher::PublishSlot;
+using ros2_cuda_ipc_core::publisher::WriteHandle;
 
 static_assert(!std::is_copy_constructible_v<PublishSlot>);
 static_assert(!std::is_copy_assignable_v<PublishSlot>);
 static_assert(std::is_nothrow_move_constructible_v<PublishSlot>);
 static_assert(std::is_nothrow_move_assignable_v<PublishSlot>);
+static_assert(!std::is_copy_constructible_v<WriteHandle>);
+static_assert(!std::is_copy_assignable_v<WriteHandle>);
+static_assert(std::is_nothrow_move_constructible_v<WriteHandle>);
+static_assert(std::is_nothrow_move_assignable_v<WriteHandle>);
 
 class GpuBufferManagerTest : public ::testing::Test {
  protected:
@@ -61,7 +66,13 @@ TEST_F(GpuBufferManagerTest, DescriptorIsGatedByReadyRecording) {
   auto slot = manager.acquire_for_publish();
   ASSERT_TRUE(slot.has_value());
   EXPECT_EQ(slot->descriptor(), std::nullopt);
-  ASSERT_TRUE(slot->record_ready(nullptr));
+  {
+    auto write = slot->write(nullptr);
+    ASSERT_TRUE(write.has_value());
+    EXPECT_NE(write->data(), nullptr);
+    EXPECT_EQ(slot->descriptor(), std::nullopt);
+    EXPECT_FALSE(slot->write(nullptr).has_value());
+  }
   auto descriptor = slot->descriptor();
   ASSERT_TRUE(descriptor.has_value());
   EXPECT_EQ(descriptor->slot_id, 0u);
@@ -69,26 +80,27 @@ TEST_F(GpuBufferManagerTest, DescriptorIsGatedByReadyRecording) {
   EXPECT_EQ(descriptor->lease_shm_name, manager.shm_name());
   EXPECT_EQ(descriptor->publisher_instance_id, instance_id);
   EXPECT_EQ(descriptor->byte_size, 1024u);
-  EXPECT_FALSE(slot->record_ready(nullptr));
-  EXPECT_TRUE(slot->commit_publish());
-  EXPECT_TRUE(slot->commit_publish());
-  EXPECT_FALSE(slot->valid());
+  EXPECT_FALSE(slot->ready_error().has_value());
+  EXPECT_FALSE(slot->write(nullptr).has_value());
+  EXPECT_TRUE(slot->valid());
 }
 
-TEST_F(GpuBufferManagerTest, CommitBeforeReadyHasNoSideEffects) {
+TEST_F(GpuBufferManagerTest, WriteHandleIsMoveOnlyAndRecordsOnce) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
   auto slot = manager.acquire_for_publish();
   ASSERT_TRUE(slot.has_value());
 
-  EXPECT_FALSE(slot->commit_publish());
-  EXPECT_TRUE(slot->valid());
-  EXPECT_NE(slot->device_ptr(), nullptr);
-  EXPECT_FALSE(manager.acquire_for_publish().has_value());
-
-  slot->cancel();
-  EXPECT_FALSE(slot->valid());
-  EXPECT_TRUE(manager.acquire_for_publish().has_value());
+  {
+    auto source = slot->write(nullptr);
+    ASSERT_TRUE(source.has_value());
+    WriteHandle destination(std::move(*source));
+    EXPECT_FALSE(source->valid());
+    EXPECT_EQ(source->data(), nullptr);
+    EXPECT_TRUE(destination.valid());
+    EXPECT_NE(destination.data<uint8_t>(), nullptr);
+  }
+  EXPECT_TRUE(slot->descriptor().has_value());
 }
 
 TEST_F(GpuBufferManagerTest, RuntimeCreatedStreamCanRecordReady) {
@@ -99,8 +111,11 @@ TEST_F(GpuBufferManagerTest, RuntimeCreatedStreamCanRecordReady) {
 
   cudaStream_t stream = nullptr;
   ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
-  const auto result = slot->record_ready(stream);
-  ASSERT_TRUE(result) << result.error().to_string();
+  {
+    auto write = slot->write(stream);
+    ASSERT_TRUE(write.has_value());
+  }
+  ASSERT_FALSE(slot->ready_error().has_value());
   ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
   ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
 }
@@ -113,61 +128,58 @@ TEST_F(GpuBufferManagerTest, DriverCreatedStreamCanRecordReady) {
 
   CUstream stream = nullptr;
   ASSERT_EQ(cuStreamCreate(&stream, CU_STREAM_DEFAULT), CUDA_SUCCESS);
-  const auto result = slot->record_ready(stream);
-  ASSERT_TRUE(result) << result.error().to_string();
+  {
+    auto write = slot->write(stream);
+    ASSERT_TRUE(write.has_value());
+  }
+  ASSERT_FALSE(slot->ready_error().has_value());
   ASSERT_EQ(cuStreamSynchronize(stream), CUDA_SUCCESS);
   ASSERT_EQ(cuStreamDestroy(stream), CUDA_SUCCESS);
 }
 
-TEST_F(GpuBufferManagerTest, UncommittedDestructionCancelsReservation) {
+TEST_F(GpuBufferManagerTest, DestructionWithoutWriteStartsPublishTimestamp) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
   {
     auto slot = manager.acquire_for_publish();
     ASSERT_TRUE(slot.has_value());
-  }
-  EXPECT_TRUE(manager.acquire_for_publish().has_value());
-}
-
-TEST_F(GpuBufferManagerTest, CommittedDestructionKeepsGracePeriod) {
-  auto manager = make_manager();
-  ASSERT_TRUE(manager.initialise());
-  {
-    auto slot = manager.acquire_for_publish();
-    ASSERT_TRUE(slot.has_value());
-    ASSERT_TRUE(slot->record_ready(nullptr));
-    slot->commit_publish();
   }
   EXPECT_FALSE(manager.acquire_for_publish().has_value());
-  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+  std::this_thread::sleep_for(std::chrono::milliseconds(105));
   EXPECT_TRUE(manager.acquire_for_publish().has_value());
 }
 
-TEST_F(GpuBufferManagerTest, FailedCommitDoesNotMarkSlotCommitted) {
+TEST_F(GpuBufferManagerTest, PublishTimestampAtSlotDestruction) {
+  auto manager = make_manager();
+  ASSERT_TRUE(manager.initialise());
+  {
+    auto slot = manager.acquire_for_publish();
+    ASSERT_TRUE(slot.has_value());
+    std::this_thread::sleep_for(std::chrono::milliseconds(105));
+    {
+      auto write = slot->write(nullptr);
+      ASSERT_TRUE(write.has_value());
+    }
+  }
+  EXPECT_FALSE(manager.acquire_for_publish().has_value());
+  std::this_thread::sleep_for(std::chrono::milliseconds(105));
+  EXPECT_TRUE(manager.acquire_for_publish().has_value());
+}
+
+TEST_F(GpuBufferManagerTest, ReadyRecordingFailureIsStoredOnSlot) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
   auto slot = manager.acquire_for_publish();
   ASSERT_TRUE(slot.has_value());
-  ASSERT_TRUE(slot->record_ready(nullptr));
+  auto write = slot->write(nullptr);
+  ASSERT_TRUE(write.has_value());
 
-  auto mapping = ros2_cuda_ipc_core::lease::LeaseMapping::attach(
-      manager.shm_name(), manager.publisher_instance_id());
-  ASSERT_TRUE(mapping);
-  const auto generation =
-      ros2_cuda_ipc_core::lease::LeaseHandle::current_generation(mapping, 0);
-  ASSERT_TRUE(generation.has_value());
+  manager.reset();
+  write.reset();
 
-  mapping->slot(0)->generation.store(*generation + 1,
-                                     std::memory_order_release);
-  EXPECT_FALSE(slot->commit_publish());
-  EXPECT_TRUE(slot->valid());
-
-  // Restore the reservation generation so its cancellation can release the
-  // temporary Publisher reference after the failed-commit check.
-  mapping->slot(0)->generation.store(*generation, std::memory_order_release);
-  slot->cancel();
-  EXPECT_FALSE(slot->valid());
-  EXPECT_TRUE(manager.acquire_for_publish().has_value());
+  ASSERT_TRUE(slot->ready_error().has_value());
+  EXPECT_EQ(slot->ready_error()->code(), CUDA_ERROR_INVALID_HANDLE);
+  EXPECT_EQ(slot->descriptor(), std::nullopt);
 }
 
 TEST_F(GpuBufferManagerTest, MovedFromSlotIsInert) {
@@ -177,16 +189,16 @@ TEST_F(GpuBufferManagerTest, MovedFromSlotIsInert) {
   ASSERT_TRUE(source.has_value());
   PublishSlot destination(std::move(*source));
   EXPECT_FALSE(source->valid());
-  EXPECT_EQ(source->device_ptr(), nullptr);
-  EXPECT_FALSE(source->commit_publish());
   EXPECT_TRUE(destination.valid());
-  destination.cancel();
-  destination.cancel();
-  EXPECT_FALSE(destination.valid());
-  EXPECT_TRUE(manager.acquire_for_publish().has_value());
+  {
+    auto write = destination.write(nullptr);
+    ASSERT_TRUE(write.has_value());
+    EXPECT_NE(write->data(), nullptr);
+  }
+  EXPECT_TRUE(destination.descriptor().has_value());
 }
 
-TEST_F(GpuBufferManagerTest, ResetDoesNotPreventReservationCancellation) {
+TEST_F(GpuBufferManagerTest, ResetDoesNotPreventReservationRelease) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
   const std::string actual_name = manager.shm_name();
@@ -217,14 +229,14 @@ TEST_F(GpuBufferManagerTest, ResetDoesNotPreventReservationCancellation) {
   }
 }
 
-TEST_F(GpuBufferManagerTest, AcquireAfterGracePeriod) {
+TEST_F(GpuBufferManagerTest, AcquireAfterPublishTimestamp) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
   {
     auto slot = manager.acquire_for_publish();
     ASSERT_TRUE(slot.has_value());
-    ASSERT_TRUE(slot->record_ready(nullptr));
-    slot->commit_publish();
+    auto write = slot->write(nullptr);
+    ASSERT_TRUE(write.has_value());
   }
 
   std::this_thread::sleep_for(std::chrono::milliseconds(105));

--- a/ros2_cuda_ipc_core/test/test_public_stream_api_driver.cpp
+++ b/ros2_cuda_ipc_core/test/test_public_stream_api_driver.cpp
@@ -13,14 +13,15 @@ namespace {
 
 using ros2_cuda_ipc_core::detail::CudaResult;
 using ros2_cuda_ipc_core::publisher::PublishSlot;
+using ros2_cuda_ipc_core::publisher::WriteHandle;
 using ros2_cuda_ipc_core::subscriber::BufferView;
 
-using PublishRecordReady = CudaResult<void> (PublishSlot::*)(CUstream) noexcept;
+using PublishWrite =
+    std::optional<WriteHandle> (PublishSlot::*)(CUstream) noexcept;
 using EnqueueReadyEvent =
     CudaResult<void> (BufferView::*)(CUstream) const noexcept;
 
-static_assert(
-    std::is_same_v<decltype(&PublishSlot::record_ready), PublishRecordReady>);
+static_assert(std::is_same_v<decltype(&PublishSlot::write), PublishWrite>);
 static_assert(std::is_same_v<decltype(&BufferView::enqueue_ready_event),
                              EnqueueReadyEvent>);
 


### PR DESCRIPTION
## What changed

- Add a move-only `WriteHandle` that exposes scoped GPU write access and records the ready event on destruction.
- Remove the public `PublishSlot` pointer/event/commit/cancel workflow in favor of `slot.write(stream)`.
- Automatically start the reuse grace period and release the publisher reservation when the slot is destroyed.
- Persist ready-event recording errors through `ready_error()` and update the example, tests, and lease protocol documentation.
- Rename the shared timestamp metadata to `grace_period_start_us` to reflect its lifecycle meaning.

## Why

The previous example required callers to remember both `record_ready()` and `commit_publish()`. The new scoped handle makes ready-event recording automatic, while slot destruction handles reservation release consistently, including early returns.

## Validation

- `colcon build --packages-up-to multi_process_image_fanout --cmake-args -DBUILD_TESTING=ON`
- `colcon test --packages-select ros2_cuda_ipc_core multi_process_image_fanout`
- `colcon test-result --verbose`
- clang-format pre-commit hook