### PR TITLE
Prepare v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,65 @@
 This document records the user-visible changes between releases of
 `ros2_cuda_ipc`.
 
+## [0.4.0] - 2026-07-30
+
+This release adds the first supported Python subscriber API and simplifies
+the publisher and subscriber lifetime contracts around asynchronous CUDA
+work.
+
+### Highlights
+
+- Added the `ros2_cuda_ipc_py` subscriber binding for zero-copy `GpuImage`
+  access from Python, including CuPy and DLPack integration, CUDA stream
+  validation, image metadata, examples, and regression tests.
+- Reworked subscriber reads around `BufferMapper` and the move-only
+  `ReadHandle` API. Imported resources, publication leases, producer waits,
+  and completion handling now follow the read-handle lifecycle, with release
+  deferred until asynchronous work completes.
+- Simplified `PublishSlot` preparation to the single
+  `prepare_publish(CUstream)` operation, which builds the descriptor,
+  records the ready event, and commits the reservation.
+- Simplified lease slot reuse to generation, reference-count, and publication
+  timestamp tracking with a fixed grace period; removed pending metadata and
+  pending-TTL configuration.
+- Replaced core `RCLCPP_*` logging and propagated logger objects with named
+  `rcutils` logging macros.
+
+### Breaking changes and migration notes
+
+- Update publisher code to use `PublishSlot::prepare_publish(CUstream)`;
+  `record_ready()`, `descriptor()`, and `commit_publish()` are no longer part
+  of the public `PublishSlot` API.
+- Remove uses of pending-lease metadata and pending-TTL configuration APIs.
+  Slot reuse is now protected by the fixed grace period and active lease
+  reference counts.
+- Update subscriber code to use `BufferMapper` and `ReadHandle`. Legacy
+  buffer-view, lease-handle, and import-cache implementation headers are no
+  longer part of the installed subscriber surface.
+- Core APIs no longer carry `rclcpp::Logger` instances or logger parameters;
+  diagnostics use fixed named `rcutils` loggers.
+
+### Tests and documentation
+
+- Added Python subscriber, DLPack, stream-validation, ownership, and
+  asynchronous lifetime regression coverage.
+- Expanded publisher, lease, subscriber, and cache tests for the revised
+  ownership and failure semantics.
+- Updated the publisher, lease protocol, subscriber, development, and demo
+  documentation and added Python subscriber examples.
+
+### Package versions
+
+All ROS 2 packages and the Python native extension are bumped from `0.3.0`
+to `0.4.0`:
+
+- `ros2_cuda_ipc_core`
+- `ros2_cuda_ipc_msgs`
+- `ros2_cuda_ipc_py`
+- `multi_process_image_fanout`
+- `gpu_image_transport`
+- `cuda_ipc_poc`
+
 ## [0.3.0] - 2026-07-25
 
 This release is primarily an internal refactoring release. The core CUDA
@@ -59,3 +118,4 @@ All packages are bumped from `0.2.0` to `0.3.0`:
 - `cuda_ipc_poc`
 
 [0.3.0]: https://github.com/dskkato/ros2_cuda_ipc/compare/v0.2.0...v0.3.0
+[0.4.0]: https://github.com/dskkato/ros2_cuda_ipc/compare/v0.3.0...v0.4.0

--- a/examples/multi_process_image_fanout/package.xml
+++ b/examples/multi_process_image_fanout/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>multi_process_image_fanout</name>
-  <version>0.3.0</version>
+  <version>0.4.0</version>
   <description>Primary ros2_cuda_ipc demo for one GPU image publisher fanning out to multiple processes.</description>
   <maintainer email="dskkato@example.com">dskkato</maintainer>
   <license>MIT</license>

--- a/ros2_cuda_ipc_core/package.xml
+++ b/ros2_cuda_ipc_core/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ros2_cuda_ipc_core</name>
-  <version>0.3.0</version>
+  <version>0.4.0</version>
   <description>Core C++ utilities for ROS 2 GPU zero-copy transport using CUDA IPC.</description>
   <maintainer email="dskkato@example.com">dskkato</maintainer>
   <license>MIT</license>

--- a/ros2_cuda_ipc_msgs/package.xml
+++ b/ros2_cuda_ipc_msgs/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ros2_cuda_ipc_msgs</name>
-  <version>0.3.0</version>
+  <version>0.4.0</version>
   <description>Message definitions for ROS 2 GPU zero-copy transport using CUDA IPC.</description>
   <maintainer email="dskkato@example.com">dskkato</maintainer>
   <license>MIT</license>

