### PR TITLE
Fix Python subscriber ImageView logging

### DIFF
--- a/ros2_cuda_ipc_py/examples/gpu_image_cupy_subscriber.py
+++ b/ros2_cuda_ipc_py/examples/gpu_image_cupy_subscriber.py
@@ -37,8 +37,7 @@ class GpuImageSubscriber(Node):
             cp.cuda.get_current_stream().synchronize()
             self.get_logger().info(
                 f"received {image.encoding or '<unspecified>'} "
-                f"shape={array.shape} dtype={array.dtype} "
-                f"device_ptr=0x{image.device_ptr:x}"
+                f"shape={array.shape} dtype={array.dtype}"
             )
         except (MappingError, RuntimeError, TypeError, ValueError) as exc:
             self.get_logger().warning(f"skipping GPU image: {exc}")

--- a/ros2_cuda_ipc_py/examples/gpu_image_torch_subscriber.py
+++ b/ros2_cuda_ipc_py/examples/gpu_image_torch_subscriber.py
@@ -40,7 +40,7 @@ class GpuImageTorchSubscriber(Node):
             consumer_stream.synchronize()
             self.get_logger().info(
                 f"received shape={tuple(result.shape)} dtype={result.dtype} "
-                f"device_ptr=0x{image.device_ptr:x}"
+                f"device={result.device}"
             )
         except (MappingError, RuntimeError, TypeError, ValueError) as exc:
             self.get_logger().warning(f"skipping GPU image: {exc}")


### PR DESCRIPTION
## Summary

- Remove stale `image.device_ptr` access from the CuPy subscriber example.
- Update the PyTorch subscriber example to report the tensor device instead of accessing the removed ImageView pointer.

## Root cause

`ImageView` intentionally exposes metadata and DLPack conversion, but not a raw `device_ptr`. The examples still used the pre-DLPack logging API, so the callback raised `AttributeError` after a successful mapping and terminated the node.

## Validation

- `python3 -m py_compile ros2_cuda_ipc_py/examples/gpu_image_cupy_subscriber.py ros2_cuda_ipc_py/examples/gpu_image_torch_subscriber.py`
- `colcon build --symlink-install --packages-select ros2_cuda_ipc_py`
- `ros2_cuda_ipc_core` BufferRef tests: 12 passed
- `ros2_cuda_ipc_core` BufferMapper tests: 5 passed