--- a/ros2_cuda_ipc_py/CMakeLists.txt
+++ b/ros2_cuda_ipc_py/CMakeLists.txt
@@ -30,7 +30,7 @@ ament_get_python_install_dir(PYTHON_INSTALL_DIR)
 pybind11_add_module(_native MODULE src/native_module.cpp)
 target_include_directories(_native PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(_native PRIVATE ros2_cuda_ipc_core::ros2_cuda_ipc_core dlpack::dlpack)
-target_compile_definitions(_native PRIVATE ROS2_CUDA_IPC_PY_VERSION="0.3.0")
+target_compile_definitions(_native PRIVATE ROS2_CUDA_IPC_PY_VERSION="0.4.0")
 
 if(BUILD_TESTING)
   target_compile_definitions(_native PRIVATE ROS2_CUDA_IPC_PY_ENABLE_TEST_SUPPORT)

--- a/ros2_cuda_ipc_py/package.xml
+++ b/ros2_cuda_ipc_py/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>ros2_cuda_ipc_py</name>
-  <version>0.3.0</version>
+  <version>0.4.0</version>
   <description>Python subscriber bindings for ros2_cuda_ipc GPU images.</description>
   <maintainer email="dskkato@example.com">dskkato</maintainer>
   <license>MIT</license>

--- a/utils/cuda_ipc_poc/package.xml
+++ b/utils/cuda_ipc_poc/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>cuda_ipc_poc</name>
-  <version>0.3.0</version>
+  <version>0.4.0</version>
   <description>Test applications for CUDA IPC mechanisms (both cudaIpc and VMM-FD)</description>
   <maintainer email="dskkato@users.noreply.github.com">dskkato</maintainer>
   <license>Apache-2.0</license>

--- a/utils/gpu_image_transport/package.xml
+++ b/utils/gpu_image_transport/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>gpu_image_transport</name>
-  <version>0.3.0</version>
+  <version>0.4.0</version>
   <description>Utility nodes that map ros2_cuda_ipc GpuImage messages to CPU sensor_msgs image topics.</description>
   <maintainer email="dskkato@example.com">dskkato</maintainer>
   <license>MIT</license>


### PR DESCRIPTION
## Summary

Prepare the repository for the v0.4.0 release. This PR covers the changes merged after v0.3.0 and updates all package and native-extension version metadata to 0.4.0.

## Changes since v0.3.0

- Added the `ros2_cuda_ipc_py` Python subscriber binding for zero-copy `GpuImage` access.
  - Added CuPy and DLPack integration, including CUDA stream validation and image metadata.
  - Added PyTorch/CuPy examples and Python API regression coverage.
- Reworked subscriber reads around `BufferMapper` and the move-only `ReadHandle` API.
  - Tied imported resources, publication leases, producer waits, and completion handling to the read-handle lifecycle.
  - Deferred resource and lease release until asynchronous CUDA work completes.
  - Removed legacy subscriber implementation headers from the installed surface.
- Simplified publisher slot preparation to `PublishSlot::prepare_publish(CUstream)`.
  - Descriptor construction, ready-event recording, and reservation commit are handled by one operation.
  - Failed preparation attempts remain quarantined until `GpuBufferManager::reset()`.
- Simplified lease slot reuse to generation, reference-count, publication-timestamp, and fixed grace-period tracking.
  - Removed pending metadata and pending-TTL configuration.
- Replaced core `RCLCPP_*` logging and logger propagation with named `rcutils` logging macros.
- Updated publisher, lease protocol, subscriber, development, and demo documentation.

## Breaking changes

- Migrate publisher code from `record_ready()`, `descriptor()`, and `commit_publish()` to `prepare_publish(CUstream)`.
- Remove uses of pending-lease metadata and pending-TTL APIs.
- Migrate subscriber code to `BufferMapper` and `ReadHandle`; legacy buffer-view, lease-handle, and import-cache implementation headers are no longer installed as subscriber API.
- Remove `rclcpp::Logger` arguments and logger objects from core API usage.

## Version updates

- Bumped all six ROS 2 package manifests from 0.3.0 to 0.4.0.
- Bumped `ROS2_CUDA_IPC_PY_VERSION` in the Python native extension from 0.3.0 to 0.4.0.
- Added the v0.4.0 section and comparison link to `CHANGELOG.md`.

## Validation

- XML validation with `xmllint`
- `git diff --check`
- `colcon build --symlink-install --packages-up-to ros2_cuda_ipc_core ros2_cuda_ipc_py multi_process_image_fanout`
- Core CTest: 13 passed, 0 failed
- Python API tests: 14 passed, 1 skipped (CUDA-dependent)
