### PR TITLE
Rename publish slots to blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This document records the user-visible changes between releases of
   using a ROS message and is not a mirror of the message field.
 - The standalone `cuda_ipc_poc` comparison programs remain available, but are
   no longer library backends.
+- Renamed publisher buffer slots to blocks across the core API, metadata,
+  ROS messages, Python descriptors, launch arguments, documentation, and
+  tests. The wire/API identifiers `slot_id` and `generation` are now
+  `block_id` and `uid`, and `slot_count` is now `block_count`.
 
 ## [0.4.0] - 2026-07-30
 
@@ -33,10 +37,10 @@ work.
   `ReadHandle` API. Imported resources, publication leases, producer waits,
   and completion handling now follow the read-handle lifecycle, with release
   deferred until asynchronous work completes.
-- Simplified `PublishSlot` preparation to the single
+- Simplified `PublishBlock` preparation to the single
   `prepare_publish(CUstream)` operation, which builds the descriptor,
   records the ready event, and commits the reservation.
-- Simplified lease slot reuse to generation, reference-count, and publication
+- Simplified lease block reuse to uid, reference-count, and publication
   timestamp tracking with a fixed grace period; removed pending metadata and
   pending-TTL configuration.
 - Replaced core `RCLCPP_*` logging and propagated logger objects with named
@@ -44,11 +48,11 @@ work.
 
 ### Breaking changes and migration notes
 
-- Update publisher code to use `PublishSlot::prepare_publish(CUstream)`;
+- Update publisher code to use `PublishBlock::prepare_publish(CUstream)`;
   `record_ready()`, `descriptor()`, and `commit_publish()` are no longer part
-  of the public `PublishSlot` API.
+  of the public `PublishBlock` API.
 - Remove uses of pending-lease metadata and pending-TTL configuration APIs.
-  Slot reuse is now protected by the fixed grace period and active lease
+  Block reuse is now protected by the fixed grace period and active lease
   reference counts.
 - Update subscriber code to use `BufferMapper` and `ReadHandle`. Legacy
   buffer-view, lease-handle, and import-cache implementation headers are no

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -27,6 +27,9 @@ Publisher code should follow this order:
 
 ```cpp
 auto block = manager.acquire_for_publish();
+if (!block) {
+  return;
+}
 launch_gpu_work(block->device_ptr(), stream);
 auto descriptor = block->prepare_publish(stream);
 if (!descriptor) {

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -17,18 +17,18 @@ who want to try the demo first.
 - `ros2_cuda_ipc_core::subscriber::BufferMapper`: maps a `BufferCore` and a consumer stream to an optional `ReadHandle`.
 - `ros2_cuda_ipc_core::subscriber::ReadHandle`: the normal pointer API. It waits for producer readiness, owns the buffer reference, and defers resource/buffer reference release until consumer completion.
 - `ros2_cuda_ipc_core::image::ImageView` / `ros2_cuda_ipc_core::pointcloud2::PointCloud2View`: typed adapters layered on `ReadHandle`; the Python image adapter is DLPack-only and binds its stream at export.
-- `ros2_cuda_ipc_core::publisher::BufferMetadataManager`: publisher reservation, generation, and grace-period state. Subscriber buffer reference handles, import caches, completion events, and deferred queues are internal.
-- `ros2_cuda_ipc_core::publisher::GpuBufferPool`: publisher-side GPU resource ownership.
-- `ros2_cuda_ipc_core::publisher::BufferMetadataManager`: publisher reservation, generation, and grace-period state.
+- `ros2_cuda_ipc_core::publisher::GpuBufferPool`: publisher-local allocation and reuse strategy for independent `GpuBufferBlock` resources.
+- `ros2_cuda_ipc_core::publisher::BufferMetadataManager`: publisher reservation, uid, and grace-period state.
 - `ros2_cuda_ipc_core::publisher::GpuBufferManager`: publisher-facing buffer manager.
-- `ros2_cuda_ipc_core::publisher::PublishSlot`: one move-only publish attempt with RAII cancellation.
+- `ros2_cuda_ipc_core::publisher::PublishBlock`: one move-only publish attempt with RAII cancellation.
+- `ros2_cuda_ipc_core::buffer_metadata::BlockMetadata`: shared per-block publication identity and refcount state. Subscriber buffer reference handles, import caches, completion events, and deferred queues are internal.
 
 Publisher code should follow this order:
 
 ```cpp
-auto slot = manager.acquire_for_publish();
-launch_gpu_work(slot->device_ptr(), stream);
-auto descriptor = slot->prepare_publish(stream);
+auto block = manager.acquire_for_publish();
+launch_gpu_work(block->device_ptr(), stream);
+auto descriptor = block->prepare_publish(stream);
 if (!descriptor) {
   return;
 }
@@ -45,9 +45,9 @@ Applications that use the CUDA Runtime API include
 passed directly to `prepare_publish()`. The stream is owned by the application
 and is only borrowed by the core library.
 
-Destroying a slot before preparation cancels its reservation. A successful
+Destroying a block before preparation cancels its reservation. A successful
 preparation commits it. The subsequent middleware publish result does not
-affect slot lifecycle.
+affect block lifecycle.
 The protocol guarantees and known limitations are specified in
 [doc/buffer_metadata_protocol.md](doc/buffer_metadata_protocol.md).
 
@@ -135,7 +135,7 @@ This writes separate reports named
 `fanout-<arch>-<width>x<height>-<rate>-<label>-<node>`. Override
 `nsys_profile_flags` to change the default `--trace=osrt,nvtx,cuda` flags.
 
-Expected NVTX ranges include slot acquisition, producer kernel work, input
+Expected NVTX ranges include block acquisition, producer kernel work, input
 event waits, preview image copy, encoder-like kernels, and inference-like
 kernels. A large device-to-host image copy should appear only in `preview_node`.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ ros2 launch multi_process_image_fanout multi_process_image_fanout.launch.py \
   width:=1280 \
   height:=720 \
   publish_rate_hz:=60.0 \
-  slot_count:=4 \
+  block_count:=4 \
   shm_name_prefix:=/ros2_cuda_ipc_fanout \
   device_index:=0
 ```
@@ -104,10 +104,10 @@ ros2 topic echo /fanout/inference_like/status
 ## Publisher API
 
 ```cpp
-auto slot = manager.acquire_for_publish();
-launch_gpu_work(slot->device_ptr(), stream);
+auto block = manager.acquire_for_publish();
+launch_gpu_work(block->device_ptr(), stream);
 
-auto descriptor = slot->prepare_publish(stream);
+auto descriptor = block->prepare_publish(stream);
 if (!descriptor) {
   return;
 }
@@ -117,7 +117,7 @@ publisher->publish(make_message(descriptor.value()));
 
 Pass the stream that carries the producer work dependency to
 `prepare_publish()`. On success, publish the returned descriptor. On failure,
-that slot is not reused until `GpuBufferManager::reset()`.
+that block is not reused until `GpuBufferManager::reset()`.
 
 The API accepts Driver API `CUstream` values and Runtime API `cudaStream_t`
 values directly. The application retains ownership of the stream.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ ros2 topic echo /fanout/inference_like/status
 
 ```cpp
 auto block = manager.acquire_for_publish();
+if (!block) {
+  return;
+}
 launch_gpu_work(block->device_ptr(), stream);
 
 auto descriptor = block->prepare_publish(stream);

--- a/doc/buffer_metadata_protocol.md
+++ b/doc/buffer_metadata_protocol.md
@@ -2,7 +2,7 @@
 
 ## 1. 目的と適用範囲
 
-この文書は、`ros2_cuda_ipc` が GPU buffer slot を Publisher と Subscriber の複数
+この文書は、`ros2_cuda_ipc` が GPU buffer block を Publisher と Subscriber の複数
 process 間で安全に再利用するための buffer metadata protocol を定義する。
 
 この protocol は、古い message や処理中の Subscriber が参照する GPU buffer を
@@ -13,11 +13,11 @@ Publisher 再起動後の状態引き継ぎは対象外である。
 
 | 用語 | 定義 |
 | --- | --- |
-| slot | GPU buffer、ready event、共有 buffer reference metadata の組 |
-| generation | slot が publish 用に取得されるたびに増加する世代番号 |
-| reservation | Publisher が保持する `slot_id` と `generation` |
+| block | GPU buffer、ready event、共有 buffer reference metadata の組 |
+| uid | block が publish 用に取得されるたびに増加する世代番号 |
+| reservation | Publisher が保持する `block_id` と `uid` |
 | refcount | Subscriber buffer reference と Publisher reservation の合計参照数 |
-| grace period | publish 後に slot を再利用しない固定期間（100 ms） |
+| grace period | publish 後に block を再利用しない固定期間（100 ms） |
 | buffer reference | Subscriber が buffer を読み取り中であることを表す RAII 所有権 |
 
 `pending` や ROS subscription count は buffer metadata protocol の状態として使用しない。実際に
@@ -31,7 +31,7 @@ Publisher process
     GpuBufferPool       GPU allocation と ready event を所有
     BufferMetadataManager        reservation と publish lifecycle を管理
       BufferRef       process-shared metadata を操作
-    PublishSlot         1回の publish 試行を表す move-only object
+    PublishBlock         1回の publish 試行を表す move-only object
 
 Subscriber process
   BufferMapper
@@ -42,22 +42,22 @@ Subscriber process
 Publisher は次の順で API を使用する。
 
 ```cpp
-auto slot = manager.acquire_for_publish();
-launch_gpu_work(slot->device_ptr(), stream);
-auto descriptor = slot->prepare_publish(stream);
+auto block = manager.acquire_for_publish();
+launch_gpu_work(block->device_ptr(), stream);
+auto descriptor = block->prepare_publish(stream);
 if (!descriptor) {
   return;
 }
 publisher->publish(make_message(descriptor.value()));
 ```
 
-## 4. Process-shared slot state
+## 4. Process-shared block state
 
-各 slot は POSIX shared memory 上に次の metadata を持つ。
+各 block は POSIX shared memory 上に次の metadata を持つ。
 
 ```cpp
-struct SlotMetadata {
-  std::atomic<uint32_t> generation;
+struct BlockMetadata {
+  std::atomic<uint32_t> uid;
   std::atomic<uint32_t> refcount;
   std::atomic<uint64_t> publish_timestamp_us;
 };
@@ -67,13 +67,13 @@ shared-memory layout version は5である。attach 時には magic、layout ver
 Publisher instance ID を検証する。
 
 各atomicは対象platformでlock-freeであることを要求し、Publisherがshared memoryを作成
-するときに`SlotMetadata`をplacement newで構築する。Subscriberは既存のslotを再構築せずに
+するときに`BlockMetadata`をplacement newで構築する。Subscriberは既存のblockを再構築せずに
 attachする。
 
 `publish_timestamp_us` は `steady_clock` のマイクロ秒値で、最後に成功した
-`prepare_publish()` の commit 時刻を表す。0 はまだ commit されていない slot を表す。
+`prepare_publish()` の commit 時刻を表す。0 はまだ commit されていない block を表す。
 
-slot の再利用条件は次である。
+block の再利用条件は次である。
 
 ```text
 refcount == 0 &&
@@ -81,25 +81,25 @@ refcount == 0 &&
  now_us - publish_timestamp_us >= 100000)
 ```
 
-`reserved` のような別の排他 flag は持たない。Publisher が slot を取得するときに
+`reserved` のような別の排他 flag は持たない。Publisher が block を取得するときに
 `refcount` を CAS で `0 -> 1` に変更し、その1件を Publisher reservation として扱う。
 
 ## 5. Publisher workflow
 
 ### 5.1 reserve
 
-`acquire_for_publish()` は round-robin で候補を探索し、各 slot に対して次を行う。
+`acquire_for_publish()` は round-robin で候補を探索し、各 block に対して次を行う。
 
 1. `refcount == 0` を確認する。
 2. timestamp が0、または publish から100 ms以上経過していることを確認する。
 3. `refcount` を CAS で `0 -> 1` に変更する。
 4. CAS に失敗したら次の候補へ進む。
-5. `generation` を1増加する。
+5. `uid` を1増加する。
 6. `publish_timestamp_us` を0へ戻す。
 7. reservation を返す。
 
-Publisher reservation が存在する間は、別の Publisher が同じ slot を取得できない。
-Subscriber は `refcount != 0` だけを理由に拒否せず、generation の前後再確認で Publisher
+Publisher reservation が存在する間は、別の Publisher が同じ block を取得できない。
+Subscriber は `refcount != 0` だけを理由に拒否せず、uid の前後再確認で Publisher
 との競合を検出する。
 
 ### 5.2 GPU work と ready event
@@ -109,37 +109,37 @@ CUDA stream で `prepare_publish()` を呼ぶ。この操作は descriptor を�
 を記録し、Publisher reservation を commit してから descriptor を返す。commit は次の
 処理を行う。
 
-1. reservation の generation が現在の generation と一致することを確認する。
+1. reservation の uid が現在の uid と一致することを確認する。
 2. `publish_timestamp_us` を現在時刻へ更新する。
 3. Publisher reservation の `refcount` を1減少させる。
 
-commit は Publisher reservation を解放する。Subscriber buffer reference が残っていれば slot は
-再利用できない。`prepare_publish()` 後の middleware publish 結果は slot lifecycle へ
+commit は Publisher reservation を解放する。Subscriber buffer reference が残っていれば block は
+再利用できない。`prepare_publish()` 後の middleware publish 結果は block lifecycle へ
 反映されない。descriptor が middleware へ渡されなかった場合も通常の再利用条件に従う。
 
 準備処理のいずれかが失敗した場合、`prepare_publish()` は descriptor を返さない。
-その slot の reservation は解放せず、`GpuBufferManager::reset()` まで再利用しない。
+その block の reservation は解放せず、`GpuBufferManager::reset()` まで再利用しない。
 library は自動回復を行わない。
 
 ### 5.3 cancel
 
-`prepare_publish()` 前に `PublishSlot` を破棄するか `cancel()` を呼ぶと、Publisher
+`prepare_publish()` 前に `PublishBlock` を破棄するか `cancel()` を呼ぶと、Publisher
 reservation の `refcount` だけを減少させる。cancel では publish timestamp を更新しないため、
-未公開の reservation は grace period を追加で発生させない。準備に失敗した slot は既に
+未公開の reservation は grace period を追加で発生させない。準備に失敗した block は既に
 再利用禁止になっているため、destructor と `cancel()` は reservation を解放しない。
 
 ## 6. Subscriber acquire と release
 
-Subscriber は message の `shm_name`、`publisher_instance_id`、`slot_id`、`generation`
+Subscriber は message の `shm_name`、`publisher_instance_id`、`block_id`、`uid`
 を使って buffer reference を取得する。
 
 acquire は次を行う。
 
-1. shared memory へ attach し、layout と slot 範囲を検証する。
+1. shared memory へ attach し、layout と block 範囲を検証する。
 2. Publisher instance ID を検証する。
-3. message の generation と slot の generation を確認する。
+3. message の uid と block の uid を確認する。
 4. `refcount` を CAS で1増加する。
-5. generation を再確認する。
+5. uid を再確認する。
 6. 再確認に失敗した場合は refcount を戻して失敗する。
 7. 成功したら内部の buffer reference を保持する `ReadHandle` を返す。
 
@@ -155,8 +155,8 @@ completion eventの記録が完了するまで有効でなければならない�
 
 ## 7. Publisher/Subscriber 競合の安全性
 
-Publisher が先に refcount を claim した場合、Subscriber が古い generation を使って
-refcount を増加できても、generation の再確認に失敗して refcount を戻す。
+Publisher が先に refcount を claim した場合、Subscriber が古い uid を使って
+refcount を増加できても、uid の再確認に失敗して refcount を戻す。
 
 Subscriber が先に refcount を増加した場合、Publisher の `0 -> 1` CAS が失敗する。
 
@@ -164,33 +164,33 @@ Subscriber が先に refcount を増加した場合、Publisher の `0 -> 1` CAS
 Publisher                              Subscriber
 
 refcount 0 -> 1 を CAS
-generation を更新
-                                        generation を確認
+uid を更新
+                                        uid を確認
                                         refcount を増加
-                                        generation を再確認
+                                        uid を再確認
                                         失敗時は refcount を減少
 publish_timestamp_us を更新
 Publisher ref を解放
 ```
 
-この手順により、Publisher が slot を再利用する一方で古い generation の Subscriber
+この手順により、Publisher が block を再利用する一方で古い uid の Subscriber
 buffer reference が成立することを防ぐ。
 
 ## 8. 失敗時の挙動と既知の制約
 
 | failure | behavior |
 | --- | --- |
-| reusable slot がない | Publisher の acquire が失敗する |
+| reusable block がない | Publisher の acquire が失敗する |
 | GPU resource 初期化失敗 | 作成済み resource を rollback する |
 | preparation 失敗 | reservation を保持し、manager reset まで再利用しない |
-| generation mismatch | Subscriber acquire または reservation 完了を失敗させる |
-| Subscriber process crash | refcount が残り、slot が再利用不能になる可能性がある |
-| 100 ms を超える message 遅延 | slot 再利用後は generation mismatch で drop される可能性がある |
+| uid mismatch | Subscriber acquire または reservation 完了を失敗させる |
+| Subscriber process crash | refcount が残り、block が再利用不能になる可能性がある |
+| 100 ms を超える message 遅延 | block 再利用後は uid mismatch で drop される可能性がある |
 
-固定 grace period は配送保証ではない。publish rate、最大 Subscriber 遅延、slot 数に
+固定 grace period は配送保証ではない。publish rate、最大 Subscriber 遅延、block 数に
 応じて、遅延 message を drop し得る安全側の設計である。
 
-`generation` は wire format と shared state の `uint32_t` を維持する。wraparound 時に
+`uid` は wire format と shared state の `uint32_t` を維持する。wraparound 時に
 非常に古い message と一致する可能性があるため、必要なら Publisher instance と shared
 memory pool を再生成する。
 

--- a/doc/buffer_metadata_protocol.md
+++ b/doc/buffer_metadata_protocol.md
@@ -43,6 +43,9 @@ Publisher は次の順で API を使用する。
 
 ```cpp
 auto block = manager.acquire_for_publish();
+if (!block) {
+  return;
+}
 launch_gpu_work(block->device_ptr(), stream);
 auto descriptor = block->prepare_publish(stream);
 if (!descriptor) {

--- a/doc/design-buffer-view-history.md
+++ b/doc/design-buffer-view-history.md
@@ -6,14 +6,14 @@
 ## 背景
 
 以前の Subscriber API は、`BufferCore` を import した結果をコピー可能な
-`BufferView` として返していた。`BufferView` は device pointer、byte size、slot の
+`BufferView` として返していた。`BufferView` は device pointer、byte size、block の
 識別情報、imported resource、`LeaseHandle` をまとめて保持し、画像と点群の view は
 これを内包していた。
 
 このモデルでは、producer ready event の wait は `enqueue_ready_event(stream)` を
 呼び出す利用者の責務であり、view の生存期間が publication lease の生存期間でもあった。
 そのため、GPU work を enqueue した直後に view が破棄されると、consumer work が完了する
-前に slot が再利用され得るという制約があった。
+前に block が再利用され得るという制約があった。
 
 ## `ReadHandle` への移行理由
 

--- a/doc/design.md
+++ b/doc/design.md
@@ -9,10 +9,10 @@ history 文書は現行 API の仕様ではないため、実装変更時の更�
 
 ROS 2 の通常のメッセージ配送を使いながら、GPU payload 自体を CPU または
 Subscriber プロセスへコピーせずに共有する。メッセージには payload の識別子と
-レイアウトメタデータを載せ、実際の GPU resource と slot lifetime は core が管理する。
+レイアウトメタデータを載せ、実際の GPU resource と block lifetime は core が管理する。
 
 現在の transport は CUDA VMM + shareable FD を唯一の memory sharing backend とする。
-- 固定 slot pool と shared-memory buffer reference による publisher/subscriber 間の lifetime 管理
+- 固定 block pool と shared-memory buffer reference による publisher/subscriber 間の lifetime 管理
 - C++ の raw pointer API、画像／点群の typed adapter、Python の GpuImage/DLPack adapter
 
 CPU fallback、Python publisher、任意の ROS message の自動変換はこの設計の範囲外である。
@@ -27,7 +27,41 @@ Python adapter の詳細は [doc/python-subscriber-implementation.md](python-sub
 | `BufferMapper` | `BufferCore` を import し、consumer stream に bind した read を作る mapper |
 | `ReadHandle` | 一つの GPU read の所有者。imported resource と buffer reference を保持する move-only handle |
 | `ImageView` / `PointCloud2View` | `ReadHandle` に画像／点群メタデータを付加する move-only typed adapter |
-| buffer reference | shared-memory slot の refcount を保持し、publisher による再利用を防ぐ subscriber 側の所有権 |
+| buffer reference | shared-memory block の refcount を保持し、publisher による再利用を防ぐ subscriber 側の所有権 |
+
+### Blockモデル
+
+`GpuBufferBlock` は、1つのGPU allocation、export可能なmemory handle、CUDA
+synchronization object、およびそのallocationに対応する再利用identityをひとまとまりで
+表す。`BlockMetadata` は同じblockに対応するPool shared memory内の共有lifetime stateであり、
+publication identity (`uid`) とrefcountを保持する。
+
+`GpuBufferPool` はwire protocol上のオブジェクトではない。これはPublisher内部で
+`GpuBufferBlock` の確保・破棄・再利用を管理するローカルなimplementation detailであり、
+Subscriberから参照されることはない。Subscriberが参照するresource identityは、descriptorの
+`publisher_instance_id`、`block_id`、`uid` と、対応する `BlockMetadata` で表される。
+
+```text
+Publisher process                                      Subscriber process
+
+GpuBufferManager                                      BufferMapper
+  ├─ GpuBufferPool                                    ├─ BufferMetadataCache
+  │    ├─ GpuBufferBlock                              │    └─ BlockMetadata[] (mapped)
+  │    │    ├─ GPU allocation                         ├─ BufferRef
+  │    │    ├─ exportable memory handle                └─ ReadHandle
+  │    │    └─ CUDA synchronization objects                 └─ imported GPU resource
+  └─ BufferMetadataManager
+       └─ Pool shared memory
+            ├─ header
+            └─ BlockMetadata[]
+
+GpuBufferBlock + BlockMetadata + BufferDescriptor
+                         └─ one publication/resource identity
+```
+
+`BufferDescriptor` はGPU resourceを所有せず、上記identityとimportに必要なwire情報だけを
+運ぶ。Pool shared memoryはPoolごとに1つのPOSIX shared memoryを持ち、layoutは引き続き
+`header` と `BlockMetadata[]` の順序で構成される。
 
 公開 API の中心は次の関係である。
 
@@ -60,12 +94,12 @@ event、deferred release queue は lifetime を実装する内部要素であり
 | `shm_name` | buffer reference/refcount 用 POSIX shared memory 名 |
 | `publisher_instance_id` | publisher 初期化単位の識別子 |
 | `device_id` | allocation が存在する CUDA device |
-| `slot_id` | 固定 pool 内の slot |
-| `generation` | slot 上の publication 世代 |
+| `block_id` | 固定 pool 内の block |
+| `uid` | block 上の publication 世代 |
 | `byte_size` | GPU buffer の論理サイズ（bytes） |
 
-Subscriber は `publisher_instance_id`、`slot_id`、`generation` を検証してから buffer reference を取得する。
-同じ `slot_id` でも publisher instance または generation が異なる publication は別物として扱う。
+Subscriber は `publisher_instance_id`、`block_id`、`uid` を検証してから buffer reference を取得する。
+同じ `block_id` でも publisher instance または uid が異なる publication は別物として扱う。
 
 ### typed message
 
@@ -81,18 +115,18 @@ Subscriber は `publisher_instance_id`、`slot_id`、`generation` を検証し�
 
 ## Memory sharing: VMM + FD
 
-Publisher は CUDA VMM allocation を slot ごとに作り、POSIX shareable FD を Unix domain socket
+Publisher は CUDA VMM allocation を block ごとに作り、POSIX shareable FD を Unix domain socket
 経由で配布する。`vmm_socket_path` には socket のパスを格納し、Subscriber はその socket に
 接続して FD を取得し、`cuMemImportFromShareableHandle`、map、access 設定を行う。ready event
 の配送は CUDA IPC event handle を使う。
 
 VMM resource の allocation、FD server、import 済み mapping の破棄は backend と resource
-cache の責務である。generation の更新だけで mapping を無条件に再作成せず、allocation または
+cache の責務である。uid の更新だけで mapping を無条件に再作成せず、allocation または
 publisher instance が変わった場合に resource identity を切り替える。
 
 ## Publisher の lifecycle
 
-Publisher は `GpuBufferManager` と `GpuBufferPool` で slot を管理する。
+Publisher は `GpuBufferManager` と `GpuBufferPool` で block を管理する。
 
 ```text
 acquire_for_publish()
@@ -105,10 +139,10 @@ acquire_for_publish()
 ```
 
 `prepare_publish()` が失敗した場合は descriptor を返さず、reservation は manager の
-reset まで再利用しない。publish 後の middleware の成否は slot の commit 状態を変えない。
+reset まで再利用しない。publish 後の middleware の成否は block の commit 状態を変えない。
 
-固定 grace period と generation は配送保証ではない。遅延した message は、slot 再利用後に
-generation mismatch として破棄される可能性がある。詳細な buffer metadata protocol と publisher／
+固定 grace period と uid は配送保証ではない。遅延した message は、block 再利用後に
+uid mismatch として破棄される可能性がある。詳細な buffer metadata protocol と publisher／
 subscriber race の不変条件は [doc/buffer_metadata_protocol.md](buffer_metadata_protocol.md) を正とする。
 
 ## Subscriber の lifecycle
@@ -124,7 +158,7 @@ std::optional<ros2_cuda_ipc_core::subscriber::ReadHandle> read =
 
 1. `publisher_instance_id` を検証する。
 2. `shm_name` に対応する buffer metadata mapping を取得または attach する。
-3. `slot_id` と `generation` を検証し、buffer reference を取得する。
+3. `block_id` と `uid` を検証し、buffer reference を取得する。
 4. `IpcHandleCache` から imported resource を取得する。未登録なら VMM-FD importer で import する。
 5. consumer stream に producer ready event の wait を enqueue する。
 6. imported resource と buffer reference を所有する `ReadHandle` を返す。
@@ -162,7 +196,7 @@ producer ready event
 ```
 
 したがって、consumer stream は対応する `ReadHandle` の破棄と completion event の record が
-完了するまで有効でなければならない。handle を破棄した時点で直ちに slot が再利用可能になる
+完了するまで有効でなければならない。handle を破棄した時点で直ちに block が再利用可能になる
 わけではない。
 
 ### typed adapter
@@ -196,12 +230,12 @@ raw pointer mapping と同じ API として扱わない。
 - `ReadHandle` の失敗理由は公開 API には含まれず、内部 log を確認する。
 - `ImageView::valid()` は resource mapping と画像 shape の基本条件を確認する。metadata の境界検証には `sanity_check()` を使う。
 - import cache と buffer metadata mapping cache は現時点で unbounded policy であり、LRU、TTL、Publisher instance 単位の自動 prune は行わない。
-- Publisher process crash や長時間の Subscriber 遅延では buffer reference が残り、slot が再利用できなくなる可能性がある。
+- Publisher process crash や長時間の Subscriber 遅延では buffer reference が残り、block が再利用できなくなる可能性がある。
 - CUDA context、CUDA stream、CUDA event の lifetime は caller／core の契約に従う必要がある。
 
 ## 設計変更時の参照先
 
 - 公開 API の概要と maintainer 向け手順: [DEVELOPING.md](../DEVELOPING.md)
-- buffer reference、generation、競合安全性: [doc/buffer_metadata_protocol.md](buffer_metadata_protocol.md)
+- buffer reference、uid、競合安全性: [doc/buffer_metadata_protocol.md](buffer_metadata_protocol.md)
 - Python／DLPack の ownership と stream semantics: [doc/python-subscriber-implementation.md](python-subscriber-implementation.md)
 - 実行例: [examples/multi_process_image_fanout/README.md](../examples/multi_process_image_fanout/README.md)

--- a/doc/python-subscriber-implementation.md
+++ b/doc/python-subscriber-implementation.md
@@ -29,8 +29,8 @@ Python側は次を担当する。
 
 C++ coreは次を担当する。
 
-- messageの検証とgenerationの確認
-- shared-memory slotのbuffer reference取得
+- messageの検証とuidの確認
+- shared-memory blockのbuffer reference取得
 - CUDA memory/eventのimportとcache
 - `ReadHandle`からのdevice pointer、ready wait、metadataの提供
 - completion event後のresource/buffer reference cleanup
@@ -56,10 +56,10 @@ Python ReadHandle
     -> native ReadHandle
         -> imported resource
         -> buffer reference
-            -> shared-memory slot reference
+            -> shared-memory block reference
 ```
 
-slotは、completion event後にdeferred queueがhandle固有のbuffer referenceを解放するまで
+blockは、completion event後にdeferred queueがhandle固有のbuffer referenceを解放するまで
 publisherから再利用されない。通常のPython `ReadHandle`の`close()`は、そのread
 stateを解放する。DLPack export後のtyped adapterは`close()`できない。
 
@@ -70,14 +70,14 @@ buffer referenceが維持される。
 ## Framework adapterの原則
 
 framework objectはraw device pointerだけを保持してはいけない。framework objectの
-lifetimeをnative viewへ接続し、slotの所有権を一方向に拡張する。
+lifetimeをnative viewへ接続し、blockの所有権を一方向に拡張する。
 
 ```text
 framework object
     -> retained native read state
         -> imported resource
         -> buffer reference
-            -> shared-memory slot
+            -> shared-memory block
 ```
 
 これはmemoryの所有権であり、CUDA kernelの完了通知ではない。capsule deleterは
@@ -113,7 +113,7 @@ framework tensor / array
         -> manager context / retained native read state
             -> imported CUDA resource
             -> buffer reference
-                -> shared-memory slot reference
+                -> shared-memory block reference
 ```
 
 capsuleがconsumerに渡された後はmanaged-tensor deleterがretained native read stateを
@@ -147,7 +147,7 @@ producerの書き込み完了を表し、capsule deleterがconsumer streamへの
 event recordを行う。利用者はframework objectと、bindしたstreamをcompletion record
 完了まで保持する必要がある。import cache entryの破棄方針はcacheが管理する。
 
-逆に、arrayを長く保持するとslot referenceも長く保持され、publisherが利用できるslot数を
+逆に、arrayを長く保持するとblock referenceも長く保持され、publisherが利用できるblock数を
 圧迫する可能性がある。stream完了に合わせた自動buffer reference releaseや、同期を伴う
 context managerは今後のAPI設計課題である。
 
@@ -169,7 +169,7 @@ CPU fallback、PointCloud2は対象外である。
 ## エラーと実行モデル
 
 - descriptorの型・field・layout不正はPythonの入力エラーとして扱う
-- stale generation、buffer reference取得失敗、CUDA import失敗はmapping failureとして扱う
+- stale uid、buffer reference取得失敗、CUDA import失敗はmapping failureとして扱う
 - ready-event waitのCUDA failureはmapping failureと分けて扱う
 - Python messageの読み取りにはGILが必要だが、C++ mapperの重い処理はGILを解放できる
 - Python wrapperのdestructorからPython APIを呼び出さない
@@ -178,5 +178,5 @@ CPU fallback、PointCloud2は対象外である。
 
 Python callbackから既存のC++ buffer reference/resource modelを壊さずにzero-copyのGPU viewを
 取得し、framework固有のobjectへ一方向にownershipを拡張できることが到達点である。
-frameworkごとの使い勝手や非同期処理の完了管理は、slotの再利用条件を曖昧にしない
+frameworkごとの使い勝手や非同期処理の完了管理は、blockの再利用条件を曖昧にしない
 形で今後拡張する。

--- a/examples/multi_process_image_fanout/README.md
+++ b/examples/multi_process_image_fanout/README.md
@@ -79,12 +79,12 @@ ros2 launch multi_process_image_fanout multi_process_image_fanout.launch.py \
   width:=1280 \
   height:=720 \
   publish_rate_hz:=60.0 \
-  slot_count:=4 \
+  block_count:=4 \
   shm_name_prefix:=/ros2_cuda_ipc_fanout \
   device_index:=0
 ```
 
-The `width`, `height`, and `slot_count`,
+The `width`, `height`, and `block_count`,
 `shm_name_prefix`, and `device_index` arguments are publisher-side pseudo-camera
 parameters.
 
@@ -132,7 +132,7 @@ ros2 launch multi_process_image_fanout multi_process_image_fanout.launch.py \
 This wraps each process with `nsys profile` and writes separate reports named
 `fanout-<arch>-<width>x<height>-<rate>-<label>-<node>`. Override
 `nsys_profile_flags` to change the default `--trace=osrt,nvtx,cuda` flags.
-Nsight Systems should show NVTX ranges for slot acquisition, producer kernel
+Nsight Systems should show NVTX ranges for block acquisition, producer kernel
 work, input event waits, preview image copy, encoder-like kernels, and
 inference-like kernels. A large device-to-host image copy should appear only in
 `preview_node`.

--- a/examples/multi_process_image_fanout/doc/design.md
+++ b/examples/multi_process_image_fanout/doc/design.md
@@ -249,7 +249,7 @@ Expected profiler result:
 * NVTX ranges appear for all four nodes.
 * Publisher process shows:
   * block acquisition
-* pattern-producing kernel
+  * pattern-producing kernel
   * CUDA event record
 * Preview process shows:
   * input event wait

--- a/examples/multi_process_image_fanout/doc/design.md
+++ b/examples/multi_process_image_fanout/doc/design.md
@@ -248,8 +248,8 @@ Expected profiler result:
 
 * NVTX ranges appear for all four nodes.
 * Publisher process shows:
-  * slot acquisition
-  * pattern generation kernel
+  * block acquisition
+* pattern-producing kernel
   * CUDA event record
 * Preview process shows:
   * input event wait

--- a/examples/multi_process_image_fanout/include/multi_process_image_fanout/kernels.hpp
+++ b/examples/multi_process_image_fanout/include/multi_process_image_fanout/kernels.hpp
@@ -20,7 +20,7 @@ struct InferenceStats {
 constexpr uint32_t kDefaultChannels = 4;
 constexpr const char* kDefaultEncoding = "rgba8";
 
-// gpu_image_publisher: fills the referenced GPU slot with the animated RGBA
+// gpu_image_publisher: fills the referenced GPU block with the animated RGBA
 // test pattern consumed by all downstream example nodes.
 cudaError_t launch_generate_rgba_pattern_kernel(uint8_t* output, int width,
                                                 int height,

--- a/examples/multi_process_image_fanout/launch/multi_process_image_fanout.launch.py
+++ b/examples/multi_process_image_fanout/launch/multi_process_image_fanout.launch.py
@@ -26,7 +26,7 @@ def generate_launch_description() -> LaunchDescription:
         DeclareLaunchArgument("height", default_value="1080"),
         DeclareLaunchArgument("device_index", default_value="0"),
         DeclareLaunchArgument("frame_id", default_value="fanout_camera_frame"),
-        DeclareLaunchArgument("slot_count", default_value="4"),
+        DeclareLaunchArgument("block_count", default_value="4"),
         DeclareLaunchArgument(
             "shm_name_prefix", default_value="/ros2_cuda_ipc_fanout"
         ),
@@ -65,7 +65,7 @@ def launch_setup(context) -> List[Node]:
     height_value = as_int("height")
 
     publish_rate = as_float("publish_rate_hz")
-    slot_count = as_int("slot_count")
+    block_count = as_int("block_count")
     device_index = as_int("device_index")
     image_topic = value("image_topic")
     preview_topic = value("preview_topic")
@@ -97,7 +97,7 @@ def launch_setup(context) -> List[Node]:
                 "width": width_value,
                 "height": height_value,
                 "frame_id": value("frame_id"),
-                "slot_count": slot_count,
+                "block_count": block_count,
                 "shm_name_prefix": value("shm_name_prefix"),
                 "device_index": device_index,
             }

--- a/examples/multi_process_image_fanout/src/gpu_image_publisher.cpp
+++ b/examples/multi_process_image_fanout/src/gpu_image_publisher.cpp
@@ -39,7 +39,7 @@ class GpuImagePublisherNode : public rclcpp::Node {
             declare_parameter<std::string>("topic_name", "/fanout/image_gpu")) {
     const int width = declare_parameter<int>("width", 1920);
     const int height = declare_parameter<int>("height", 1080);
-    const int slot_count_parameter = declare_parameter<int>("slot_count", 4);
+    const int block_count_parameter = declare_parameter<int>("block_count", 4);
     const auto shm_name_prefix = declare_parameter<std::string>(
         "shm_name_prefix", "/ros2_cuda_ipc_fanout");
     const int device_index = declare_parameter<int>("device_index", 0);
@@ -48,12 +48,12 @@ class GpuImagePublisherNode : public rclcpp::Node {
     if (width <= 0 || height <= 0) {
       throw std::runtime_error("width and height must be greater than zero");
     }
-    if (slot_count_parameter <= 0) {
-      throw std::runtime_error("slot_count must be greater than zero");
+    if (block_count_parameter <= 0) {
+      throw std::runtime_error("block_count must be greater than zero");
     }
     width_ = static_cast<uint32_t>(width);
     height_ = static_cast<uint32_t>(height);
-    const auto slot_count = static_cast<std::size_t>(slot_count_parameter);
+    const auto block_count = static_cast<std::size_t>(block_count_parameter);
 
     throw_on_cuda_error(cudaSetDevice(device_index), "cudaSetDevice");
     const uint64_t frame_size_bytes =
@@ -61,7 +61,7 @@ class GpuImagePublisherNode : public rclcpp::Node {
     manager_ =
         std::make_unique<ros2_cuda_ipc_core::publisher::GpuBufferManager>(
             ros2_cuda_ipc_core::publisher::GpuBufferManager::Config{
-                shm_name_prefix, slot_count, frame_size_bytes, device_index});
+                shm_name_prefix, block_count, frame_size_bytes, device_index});
     if (!manager_->initialise()) {
       throw std::runtime_error("Failed to initialise GPU buffer manager");
     }
@@ -91,8 +91,8 @@ class GpuImagePublisherNode : public rclcpp::Node {
     }
 
     RCLCPP_INFO(get_logger(),
-                "Publishing fanout GPU image %ux%u on %s with %zu slots",
-                width_, height_, topic_name_.c_str(), slot_count);
+                "Publishing fanout GPU image %ux%u on %s with %zu blocks",
+                width_, height_, topic_name_.c_str(), block_count);
   }
 
   ~GpuImagePublisherNode() override {
@@ -111,15 +111,15 @@ class GpuImagePublisherNode : public rclcpp::Node {
   void on_timer() {
     NvtxScopedRange timer_range("GpuImagePublisherNode::on_timer");
 
-    std::optional<ros2_cuda_ipc_core::publisher::PublishSlot> slot;
+    std::optional<ros2_cuda_ipc_core::publisher::PublishBlock> block;
     {
-      NvtxScopedRange acquire_range("GpuImagePublisherNode::acquire_slot");
-      slot = manager_->acquire_for_publish();
+      NvtxScopedRange acquire_range("GpuImagePublisherNode::acquire_block");
+      block = manager_->acquire_for_publish();
     }
-    if (!slot) {
+    if (!block) {
       RCLCPP_WARN_THROTTLE(
           get_logger(), *get_clock(), 2000,
-          "No available GPU slots (all buffer references in use)");
+          "No available GPU blocks (all buffer references in use)");
       return;
     }
 
@@ -128,7 +128,7 @@ class GpuImagePublisherNode : public rclcpp::Node {
       NvtxScopedRange kernel_range(
           "GpuImagePublisherNode::generate_rgba_pattern_kernel");
       error = launch_generate_rgba_pattern_kernel(
-          static_cast<uint8_t*>(slot->device_ptr()), static_cast<int>(width_),
+          static_cast<uint8_t*>(block->device_ptr()), static_cast<int>(width_),
           static_cast<int>(height_), width_ * kBytesPerPixel, frame_index_,
           stream_);
     }
@@ -139,7 +139,7 @@ class GpuImagePublisherNode : public rclcpp::Node {
 
     NvtxScopedRange prepare_publish_range(
         "GpuImagePublisherNode::prepare_publish");
-    auto descriptor = slot->prepare_publish(stream_);
+    auto descriptor = block->prepare_publish(stream_);
     if (!descriptor) {
       RCLCPP_WARN(get_logger(), "prepare_publish failed: %s",
                   descriptor.error().to_string().c_str());

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_backend.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/backend/memory_backend.hpp
@@ -15,33 +15,33 @@
 namespace ros2_cuda_ipc_core::backend {
 
 /**
- * @brief Private VMM-FD allocation state owned by a publisher slot.
+ * @brief Private VMM-FD allocation state owned by a publisher block.
  *
  * The definition remains in the implementation file so Unix-socket and CUDA
- * VMM details are not exposed through this public header.  SlotResources owns
+ * VMM details are not exposed through this public header.  GpuBufferBlock owns
  * it with unique_ptr; consequently its destructor and move operations are
- * defined out of line, where VmmFdSlotState is complete and default_delete can
+ * defined out of line, where VmmFdBlockState is complete and default_delete can
  * destroy it.
  */
-struct VmmFdSlotState;
+struct VmmFdBlockState;
 
-struct SlotResources {
-  SlotResources();
-  ~SlotResources();
-  SlotResources(const SlotResources&) = delete;
-  SlotResources& operator=(const SlotResources&) = delete;
-  SlotResources(SlotResources&&) noexcept;
-  SlotResources& operator=(SlotResources&&) noexcept;
+struct GpuBufferBlock {
+  GpuBufferBlock();
+  ~GpuBufferBlock();
+  GpuBufferBlock(const GpuBufferBlock&) = delete;
+  GpuBufferBlock& operator=(const GpuBufferBlock&) = delete;
+  GpuBufferBlock(GpuBufferBlock&&) noexcept;
+  GpuBufferBlock& operator=(GpuBufferBlock&&) noexcept;
 
   uint32_t index = 0;
   void* device_ptr = nullptr;
   std::unique_ptr<detail::InterprocessEvent> ready_event;
   std::string vmm_socket_path;
-  std::unique_ptr<VmmFdSlotState> vmm_fd_state;
+  std::unique_ptr<VmmFdBlockState> vmm_fd_state;
 };
 
 bool allocate_vmm_fd_memory(uint64_t byte_size, int device_index,
-                            std::vector<SlotResources>& slots);
-void destroy_vmm_fd_memory(std::vector<SlotResources>& slots) noexcept;
+                            std::vector<GpuBufferBlock>& blocks);
+void destroy_vmm_fd_memory(std::vector<GpuBufferBlock>& blocks) noexcept;
 
 }  // namespace ros2_cuda_ipc_core::backend

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/buffer_metadata/buffer_metadata.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/buffer_metadata/buffer_metadata.hpp
@@ -13,17 +13,17 @@
 
 namespace ros2_cuda_ipc_core::buffer_metadata {
 
-/// Metadata for one slot in the shared-memory buffer metadata pool.
-struct SlotMetadata {
-  std::atomic<uint32_t> generation{0};
+/// Metadata for one block in the shared-memory buffer metadata pool.
+struct BlockMetadata {
+  std::atomic<uint32_t> uid{0};
   std::atomic<uint32_t> refcount{0};
   std::atomic<uint64_t> publish_timestamp_us{0};
 };
 
 static_assert(std::atomic<uint32_t>::is_always_lock_free);
 static_assert(std::atomic<uint64_t>::is_always_lock_free);
-static_assert(sizeof(SlotMetadata) == 16);
-static_assert(alignof(SlotMetadata) >= alignof(std::atomic<uint64_t>));
+static_assert(sizeof(BlockMetadata) == 16);
+static_assert(alignof(BlockMetadata) >= alignof(std::atomic<uint64_t>));
 
 /// Owns one POSIX shared-memory mapping.
 ///
@@ -37,7 +37,7 @@ class BufferMetadata {
   ///
   /// @param shm_name POSIX shared-memory name.
   /// @param instance_id Publisher instance identity stored in the header.
-  /// @param capacity Number of slots to allocate.
+  /// @param capacity Number of blocks to allocate.
   /// @return Owning mapping, or nullptr when creation or initialization fails.
   static std::shared_ptr<BufferMetadata> create(
       const std::string& shm_name, const PublisherInstanceId& instance_id,
@@ -64,10 +64,10 @@ class BufferMetadata {
     return publisher_instance_id_;
   }
   uint32_t capacity() const noexcept { return capacity_; }
-  SlotMetadata* slot(uint32_t slot_id) noexcept {
-    return slot_id < capacity_ ? &slots_[slot_id] : nullptr;
+  BlockMetadata* block(uint32_t block_id) noexcept {
+    return block_id < capacity_ ? &blocks_[block_id] : nullptr;
   }
-  std::atomic<uint32_t>& next_slot() noexcept { return next_slot_; }
+  std::atomic<uint32_t>& next_block() noexcept { return next_block_; }
 
  private:
   BufferMetadata() = default;
@@ -77,8 +77,8 @@ class BufferMetadata {
   uint32_t capacity_ = 0;
   std::size_t mapped_size_ = 0;
   void* addr_ = nullptr;
-  SlotMetadata* slots_ = nullptr;
-  std::atomic<uint32_t> next_slot_{0};
+  BlockMetadata* blocks_ = nullptr;
+  std::atomic<uint32_t> next_block_{0};
 };
 
 }  // namespace ros2_cuda_ipc_core::buffer_metadata

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/buffer_metadata/buffer_ref.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/buffer_metadata/buffer_ref.hpp
@@ -16,25 +16,25 @@ class BufferRef {
  public:
   struct PublisherReservation {
     std::shared_ptr<BufferMetadata> mapping;
-    uint32_t slot_id = 0;
-    uint32_t generation = 0;
+    uint32_t block_id = 0;
+    uint32_t uid = 0;
   };
 
-  static std::optional<uint32_t> current_generation(
-      const std::shared_ptr<BufferMetadata>& mapping, uint32_t slot_id);
+  static std::optional<uint32_t> current_uid(
+      const std::shared_ptr<BufferMetadata>& mapping, uint32_t block_id);
   static std::optional<uint32_t> current_refcount(
-      const std::shared_ptr<BufferMetadata>& mapping, uint32_t slot_id);
+      const std::shared_ptr<BufferMetadata>& mapping, uint32_t block_id);
   static std::optional<uint64_t> current_publish_timestamp_us(
-      const std::shared_ptr<BufferMetadata>& mapping, uint32_t slot_id);
+      const std::shared_ptr<BufferMetadata>& mapping, uint32_t block_id);
 
   static std::optional<PublisherReservation> reserve_for_publish(
       const std::shared_ptr<BufferMetadata>& mapping);
   static bool commit_publish(const std::shared_ptr<BufferMetadata>& mapping,
-                             uint32_t slot_id, uint32_t generation) noexcept;
+                             uint32_t block_id, uint32_t uid) noexcept;
   static bool cancel_publish(const std::shared_ptr<BufferMetadata>& mapping,
-                             uint32_t slot_id, uint32_t generation) noexcept;
+                             uint32_t block_id, uint32_t uid) noexcept;
   static BufferRef acquire(const std::shared_ptr<BufferMetadata>& mapping,
-                           uint32_t slot_id, uint32_t generation);
+                           uint32_t block_id, uint32_t uid);
 
   ~BufferRef();
 
@@ -43,21 +43,21 @@ class BufferRef {
   BufferRef(const BufferRef&) = delete;
   BufferRef& operator=(const BufferRef&) = delete;
 
-  bool valid() const noexcept { return slot_meta_ != nullptr; }
-  uint32_t slot_id() const noexcept { return slot_id_; }
-  uint32_t generation() const noexcept { return generation_; }
+  bool valid() const noexcept { return block_meta_ != nullptr; }
+  uint32_t block_id() const noexcept { return block_id_; }
+  uint32_t uid() const noexcept { return uid_; }
 
  private:
   BufferRef() = default;
-  BufferRef(std::shared_ptr<BufferMetadata> mapping, SlotMetadata* slot,
-            uint32_t slot_id, uint32_t generation);
+  BufferRef(std::shared_ptr<BufferMetadata> mapping, BlockMetadata* block,
+            uint32_t block_id, uint32_t uid);
 
   void release() noexcept;
 
   std::shared_ptr<BufferMetadata> mapping_;
-  SlotMetadata* slot_meta_ = nullptr;
-  uint32_t slot_id_ = 0;
-  uint32_t generation_ = 0;
+  BlockMetadata* block_meta_ = nullptr;
+  uint32_t block_id_ = 0;
+  uint32_t uid_ = 0;
 };
 
 }  // namespace ros2_cuda_ipc_core::buffer_metadata

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/buffer_metadata_manager.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/buffer_metadata_manager.hpp
@@ -18,13 +18,15 @@ class BufferMetadataManager {
  public:
   struct Reservation {
     std::shared_ptr<buffer_metadata::BufferMetadata> mapping;
-    uint32_t slot_id = 0;
-    uint32_t generation = 0;
+    uint32_t block_id = 0;
+    uint32_t uid = 0;
     std::string shm_name;
     PublisherInstanceId publisher_instance_id{};
   };
 
-  BufferMetadataManager(std::string shm_name_prefix, std::size_t slot_count);
+  /// Owns the publisher-local POSIX mapping containing BlockMetadata[].
+  /// It is not part of the transport wire protocol.
+  BufferMetadataManager(std::string shm_name_prefix, std::size_t block_count);
 
   ~BufferMetadataManager();
 
@@ -42,7 +44,7 @@ class BufferMetadataManager {
   std::string shm_name_prefix_;
   std::string shm_name_;
   PublisherInstanceId publisher_instance_id_{};
-  std::size_t slot_count_;
+  std::size_t block_count_;
   mutable std::mutex mutex_;
   std::shared_ptr<buffer_metadata::BufferMetadata> mapping_;
   bool initialised_ = false;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_manager.hpp
@@ -20,34 +20,34 @@ class GpuBufferManager;
 
 /// Represents one active publish attempt.
 ///
-/// The owning GpuBufferManager must outlive every PublishSlot created from
-/// it. Calling GpuBufferManager::reset() invalidates slot resource
+/// The owning GpuBufferManager must outlive every PublishBlock created from
+/// it. Calling GpuBufferManager::reset() invalidates block resource
 /// operations. Destruction cancels an ordinary uncommitted reservation, while
 /// a failed preparation intentionally retains its reservation until reset.
-class PublishSlot {
+class PublishBlock {
  public:
-  /// Move a publish slot while transferring ownership of its reservation.
-  PublishSlot(PublishSlot&& other) noexcept;
+  /// Move a publish block while transferring ownership of its reservation.
+  PublishBlock(PublishBlock&& other) noexcept;
 
   /// Cancel the current reservation, if any, before taking ownership of other.
-  PublishSlot& operator=(PublishSlot&& other) noexcept;
+  PublishBlock& operator=(PublishBlock&& other) noexcept;
 
-  PublishSlot(const PublishSlot&) = delete;
-  PublishSlot& operator=(const PublishSlot&) = delete;
+  PublishBlock(const PublishBlock&) = delete;
+  PublishBlock& operator=(const PublishBlock&) = delete;
 
   /// Cancel an ordinary uncommitted reservation on destruction.
-  ~PublishSlot() noexcept;
+  ~PublishBlock() noexcept;
 
-  /// Return the device pointer associated with the reserved slot.
+  /// Return the device pointer associated with the reserved block.
   ///
-  /// @return Device pointer when the slot is usable; nullptr otherwise.
+  /// @return Device pointer when the block is usable; nullptr otherwise.
   void* device_ptr() const noexcept;
 
   /// Build the descriptor, record the ready event, and commit the reservation.
   ///
   /// A successful return commits the Publisher reservation. A failed
-  /// preparation leaves the slot unavailable until GpuBufferManager::reset().
-  /// The subsequent middleware publish result does not affect slot lifecycle.
+  /// preparation leaves the block unavailable until GpuBufferManager::reset().
+  /// The subsequent middleware publish result does not affect block lifecycle.
   ///
   /// @return The descriptor when preparation and commit succeed; a failed
   /// result otherwise.
@@ -57,16 +57,16 @@ class PublishSlot {
   /// Cancel an active reservation. A failed preparation cannot be cancelled.
   void cancel() noexcept;
 
-  /// Check whether the slot can still be used for publishing.
+  /// Check whether the block can still be used for publishing.
   bool valid() const noexcept;
 
  private:
-  /// Allow the manager to construct slots only from valid reservations.
+  /// Allow the manager to construct blocks only from valid reservations.
   friend class GpuBufferManager;
 
-  PublishSlot(GpuBufferManager* owner,
-              BufferMetadataManager::Reservation reservation) noexcept;
-  void move_from(PublishSlot&& other) noexcept;
+  PublishBlock(GpuBufferManager* owner,
+               BufferMetadataManager::Reservation reservation) noexcept;
+  void move_from(PublishBlock&& other) noexcept;
   void quarantine(const char* step,
                   const detail::CudaDriverError* error = nullptr) noexcept;
 
@@ -74,7 +74,7 @@ class PublishSlot {
   BufferMetadataManager::Reservation reservation_{};
 };
 
-/// Owns the GPU buffer pool and shared-memory slot reservations used for
+/// Owns the GPU buffer pool and shared-memory block reservations used for
 /// publishing.
 class GpuBufferManager {
  public:
@@ -83,8 +83,8 @@ class GpuBufferManager {
     /// Prefix used to create a publisher-instance-specific shared-memory name.
     std::string shm_name_prefix;
 
-    /// Number of reusable GPU buffer slots.
-    std::size_t slot_count = 0;
+    /// Number of reusable GPU buffer blocks.
+    std::size_t block_count = 0;
 
     /// Size in bytes of each GPU buffer.
     uint64_t byte_size = 0;
@@ -121,15 +121,15 @@ class GpuBufferManager {
   /// Return the current publisher instance identity.
   PublisherInstanceId publisher_instance_id() const;
 
-  /// Reserve a slot for a new publish attempt.
-  /// @return A publish slot when a reservation is available; std::nullopt
+  /// Reserve a block for a new publish attempt.
+  /// @return A publish block when a reservation is available; std::nullopt
   /// otherwise.
-  [[nodiscard]] std::optional<PublishSlot> acquire_for_publish();
+  [[nodiscard]] std::optional<PublishBlock> acquire_for_publish();
 
  private:
-  /// Allow a slot to delegate resource operations to its owning manager
+  /// Allow a block to delegate resource operations to its owning manager
   /// without exposing those operations as part of the public manager API.
-  friend class PublishSlot;
+  friend class PublishBlock;
 
   void* device_ptr(
       const BufferMetadataManager::Reservation& reservation) const noexcept;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp
@@ -13,11 +13,15 @@
 
 namespace ros2_cuda_ipc_core::publisher {
 
+/// A single independently allocated GPU resource owned by a publisher pool.
+using GpuBufferBlock = backend::GpuBufferBlock;
+
 class GpuBufferPool {
  public:
-  using SlotResources = backend::SlotResources;
+  /// One independently allocated GPU resource managed by this local pool.
+  using GpuBufferBlock = backend::GpuBufferBlock;
 
-  explicit GpuBufferPool(std::size_t slot_count);
+  explicit GpuBufferPool(std::size_t block_count);
   ~GpuBufferPool();
 
   GpuBufferPool(const GpuBufferPool&) = delete;
@@ -29,21 +33,22 @@ class GpuBufferPool {
   void reset() noexcept;
   bool is_initialised() const noexcept { return initialised_; }
   bool matches(uint64_t byte_size, int device_index) const noexcept;
-  std::size_t size() const noexcept { return slots_.size(); }
+  std::size_t size() const noexcept { return blocks_.size(); }
   uint64_t byte_size() const noexcept { return byte_size_; }
   int device_index() const noexcept { return device_index_; }
 
-  void* device_ptr(uint32_t slot_id) const noexcept;
-  detail::CudaResult<void> record_ready(uint32_t slot_id,
+  void* device_ptr(uint32_t block_id) const noexcept;
+  detail::CudaResult<void> record_ready(uint32_t block_id,
                                         CUstream stream) noexcept;
-  const SlotResources* resources(uint32_t slot_id) const noexcept;
+  const GpuBufferBlock* resources(uint32_t block_id) const noexcept;
 
  private:
-  bool allocate_slots();
-  void destroy_slots() noexcept;
+  /// Pool is a publisher-local block allocation and reuse strategy.
+  bool allocate_blocks();
+  void destroy_blocks() noexcept;
 
-  std::size_t slot_count_;
-  std::vector<SlotResources> slots_;
+  std::size_t block_count_;
+  std::vector<GpuBufferBlock> blocks_;
   uint64_t byte_size_ = 0;
   int device_index_ = -1;
   bool initialised_ = false;

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp
@@ -13,9 +13,6 @@
 
 namespace ros2_cuda_ipc_core::publisher {
 
-/// A single independently allocated GPU resource owned by a publisher pool.
-using GpuBufferBlock = backend::GpuBufferBlock;
-
 class GpuBufferPool {
  public:
   /// One independently allocated GPU resource managed by this local pool.

--- a/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/transport/buffer_descriptor.hpp
+++ b/ros2_cuda_ipc_core/include/ros2_cuda_ipc_core/transport/buffer_descriptor.hpp
@@ -17,8 +17,8 @@ namespace ros2_cuda_ipc_core::transport {
 struct BufferDescriptor {
   std::string buffer_metadata_shm_name;
   PublisherInstanceId publisher_instance_id{};
-  uint32_t slot_id = 0;
-  uint32_t generation = 0;
+  uint32_t block_id = 0;
+  uint32_t uid = 0;
   int device_id = -1;
   uint64_t byte_size = 0;
   std::string vmm_socket_path;

--- a/ros2_cuda_ipc_core/src/backend/memory_backend.cpp
+++ b/ros2_cuda_ipc_core/src/backend/memory_backend.cpp
@@ -43,7 +43,7 @@ uint64_t align_up(uint64_t value, uint64_t alignment) {
  * @brief Helper that serves a shareable file descriptor over a Unix socket.
  *
  * The VMM backend exports CUDA memory as a POSIX FD. `UnixFdServer` listens on
- * an `AF_UNIX` socket (one per slot) and sends that FD to every client via
+ * an `AF_UNIX` socket (one per block) and sends that FD to every client via
  * `SCM_RIGHTS`. This isolates the POSIX details from the backend logic.
  */
 class UnixFdServer {
@@ -244,14 +244,14 @@ bool ensure_driver() {
 }  // namespace
 
 /**
- * @brief Runtime state for a VMM-backed slot (address, FD server, etc.).
+ * @brief Runtime state for a VMM-backed block (address, FD server, etc.).
  *
  * Owns the CUDA driver objects and POSIX FD server used to share the
  * allocation. Destruction tears down the mapping, frees the allocation, closes
  * the FD, and stops the Unix socket server.
  */
-struct VmmFdSlotState {
-  ~VmmFdSlotState() {
+struct VmmFdBlockState {
+  ~VmmFdBlockState() {
     if (server) {
       server->stop();
       server.reset();
@@ -277,13 +277,13 @@ struct VmmFdSlotState {
   std::unique_ptr<UnixFdServer> server;
 };
 
-SlotResources::SlotResources() = default;
-SlotResources::~SlotResources() = default;
-SlotResources::SlotResources(SlotResources&&) noexcept = default;
-SlotResources& SlotResources::operator=(SlotResources&&) noexcept = default;
+GpuBufferBlock::GpuBufferBlock() = default;
+GpuBufferBlock::~GpuBufferBlock() = default;
+GpuBufferBlock::GpuBufferBlock(GpuBufferBlock&&) noexcept = default;
+GpuBufferBlock& GpuBufferBlock::operator=(GpuBufferBlock&&) noexcept = default;
 
 bool allocate_vmm_fd_memory(uint64_t frame_size_bytes, int device_index,
-                            std::vector<SlotResources>& slots) {
+                            std::vector<GpuBufferBlock>& blocks) {
   if (!ensure_driver()) {
     return false;
   }
@@ -308,8 +308,8 @@ bool allocate_vmm_fd_memory(uint64_t frame_size_bytes, int device_index,
   }
 
   const uint64_t aligned_size = align_up(frame_size_bytes, granularity);
-  for (auto& slot : slots) {
-    auto state = std::make_unique<VmmFdSlotState>();
+  for (auto& block : blocks) {
+    auto state = std::make_unique<VmmFdBlockState>();
     state->allocation_size = aligned_size;
 
     CUdeviceptr address = 0;
@@ -319,7 +319,7 @@ bool allocate_vmm_fd_memory(uint64_t frame_size_bytes, int device_index,
       RCUTILS_LOG_ERROR_NAMED(
           "ros2_cuda_ipc_core.backend.vmm_fd", "cuMemAddressReserve failed: %s",
           ros2_cuda_ipc_core::detail::cu_result_to_string(res).c_str());
-      destroy_vmm_fd_memory(slots);
+      destroy_vmm_fd_memory(blocks);
       return false;
     }
     state->address = address;
@@ -330,7 +330,7 @@ bool allocate_vmm_fd_memory(uint64_t frame_size_bytes, int device_index,
       RCUTILS_LOG_ERROR_NAMED(
           "ros2_cuda_ipc_core.backend.vmm_fd", "cuMemCreate failed: %s",
           ros2_cuda_ipc_core::detail::cu_result_to_string(res).c_str());
-      destroy_vmm_fd_memory(slots);
+      destroy_vmm_fd_memory(blocks);
       return false;
     }
 
@@ -339,7 +339,7 @@ bool allocate_vmm_fd_memory(uint64_t frame_size_bytes, int device_index,
       RCUTILS_LOG_ERROR_NAMED(
           "ros2_cuda_ipc_core.backend.vmm_fd", "cuMemMap failed: %s",
           ros2_cuda_ipc_core::detail::cu_result_to_string(res).c_str());
-      destroy_vmm_fd_memory(slots);
+      destroy_vmm_fd_memory(blocks);
       return false;
     }
 
@@ -352,7 +352,7 @@ bool allocate_vmm_fd_memory(uint64_t frame_size_bytes, int device_index,
       RCUTILS_LOG_ERROR_NAMED(
           "ros2_cuda_ipc_core.backend.vmm_fd", "cuMemSetAccess failed: %s",
           ros2_cuda_ipc_core::detail::cu_result_to_string(res).c_str());
-      destroy_vmm_fd_memory(slots);
+      destroy_vmm_fd_memory(blocks);
       return false;
     }
 
@@ -366,7 +366,7 @@ bool allocate_vmm_fd_memory(uint64_t frame_size_bytes, int device_index,
           "ros2_cuda_ipc_core.backend.vmm_fd",
           "cuMemExportToShareableHandle failed: %s",
           ros2_cuda_ipc_core::detail::cu_result_to_string(res).c_str());
-      destroy_vmm_fd_memory(slots);
+      destroy_vmm_fd_memory(blocks);
       return false;
     }
     if (state->shareable_fd >= 0) {
@@ -388,23 +388,23 @@ bool allocate_vmm_fd_memory(uint64_t frame_size_bytes, int device_index,
     state->server =
         std::make_unique<UnixFdServer>(socket_path, state->shareable_fd);
     if (!state->server->start()) {
-      destroy_vmm_fd_memory(slots);
+      destroy_vmm_fd_memory(blocks);
       return false;
     }
 
     // Store the socket path so subscribers know which socket to contact.
-    slot.vmm_socket_path = socket_path;
-    slot.device_ptr = reinterpret_cast<void*>(state->address);
-    slot.vmm_fd_state = std::move(state);
+    block.vmm_socket_path = socket_path;
+    block.device_ptr = reinterpret_cast<void*>(state->address);
+    block.vmm_fd_state = std::move(state);
   }
   return true;
 }
 
-void destroy_vmm_fd_memory(std::vector<SlotResources>& slots) noexcept {
-  for (auto& slot : slots) {
-    slot.device_ptr = nullptr;
-    slot.vmm_fd_state.reset();
-    slot.vmm_socket_path.clear();
+void destroy_vmm_fd_memory(std::vector<GpuBufferBlock>& blocks) noexcept {
+  for (auto& block : blocks) {
+    block.device_ptr = nullptr;
+    block.vmm_fd_state.reset();
+    block.vmm_socket_path.clear();
   }
 }
 

--- a/ros2_cuda_ipc_core/src/buffer_metadata/buffer_metadata.cpp
+++ b/ros2_cuda_ipc_core/src/buffer_metadata/buffer_metadata.cpp
@@ -35,12 +35,12 @@ bool valid_layout(const struct stat& st, const ShmHeader& header,
       header.capacity == 0 ||
       header.capacity >
           (std::numeric_limits<std::size_t>::max() - sizeof(ShmHeader)) /
-              sizeof(SlotMetadata)) {
+              sizeof(BlockMetadata)) {
     return false;
   }
   *expected_size =
       sizeof(ShmHeader) +
-      static_cast<std::size_t>(header.capacity) * sizeof(SlotMetadata);
+      static_cast<std::size_t>(header.capacity) * sizeof(BlockMetadata);
   return *expected_size <= static_cast<std::size_t>(st.st_size);
 }
 
@@ -59,12 +59,12 @@ std::shared_ptr<BufferMetadata> BufferMetadata::create(
     return nullptr;
   }
   if (capacity > (std::numeric_limits<std::size_t>::max() - sizeof(ShmHeader)) /
-                     sizeof(SlotMetadata)) {
+                     sizeof(BlockMetadata)) {
     return nullptr;
   }
   const std::size_t size =
       sizeof(ShmHeader) +
-      static_cast<std::size_t>(capacity) * sizeof(SlotMetadata);
+      static_cast<std::size_t>(capacity) * sizeof(BlockMetadata);
   const int fd = shm_open(shm_name.c_str(), O_CREAT | O_EXCL | O_RDWR, 0660);
   if (fd < 0) {
     RCUTILS_LOG_ERROR_NAMED(
@@ -100,12 +100,12 @@ std::shared_ptr<BufferMetadata> BufferMetadata::create(
   header->capacity = capacity;
   header->consumer_count = 0;
   header->publisher_instance_id = instance_id;
-  auto* slot_storage = static_cast<std::byte*>(addr) + sizeof(ShmHeader);
+  auto* block_storage = static_cast<std::byte*>(addr) + sizeof(ShmHeader);
   for (uint32_t i = 0; i < capacity; ++i) {
-    ::new (static_cast<void*>(slot_storage + i * sizeof(SlotMetadata)))
-        SlotMetadata{};
+    ::new (static_cast<void*>(block_storage + i * sizeof(BlockMetadata)))
+        BlockMetadata{};
   }
-  auto* slots = reinterpret_cast<SlotMetadata*>(slot_storage);
+  auto* blocks = reinterpret_cast<BlockMetadata*>(block_storage);
 
   auto mapping = std::shared_ptr<BufferMetadata>(new BufferMetadata);
   mapping->shm_name_ = shm_name;
@@ -113,7 +113,7 @@ std::shared_ptr<BufferMetadata> BufferMetadata::create(
   mapping->capacity_ = capacity;
   mapping->mapped_size_ = size;
   mapping->addr_ = addr;
-  mapping->slots_ = slots;
+  mapping->blocks_ = blocks;
   return mapping;
 }
 
@@ -185,7 +185,7 @@ std::shared_ptr<BufferMetadata> BufferMetadata::attach(
   mapping->capacity_ = header->capacity;
   mapping->mapped_size_ = static_cast<std::size_t>(st.st_size);
   mapping->addr_ = addr;
-  mapping->slots_ = reinterpret_cast<SlotMetadata*>(header + 1);
+  mapping->blocks_ = reinterpret_cast<BlockMetadata*>(header + 1);
   return mapping;
 }
 

--- a/ros2_cuda_ipc_core/src/buffer_metadata/buffer_ref.cpp
+++ b/ros2_cuda_ipc_core/src/buffer_metadata/buffer_ref.cpp
@@ -23,26 +23,26 @@ uint64_t now_us() {
 }
 
 bool release_publisher_reservation(
-    const std::shared_ptr<BufferMetadata>& mapping, uint32_t slot_id,
-    uint32_t generation, bool published) noexcept {
-  if (!mapping || slot_id >= mapping->capacity()) return false;
-  SlotMetadata& slot = *mapping->slot(slot_id);
-  if (slot.generation.load(std::memory_order_acquire) != generation) {
+    const std::shared_ptr<BufferMetadata>& mapping, uint32_t block_id,
+    uint32_t uid, bool published) noexcept {
+  if (!mapping || block_id >= mapping->capacity()) return false;
+  BlockMetadata& block = *mapping->block(block_id);
+  if (block.uid.load(std::memory_order_acquire) != uid) {
     RCUTILS_LOG_ERROR_NAMED(
         "ros2_cuda_ipc_core.buffer_ref",
-        "buffer_ref:publisher_reservation_generation_mismatch slot=%u gen=%u",
-        slot_id, generation);
+        "buffer_ref:publisher_reservation_uid_mismatch block=%u uid=%u",
+        block_id, uid);
     return false;
   }
   if (published) {
-    slot.publish_timestamp_us.store(now_us(), std::memory_order_release);
+    block.publish_timestamp_us.store(now_us(), std::memory_order_release);
   }
   const uint32_t previous =
-      slot.refcount.fetch_sub(1, std::memory_order_acq_rel);
+      block.refcount.fetch_sub(1, std::memory_order_acq_rel);
   if (previous == 0) {
     RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.buffer_ref",
-                            "buffer_ref:refcount_underflow slot=%u", slot_id);
-    slot.refcount.store(0, std::memory_order_release);
+                            "buffer_ref:refcount_underflow block=%u", block_id);
+    block.refcount.store(0, std::memory_order_release);
     return false;
   }
   return true;
@@ -51,11 +51,11 @@ bool release_publisher_reservation(
 }  // namespace
 
 BufferRef::BufferRef(std::shared_ptr<BufferMetadata> mapping,
-                     SlotMetadata* slot, uint32_t slot_id, uint32_t generation)
+                     BlockMetadata* block, uint32_t block_id, uint32_t uid)
     : mapping_(std::move(mapping)),
-      slot_meta_(slot),
-      slot_id_(slot_id),
-      generation_(generation) {}
+      block_meta_(block),
+      block_id_(block_id),
+      uid_(uid) {}
 
 BufferRef::BufferRef(BufferRef&& other) noexcept { *this = std::move(other); }
 
@@ -63,48 +63,49 @@ BufferRef& BufferRef::operator=(BufferRef&& other) noexcept {
   if (this == &other) return *this;
   release();
   mapping_ = std::move(other.mapping_);
-  slot_meta_ = other.slot_meta_;
-  slot_id_ = other.slot_id_;
-  generation_ = other.generation_;
-  other.slot_meta_ = nullptr;
-  other.slot_id_ = 0;
-  other.generation_ = 0;
+  block_meta_ = other.block_meta_;
+  block_id_ = other.block_id_;
+  uid_ = other.uid_;
+  other.block_meta_ = nullptr;
+  other.block_id_ = 0;
+  other.uid_ = 0;
   return *this;
 }
 
 BufferRef::~BufferRef() { release(); }
 
 void BufferRef::release() noexcept {
-  if (!slot_meta_) return;
+  if (!block_meta_) return;
   const uint32_t previous =
-      slot_meta_->refcount.fetch_sub(1, std::memory_order_acq_rel);
+      block_meta_->refcount.fetch_sub(1, std::memory_order_acq_rel);
   if (previous == 0) {
     RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.buffer_ref",
-                            "buffer_ref:refcount_underflow slot=%u", slot_id_);
-    slot_meta_->refcount.store(0, std::memory_order_release);
+                            "buffer_ref:refcount_underflow block=%u",
+                            block_id_);
+    block_meta_->refcount.store(0, std::memory_order_release);
   }
-  slot_meta_ = nullptr;
-  slot_id_ = 0;
-  generation_ = 0;
+  block_meta_ = nullptr;
+  block_id_ = 0;
+  uid_ = 0;
   mapping_.reset();
 }
 
-std::optional<uint32_t> BufferRef::current_generation(
-    const std::shared_ptr<BufferMetadata>& mapping, uint32_t slot_id) {
-  if (!mapping || slot_id >= mapping->capacity()) return std::nullopt;
-  return mapping->slot(slot_id)->generation.load(std::memory_order_acquire);
+std::optional<uint32_t> BufferRef::current_uid(
+    const std::shared_ptr<BufferMetadata>& mapping, uint32_t block_id) {
+  if (!mapping || block_id >= mapping->capacity()) return std::nullopt;
+  return mapping->block(block_id)->uid.load(std::memory_order_acquire);
 }
 
 std::optional<uint32_t> BufferRef::current_refcount(
-    const std::shared_ptr<BufferMetadata>& mapping, uint32_t slot_id) {
-  if (!mapping || slot_id >= mapping->capacity()) return std::nullopt;
-  return mapping->slot(slot_id)->refcount.load(std::memory_order_acquire);
+    const std::shared_ptr<BufferMetadata>& mapping, uint32_t block_id) {
+  if (!mapping || block_id >= mapping->capacity()) return std::nullopt;
+  return mapping->block(block_id)->refcount.load(std::memory_order_acquire);
 }
 
 std::optional<uint64_t> BufferRef::current_publish_timestamp_us(
-    const std::shared_ptr<BufferMetadata>& mapping, uint32_t slot_id) {
-  if (!mapping || slot_id >= mapping->capacity()) return std::nullopt;
-  return mapping->slot(slot_id)->publish_timestamp_us.load(
+    const std::shared_ptr<BufferMetadata>& mapping, uint32_t block_id) {
+  if (!mapping || block_id >= mapping->capacity()) return std::nullopt;
+  return mapping->block(block_id)->publish_timestamp_us.load(
       std::memory_order_acquire);
 }
 
@@ -113,66 +114,66 @@ std::optional<BufferRef::PublisherReservation> BufferRef::reserve_for_publish(
   if (!mapping || mapping->capacity() == 0) return std::nullopt;
   const uint32_t capacity = mapping->capacity();
   const uint32_t start =
-      mapping->next_slot().fetch_add(1, std::memory_order_relaxed) % capacity;
+      mapping->next_block().fetch_add(1, std::memory_order_relaxed) % capacity;
   const uint64_t now = now_us();
   for (uint32_t offset = 0; offset < capacity; ++offset) {
-    const uint32_t slot_id = (start + offset) % capacity;
-    SlotMetadata& slot = *mapping->slot(slot_id);
-    if (slot.refcount.load(std::memory_order_acquire) != 0) continue;
+    const uint32_t block_id = (start + offset) % capacity;
+    BlockMetadata& block = *mapping->block(block_id);
+    if (block.refcount.load(std::memory_order_acquire) != 0) continue;
     const uint64_t published_at =
-        slot.publish_timestamp_us.load(std::memory_order_acquire);
+        block.publish_timestamp_us.load(std::memory_order_acquire);
     if (published_at != 0 &&
         (now < published_at || now - published_at < kGracePeriodUs))
       continue;
     uint32_t expected = 0;
-    if (!slot.refcount.compare_exchange_strong(
+    if (!block.refcount.compare_exchange_strong(
             expected, 1, std::memory_order_acq_rel, std::memory_order_acquire))
       continue;
-    const uint32_t next = slot.generation.load(std::memory_order_relaxed) + 1;
-    slot.generation.store(next, std::memory_order_release);
-    slot.publish_timestamp_us.store(0, std::memory_order_release);
-    mapping->next_slot().store((slot_id + 1) % capacity,
-                               std::memory_order_relaxed);
-    return PublisherReservation{mapping, slot_id, next};
+    const uint32_t next = block.uid.load(std::memory_order_relaxed) + 1;
+    block.uid.store(next, std::memory_order_release);
+    block.publish_timestamp_us.store(0, std::memory_order_release);
+    mapping->next_block().store((block_id + 1) % capacity,
+                                std::memory_order_relaxed);
+    return PublisherReservation{mapping, block_id, next};
   }
   return std::nullopt;
 }
 
 bool BufferRef::commit_publish(const std::shared_ptr<BufferMetadata>& mapping,
-                               uint32_t slot_id, uint32_t generation) noexcept {
-  return release_publisher_reservation(mapping, slot_id, generation, true);
+                               uint32_t block_id, uint32_t uid) noexcept {
+  return release_publisher_reservation(mapping, block_id, uid, true);
 }
 
 bool BufferRef::cancel_publish(const std::shared_ptr<BufferMetadata>& mapping,
-                               uint32_t slot_id, uint32_t generation) noexcept {
-  return release_publisher_reservation(mapping, slot_id, generation, false);
+                               uint32_t block_id, uint32_t uid) noexcept {
+  return release_publisher_reservation(mapping, block_id, uid, false);
 }
 
 BufferRef BufferRef::acquire(const std::shared_ptr<BufferMetadata>& mapping,
-                             uint32_t slot_id, uint32_t generation) {
-  if (!mapping || slot_id >= mapping->capacity()) return BufferRef{};
-  SlotMetadata* slot = mapping->slot(slot_id);
-  if (slot->generation.load(std::memory_order_acquire) != generation)
-    return BufferRef{};
+                             uint32_t block_id, uint32_t uid) {
+  if (!mapping || block_id >= mapping->capacity()) return BufferRef{};
+  BlockMetadata* block = mapping->block(block_id);
+  if (block->uid.load(std::memory_order_acquire) != uid) return BufferRef{};
 
-  uint32_t observed_ref = slot->refcount.load(std::memory_order_acquire);
+  uint32_t observed_ref = block->refcount.load(std::memory_order_acquire);
   while (true) {
     if (observed_ref == UINT32_MAX) {
       RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.buffer_ref",
-                              "buffer_ref:refcount_overflow slot=%u", slot_id);
+                              "buffer_ref:refcount_overflow block=%u",
+                              block_id);
       return BufferRef{};
     }
-    if (slot->refcount.compare_exchange_weak(observed_ref, observed_ref + 1,
-                                             std::memory_order_acq_rel,
-                                             std::memory_order_acquire))
+    if (block->refcount.compare_exchange_weak(observed_ref, observed_ref + 1,
+                                              std::memory_order_acq_rel,
+                                              std::memory_order_acquire))
       break;
   }
-  const uint32_t recheck_gen = slot->generation.load(std::memory_order_acquire);
-  if (recheck_gen != generation) {
-    slot->refcount.fetch_sub(1, std::memory_order_acq_rel);
+  const uint32_t recheck_uid = block->uid.load(std::memory_order_acquire);
+  if (recheck_uid != uid) {
+    block->refcount.fetch_sub(1, std::memory_order_acq_rel);
     return BufferRef{};
   }
-  return BufferRef(mapping, slot, slot_id, generation);
+  return BufferRef(mapping, block, block_id, uid);
 }
 
 }  // namespace ros2_cuda_ipc_core::buffer_metadata

--- a/ros2_cuda_ipc_core/src/publisher/buffer_metadata_manager.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/buffer_metadata_manager.cpp
@@ -35,17 +35,18 @@ std::pair<PublisherInstanceId, std::string> make_instance_identity(
 }  // namespace
 
 BufferMetadataManager::BufferMetadataManager(std::string shm_name_prefix,
-                                             std::size_t slot_count)
-    : shm_name_prefix_(std::move(shm_name_prefix)), slot_count_(slot_count) {}
+                                             std::size_t block_count)
+    : shm_name_prefix_(std::move(shm_name_prefix)), block_count_(block_count) {}
 
 BufferMetadataManager::~BufferMetadataManager() { reset(); }
 
 bool BufferMetadataManager::initialise() {
   reset();
-  if (slot_count_ == 0 || slot_count_ > std::numeric_limits<uint32_t>::max()) {
+  if (block_count_ == 0 ||
+      block_count_ > std::numeric_limits<uint32_t>::max()) {
     RCUTILS_LOG_ERROR_NAMED(
         "ros2_cuda_ipc_core.publisher.buffer_metadata_manager",
-        "Invalid slot_count: %zu", slot_count_);
+        "Invalid block_count: %zu", block_count_);
     return false;
   }
   if (!valid_prefix(shm_name_prefix_)) {
@@ -62,7 +63,7 @@ bool BufferMetadataManager::initialise() {
     return false;
   }
   auto mapping = buffer_metadata::BufferMetadata::create(
-      instance_name, instance_id, static_cast<uint32_t>(slot_count_));
+      instance_name, instance_id, static_cast<uint32_t>(block_count_));
   if (!mapping) {
     return false;
   }
@@ -124,19 +125,19 @@ BufferMetadataManager::reserve_for_publish() {
   if (!reservation) {
     return std::nullopt;
   }
-  if (reservation->slot_id >= slot_count_) {
+  if (reservation->block_id >= block_count_) {
     RCUTILS_LOG_ERROR_NAMED(
         "ros2_cuda_ipc_core.publisher.buffer_metadata_manager",
         "Buffer metadata shared-memory capacity changed unexpectedly: "
-        "slot=%u configured_count=%zu",
-        reservation->slot_id, slot_count_);
+        "block=%u configured_count=%zu",
+        reservation->block_id, block_count_);
     const bool rolled_back = buffer_metadata::BufferRef::cancel_publish(
-        reservation->mapping, reservation->slot_id, reservation->generation);
+        reservation->mapping, reservation->block_id, reservation->uid);
     if (!rolled_back) {
       RCUTILS_LOG_ERROR_NAMED(
           "ros2_cuda_ipc_core.publisher.buffer_metadata_manager",
-          "Failed to roll back out-of-range reservation slot=%u generation=%u",
-          reservation->slot_id, reservation->generation);
+          "Failed to roll back out-of-range reservation block=%u uid=%u",
+          reservation->block_id, reservation->uid);
     }
     return std::nullopt;
   }
@@ -144,45 +145,45 @@ BufferMetadataManager::reserve_for_publish() {
     std::lock_guard<std::mutex> lock(mutex_);
     if (initialised_ && shm_name_ == shm_name &&
         publisher_instance_id_ == instance_id) {
-      return Reservation{reservation->mapping, reservation->slot_id,
-                         reservation->generation, shm_name, instance_id};
+      return Reservation{reservation->mapping, reservation->block_id,
+                         reservation->uid, shm_name, instance_id};
     }
   }
 
   const bool rolled_back = buffer_metadata::BufferRef::cancel_publish(
-      reservation->mapping, reservation->slot_id, reservation->generation);
+      reservation->mapping, reservation->block_id, reservation->uid);
   if (!rolled_back) {
     RCUTILS_LOG_ERROR_NAMED(
         "ros2_cuda_ipc_core.publisher.buffer_metadata_manager",
-        "Failed to roll back reservation slot=%u generation=%u",
-        reservation->slot_id, reservation->generation);
+        "Failed to roll back reservation block=%u uid=%u",
+        reservation->block_id, reservation->uid);
   }
   return std::nullopt;
 }
 
 bool BufferMetadataManager::commit(const Reservation& reservation) noexcept {
   const bool committed = buffer_metadata::BufferRef::commit_publish(
-      reservation.mapping, reservation.slot_id, reservation.generation);
+      reservation.mapping, reservation.block_id, reservation.uid);
   if (!committed) {
     RCUTILS_LOG_ERROR_NAMED(
         "ros2_cuda_ipc_core.publisher.buffer_metadata_manager",
-        "Failed to commit reservation slot=%u generation=%u",
-        reservation.slot_id, reservation.generation);
+        "Failed to commit reservation block=%u uid=%u", reservation.block_id,
+        reservation.uid);
   }
   return committed;
 }
 
 bool BufferMetadataManager::cancel(const Reservation& reservation) noexcept {
-  if (reservation.slot_id >= slot_count_) {
+  if (reservation.block_id >= block_count_) {
     return false;
   }
   const bool cancelled = buffer_metadata::BufferRef::cancel_publish(
-      reservation.mapping, reservation.slot_id, reservation.generation);
+      reservation.mapping, reservation.block_id, reservation.uid);
   if (!cancelled) {
     RCUTILS_LOG_ERROR_NAMED(
         "ros2_cuda_ipc_core.publisher.buffer_metadata_manager",
-        "Failed to cancel reservation slot=%u generation=%u",
-        reservation.slot_id, reservation.generation);
+        "Failed to cancel reservation block=%u uid=%u", reservation.block_id,
+        reservation.uid);
   }
   return cancelled;
 }

--- a/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/gpu_buffer_manager.cpp
@@ -9,16 +9,16 @@
 
 namespace ros2_cuda_ipc_core::publisher {
 
-PublishSlot::PublishSlot(
+PublishBlock::PublishBlock(
     GpuBufferManager* owner,
     BufferMetadataManager::Reservation reservation) noexcept
     : owner_(owner), reservation_(std::move(reservation)) {}
 
-PublishSlot::PublishSlot(PublishSlot&& other) noexcept {
+PublishBlock::PublishBlock(PublishBlock&& other) noexcept {
   move_from(std::move(other));
 }
 
-PublishSlot& PublishSlot::operator=(PublishSlot&& other) noexcept {
+PublishBlock& PublishBlock::operator=(PublishBlock&& other) noexcept {
   if (this != &other) {
     cancel();
     move_from(std::move(other));
@@ -26,21 +26,21 @@ PublishSlot& PublishSlot::operator=(PublishSlot&& other) noexcept {
   return *this;
 }
 
-PublishSlot::~PublishSlot() noexcept { cancel(); }
+PublishBlock::~PublishBlock() noexcept { cancel(); }
 
-void PublishSlot::move_from(PublishSlot&& other) noexcept {
+void PublishBlock::move_from(PublishBlock&& other) noexcept {
   owner_ = other.owner_;
   reservation_ = std::move(other.reservation_);
   other.owner_ = nullptr;
 }
 
-bool PublishSlot::valid() const noexcept { return owner_ != nullptr; }
+bool PublishBlock::valid() const noexcept { return owner_ != nullptr; }
 
-void* PublishSlot::device_ptr() const noexcept {
+void* PublishBlock::device_ptr() const noexcept {
   return valid() ? owner_->device_ptr(reservation_) : nullptr;
 }
 
-detail::CudaResult<transport::BufferDescriptor> PublishSlot::prepare_publish(
+detail::CudaResult<transport::BufferDescriptor> PublishBlock::prepare_publish(
     CUstream stream) noexcept {
   if (owner_ == nullptr) {
     return detail::CudaResult<transport::BufferDescriptor>::failure(
@@ -71,29 +71,29 @@ detail::CudaResult<transport::BufferDescriptor> PublishSlot::prepare_publish(
       std::move(*descriptor));
 }
 
-void PublishSlot::quarantine(const char* step,
-                             const detail::CudaDriverError* error) noexcept {
+void PublishBlock::quarantine(const char* step,
+                              const detail::CudaDriverError* error) noexcept {
   owner_ = nullptr;
   if (error != nullptr) {
     RCUTILS_LOG_ERROR_NAMED(
         "ros2_cuda_ipc_core.publisher.gpu_buffer_manager",
-        "Failed to safely release or publish slot %u generation %u "
-        "publisher=%s during %s. The slot will not be reused until "
+        "Failed to safely release or publish block %u uid %u "
+        "publisher=%s during %s. The block will not be reused until "
         "GpuBufferManager is reset. CUDA error: %s",
-        reservation_.slot_id, reservation_.generation,
-        reservation_.shm_name.c_str(), step, error->to_string().c_str());
+        reservation_.block_id, reservation_.uid, reservation_.shm_name.c_str(),
+        step, error->to_string().c_str());
     return;
   }
   RCUTILS_LOG_ERROR_NAMED(
       "ros2_cuda_ipc_core.publisher.gpu_buffer_manager",
-      "Failed to safely release or publish slot %u generation %u "
-      "publisher=%s during %s. The slot will not be reused until "
+      "Failed to safely release or publish block %u uid %u "
+      "publisher=%s during %s. The block will not be reused until "
       "GpuBufferManager is reset.",
-      reservation_.slot_id, reservation_.generation,
-      reservation_.shm_name.c_str(), step);
+      reservation_.block_id, reservation_.uid, reservation_.shm_name.c_str(),
+      step);
 }
 
-void PublishSlot::cancel() noexcept {
+void PublishBlock::cancel() noexcept {
   if (owner_ != nullptr) {
     if (owner_->cancel(reservation_)) {
       owner_ = nullptr;
@@ -105,8 +105,8 @@ void PublishSlot::cancel() noexcept {
 
 GpuBufferManager::GpuBufferManager(Config config)
     : config_(std::move(config)),
-      buffer_pool_(config_.slot_count),
-      buffer_metadata_manager_(config_.shm_name_prefix, config_.slot_count) {}
+      buffer_pool_(config_.block_count),
+      buffer_metadata_manager_(config_.shm_name_prefix, config_.block_count) {}
 
 GpuBufferManager::~GpuBufferManager() { reset(); }
 
@@ -140,7 +140,7 @@ PublisherInstanceId GpuBufferManager::publisher_instance_id() const {
   return buffer_metadata_manager_.publisher_instance_id();
 }
 
-std::optional<PublishSlot> GpuBufferManager::acquire_for_publish() {
+std::optional<PublishBlock> GpuBufferManager::acquire_for_publish() {
   if (!is_initialised()) {
     return std::nullopt;
   }
@@ -148,7 +148,7 @@ std::optional<PublishSlot> GpuBufferManager::acquire_for_publish() {
   if (!reservation) {
     return std::nullopt;
   }
-  return PublishSlot(this, *reservation);
+  return PublishBlock(this, *reservation);
 }
 
 void* GpuBufferManager::device_ptr(
@@ -158,7 +158,7 @@ void* GpuBufferManager::device_ptr(
           buffer_metadata_manager_.publisher_instance_id()) {
     return nullptr;
   }
-  return buffer_pool_.device_ptr(reservation.slot_id);
+  return buffer_pool_.device_ptr(reservation.block_id);
 }
 
 detail::CudaResult<void> GpuBufferManager::record_ready(
@@ -170,13 +170,13 @@ detail::CudaResult<void> GpuBufferManager::record_ready(
     return detail::CudaResult<void>::failure(
         detail::CudaDriverError(CUDA_ERROR_INVALID_HANDLE));
   }
-  return buffer_pool_.record_ready(reservation.slot_id, stream);
+  return buffer_pool_.record_ready(reservation.block_id, stream);
 }
 
 std::optional<transport::BufferDescriptor>
 GpuBufferManager::try_build_descriptor(
     const BufferMetadataManager::Reservation& reservation) const noexcept {
-  const auto* resources = buffer_pool_.resources(reservation.slot_id);
+  const auto* resources = buffer_pool_.resources(reservation.block_id);
   if (resources == nullptr || !resources->ready_event) {
     return std::nullopt;
   }
@@ -188,8 +188,8 @@ GpuBufferManager::try_build_descriptor(
   transport::BufferDescriptor result;
   result.buffer_metadata_shm_name = reservation.shm_name;
   result.publisher_instance_id = reservation.publisher_instance_id;
-  result.slot_id = reservation.slot_id;
-  result.generation = reservation.generation;
+  result.block_id = reservation.block_id;
+  result.uid = reservation.uid;
   result.device_id = config_.device_index;
   result.byte_size = config_.byte_size;
   result.vmm_socket_path = resources->vmm_socket_path;

--- a/ros2_cuda_ipc_core/src/publisher/gpu_buffer_pool.cpp
+++ b/ros2_cuda_ipc_core/src/publisher/gpu_buffer_pool.cpp
@@ -9,20 +9,20 @@
 
 namespace ros2_cuda_ipc_core::publisher {
 
-GpuBufferPool::GpuBufferPool(std::size_t slot_count)
-    : slot_count_(slot_count) {}
+GpuBufferPool::GpuBufferPool(std::size_t block_count)
+    : block_count_(block_count) {}
 
-GpuBufferPool::~GpuBufferPool() { destroy_slots(); }
+GpuBufferPool::~GpuBufferPool() { destroy_blocks(); }
 
 bool GpuBufferPool::initialise(uint64_t byte_size, int device_index) {
-  if (slot_count_ == 0 || byte_size == 0) {
+  if (block_count_ == 0 || byte_size == 0) {
     RCUTILS_LOG_ERROR_NAMED(
         "ros2_cuda_ipc_core.publisher.gpu_buffer_pool",
-        "GpuBufferPool requires slot_count and byte_size > 0");
+        "GpuBufferPool requires block_count and byte_size > 0");
     return false;
   }
-  if (initialised_ || !slots_.empty()) {
-    destroy_slots();
+  if (initialised_ || !blocks_.empty()) {
+    destroy_blocks();
   }
   auto context_result = detail::CudaDeviceContext::retain_primary(device_index);
   if (!context_result) {
@@ -34,20 +34,20 @@ bool GpuBufferPool::initialise(uint64_t byte_size, int device_index) {
   context_ = std::move(context_result).value();
   byte_size_ = byte_size;
   device_index_ = device_index;
-  slots_.clear();
-  slots_.resize(slot_count_);
-  for (std::size_t i = 0; i < slots_.size(); ++i) {
-    slots_[i].index = static_cast<uint32_t>(i);
+  blocks_.clear();
+  blocks_.resize(block_count_);
+  for (std::size_t i = 0; i < blocks_.size(); ++i) {
+    blocks_[i].index = static_cast<uint32_t>(i);
   }
-  if (!allocate_slots()) {
-    destroy_slots();
+  if (!allocate_blocks()) {
+    destroy_blocks();
     return false;
   }
   initialised_ = true;
   return true;
 }
 
-void GpuBufferPool::reset() noexcept { destroy_slots(); }
+void GpuBufferPool::reset() noexcept { destroy_blocks(); }
 
 bool GpuBufferPool::matches(uint64_t byte_size,
                             int device_index) const noexcept {
@@ -55,30 +55,30 @@ bool GpuBufferPool::matches(uint64_t byte_size,
          device_index_ == device_index;
 }
 
-void* GpuBufferPool::device_ptr(uint32_t slot_id) const noexcept {
-  const auto* slot = resources(slot_id);
-  return slot ? slot->device_ptr : nullptr;
+void* GpuBufferPool::device_ptr(uint32_t block_id) const noexcept {
+  const auto* block = resources(block_id);
+  return block ? block->device_ptr : nullptr;
 }
 
-detail::CudaResult<void> GpuBufferPool::record_ready(uint32_t slot_id,
+detail::CudaResult<void> GpuBufferPool::record_ready(uint32_t block_id,
                                                      CUstream stream) noexcept {
-  const auto* slot = resources(slot_id);
-  if (!initialised_ || slot == nullptr || !slot->ready_event) {
+  const auto* block = resources(block_id);
+  if (!initialised_ || block == nullptr || !block->ready_event) {
     return detail::CudaResult<void>::failure(
         detail::CudaDriverError(CUDA_ERROR_INVALID_HANDLE));
   }
-  return slot->ready_event->record(stream);
+  return block->ready_event->record(stream);
 }
 
-const GpuBufferPool::SlotResources* GpuBufferPool::resources(
-    uint32_t slot_id) const noexcept {
-  if (slot_id >= slots_.size()) {
+const GpuBufferPool::GpuBufferBlock* GpuBufferPool::resources(
+    uint32_t block_id) const noexcept {
+  if (block_id >= blocks_.size()) {
     return nullptr;
   }
-  return &slots_[slot_id];
+  return &blocks_[block_id];
 }
 
-bool GpuBufferPool::allocate_slots() {
+bool GpuBufferPool::allocate_blocks() {
   if (!context_) {
     RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.publisher.gpu_buffer_pool",
                             "CUDA primary context is unavailable");
@@ -93,12 +93,12 @@ bool GpuBufferPool::allocate_slots() {
       return false;
     }
     auto memory_guard = std::move(memory_guard_result).value();
-    if (!backend::allocate_vmm_fd_memory(byte_size_, device_index_, slots_)) {
-      backend::destroy_vmm_fd_memory(slots_);
+    if (!backend::allocate_vmm_fd_memory(byte_size_, device_index_, blocks_)) {
+      backend::destroy_vmm_fd_memory(blocks_);
       return false;
     }
   }
-  for (auto& slot : slots_) {
+  for (auto& block : blocks_) {
     auto event_result = detail::InterprocessEvent::create(context_);
     if (!event_result) {
       RCUTILS_LOG_ERROR_NAMED("ros2_cuda_ipc_core.publisher.gpu_buffer_pool",
@@ -106,14 +106,14 @@ bool GpuBufferPool::allocate_slots() {
                               event_result.error().to_string().c_str());
       return false;
     }
-    slot.ready_event = std::move(event_result).value();
+    block.ready_event = std::move(event_result).value();
   }
   return true;
 }
 
-void GpuBufferPool::destroy_slots() noexcept {
-  for (auto& slot : slots_) {
-    slot.ready_event.reset();
+void GpuBufferPool::destroy_blocks() noexcept {
+  for (auto& block : blocks_) {
+    block.ready_event.reset();
   }
   std::optional<detail::CudaContextGuard> guard;
   if (context_) {
@@ -127,8 +127,8 @@ void GpuBufferPool::destroy_slots() noexcept {
       guard.emplace(std::move(guard_result).value());
     }
   }
-  backend::destroy_vmm_fd_memory(slots_);
-  slots_.clear();
+  backend::destroy_vmm_fd_memory(blocks_);
+  blocks_.clear();
   byte_size_ = 0;
   device_index_ = -1;
   initialised_ = false;

--- a/ros2_cuda_ipc_core/src/subscriber/buffer_mapper.cpp
+++ b/ros2_cuda_ipc_core/src/subscriber/buffer_mapper.cpp
@@ -39,12 +39,12 @@ std::unique_ptr<detail::MappedPublication> map_descriptor(
 
   auto mapping = mapping_cache->get_or_attach(msg.shm_name, instance_id);
   auto buffer_ref =
-      buffer_metadata::BufferRef::acquire(mapping, msg.slot_id, msg.generation);
+      buffer_metadata::BufferRef::acquire(mapping, msg.block_id, msg.uid);
   if (!buffer_ref.valid()) {
     RCUTILS_LOG_WARN_NAMED(
         "ros2_cuda_ipc_core.subscriber.buffer_mapper",
-        "Failed to acquire buffer reference shm=%s slot=%u gen=%u",
-        msg.shm_name.c_str(), msg.slot_id, msg.generation);
+        "Failed to acquire buffer reference shm=%s block=%u uid=%u",
+        msg.shm_name.c_str(), msg.block_id, msg.uid);
     return nullptr;
   }
   auto buffer_ref_ptr =
@@ -64,8 +64,8 @@ std::unique_ptr<detail::MappedPublication> map_descriptor(
     if (!opened.has_value()) {
       RCUTILS_LOG_WARN_NAMED(
           "ros2_cuda_ipc_core.subscriber.buffer_mapper",
-          "Failed to import GPU resource shm=%s slot=%u gen=%u",
-          msg.shm_name.c_str(), msg.slot_id, msg.generation);
+          "Failed to import GPU resource shm=%s block=%u uid=%u",
+          msg.shm_name.c_str(), msg.block_id, msg.uid);
       return nullptr;
     }
     imported = IpcHandleCache::instance().insert_or_discard_duplicate(
@@ -78,8 +78,8 @@ std::unique_ptr<detail::MappedPublication> map_descriptor(
   if (!publication) {
     RCUTILS_LOG_WARN_NAMED(
         "ros2_cuda_ipc_core.subscriber.buffer_mapper",
-        "Failed to create mapped publication for shm=%s slot=%u gen=%u",
-        msg.shm_name.c_str(), msg.slot_id, msg.generation);
+        "Failed to create mapped publication for shm=%s block=%u uid=%u",
+        msg.shm_name.c_str(), msg.block_id, msg.uid);
   }
   return publication;
 }
@@ -110,8 +110,8 @@ std::optional<ReadHandle> BufferMapper::map(
   if (!read) {
     RCUTILS_LOG_WARN_NAMED(
         "ros2_cuda_ipc_core.subscriber.buffer_mapper",
-        "Failed to bind mapped publication for shm=%s slot=%u gen=%u",
-        msg.shm_name.c_str(), msg.slot_id, msg.generation);
+        "Failed to bind mapped publication for shm=%s block=%u uid=%u",
+        msg.shm_name.c_str(), msg.block_id, msg.uid);
   }
   return read;
 }

--- a/ros2_cuda_ipc_core/src/transport/message_utils.cpp
+++ b/ros2_cuda_ipc_core/src/transport/message_utils.cpp
@@ -26,8 +26,8 @@ void fill_buffer_core_message(const BufferDescriptor& descriptor,
   message.shm_name = descriptor.buffer_metadata_shm_name;
   message.publisher_instance_id = descriptor.publisher_instance_id;
   message.device_id = static_cast<uint32_t>(descriptor.device_id);
-  message.slot_id = descriptor.slot_id;
-  message.generation = descriptor.generation;
+  message.block_id = descriptor.block_id;
+  message.uid = descriptor.uid;
   message.byte_size = descriptor.byte_size;
   message.vmm_socket_path = descriptor.vmm_socket_path;
   std::memcpy(message.event_handle.data(), &descriptor.ready_event_handle,

--- a/ros2_cuda_ipc_core/test/mapper/test_buffer_mapper.cpp
+++ b/ros2_cuda_ipc_core/test/mapper/test_buffer_mapper.cpp
@@ -26,9 +26,9 @@ TEST_F(BufferMapperTest, BufferReferenceFailureReturnsEmptyOptional) {
   ros2_cuda_ipc_msgs::msg::BufferCore msg;
   msg.shm_name = shm_name;
   msg.publisher_instance_id = test::publisher_instance_id(shm_name);
-  msg.slot_id = 0;
+  msg.block_id = 0;
   msg.device_id = 0;
-  msg.generation = 99;
+  msg.uid = 99;
   msg.byte_size = 64;
 
   subscriber::BufferMapper mapper;
@@ -47,7 +47,7 @@ TEST_F(BufferMapperTest, PublisherInstanceMismatchRejectsMessage) {
   ASSERT_TRUE(reservation.has_value());
 
   auto msg = test::make_cached_buffer_core_message(
-      shm_name, reservation->slot_id, reservation->generation, 91);
+      shm_name, reservation->block_id, reservation->uid, 91);
   msg.publisher_instance_id =
       test::publisher_instance_id(shm_name + "_different");
   subscriber::BufferMapper mapper;
@@ -56,7 +56,7 @@ TEST_F(BufferMapperTest, PublisherInstanceMismatchRejectsMessage) {
   ASSERT_TRUE(refcount.has_value());
   EXPECT_EQ(*refcount, 1u);
   ASSERT_TRUE(buffer_metadata::BufferRef::cancel_publish(
-      mapping, reservation->slot_id, reservation->generation));
+      mapping, reservation->block_id, reservation->uid));
   ::shm_unlink(shm_name.c_str());
 }
 
@@ -72,9 +72,9 @@ TEST_F(BufferMapperTest, InvalidVmmPayloadReturnsEmptyOptional) {
   ros2_cuda_ipc_msgs::msg::BufferCore msg;
   msg.shm_name = shm_name;
   msg.publisher_instance_id = test::publisher_instance_id(shm_name);
-  msg.slot_id = 0;
+  msg.block_id = 0;
   msg.device_id = 0;
-  msg.generation = reservation->generation;
+  msg.uid = reservation->uid;
   msg.byte_size = 64;
   msg.vmm_socket_path.clear();
   msg.event_handle.fill(0);
@@ -86,7 +86,7 @@ TEST_F(BufferMapperTest, InvalidVmmPayloadReturnsEmptyOptional) {
   ASSERT_TRUE(refcount.has_value());
   EXPECT_EQ(refcount.value(), 1u);
   ASSERT_TRUE(buffer_metadata::BufferRef::cancel_publish(
-      mapping, reservation->slot_id, reservation->generation));
+      mapping, reservation->block_id, reservation->uid));
 
   ::shm_unlink(shm_name.c_str());
 }
@@ -103,9 +103,9 @@ TEST_F(BufferMapperTest, MissingVmmSocketReturnsEmptyAndReleasesBufferRef) {
   ros2_cuda_ipc_msgs::msg::BufferCore msg;
   msg.shm_name = shm_name;
   msg.publisher_instance_id = test::publisher_instance_id(shm_name);
-  msg.slot_id = 0;
+  msg.block_id = 0;
   msg.device_id = 0;
-  msg.generation = reservation->generation;
+  msg.uid = reservation->uid;
   msg.byte_size = 64;
   msg.event_handle.fill(0);
   msg.vmm_socket_path =
@@ -118,7 +118,7 @@ TEST_F(BufferMapperTest, MissingVmmSocketReturnsEmptyAndReleasesBufferRef) {
   ASSERT_TRUE(refcount.has_value());
   EXPECT_EQ(refcount.value(), 1u);
   ASSERT_TRUE(buffer_metadata::BufferRef::cancel_publish(
-      mapping, reservation->slot_id, reservation->generation));
+      mapping, reservation->block_id, reservation->uid));
 
   ::shm_unlink(shm_name.c_str());
 }

--- a/ros2_cuda_ipc_core/test/mapper/test_image_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/test/mapper/test_image_view_mapper.cpp
@@ -30,9 +30,9 @@ TEST_F(ImageViewMapperTest, InvalidCoreReturnsDefaultImageView) {
   msg.encoding = "rgb8";
   msg.core.shm_name = shm_name;
   msg.core.publisher_instance_id = test::publisher_instance_id(shm_name);
-  msg.core.slot_id = 0;
+  msg.core.block_id = 0;
   msg.core.device_id = 0;
-  msg.core.generation = 42;
+  msg.core.uid = 42;
   msg.core.byte_size = 60;
 
   image::ImageViewMapper mapper;
@@ -58,7 +58,7 @@ TEST_F(ImageViewMapperTest, CopiesMetadataWhenPublicationIsValid) {
       core.shm_name, core.publisher_instance_id);
   ASSERT_TRUE(mapping);
   auto before =
-      buffer_metadata::BufferRef::current_refcount(mapping, core.slot_id);
+      buffer_metadata::BufferRef::current_refcount(mapping, core.block_id);
   ASSERT_TRUE(before.has_value());
   EXPECT_EQ(before.value(), 0u);
 
@@ -67,7 +67,7 @@ TEST_F(ImageViewMapperTest, CopiesMetadataWhenPublicationIsValid) {
   ASSERT_TRUE(view.valid());
   EXPECT_FALSE(view.core.valid());
   auto during =
-      buffer_metadata::BufferRef::current_refcount(mapping, core.slot_id);
+      buffer_metadata::BufferRef::current_refcount(mapping, core.block_id);
   ASSERT_TRUE(during.has_value());
   EXPECT_EQ(during.value(), 1u);
   EXPECT_EQ(view.header.frame_id, "camera_frame");
@@ -78,7 +78,7 @@ TEST_F(ImageViewMapperTest, CopiesMetadataWhenPublicationIsValid) {
 
   view = image::ImageView{};
   auto after =
-      buffer_metadata::BufferRef::current_refcount(mapping, core.slot_id);
+      buffer_metadata::BufferRef::current_refcount(mapping, core.block_id);
   ASSERT_TRUE(after.has_value());
   EXPECT_EQ(after.value(), 0u);
   ::shm_unlink(core.shm_name.c_str());
@@ -102,13 +102,13 @@ TEST_F(ImageViewMapperTest, DlpackMappingKeepsPublicationUnbound) {
   ASSERT_TRUE(view.valid());
   EXPECT_FALSE(view.core.valid());
   auto during =
-      buffer_metadata::BufferRef::current_refcount(mapping, core.slot_id);
+      buffer_metadata::BufferRef::current_refcount(mapping, core.block_id);
   ASSERT_TRUE(during.has_value());
   EXPECT_EQ(during.value(), 1u);
 
   view = image::ImageView{};
   auto after =
-      buffer_metadata::BufferRef::current_refcount(mapping, core.slot_id);
+      buffer_metadata::BufferRef::current_refcount(mapping, core.block_id);
   ASSERT_TRUE(after.has_value());
   EXPECT_EQ(after.value(), 0u);
   ::shm_unlink(core.shm_name.c_str());

--- a/ros2_cuda_ipc_core/test/mapper/test_pointcloud2_view_mapper.cpp
+++ b/ros2_cuda_ipc_core/test/mapper/test_pointcloud2_view_mapper.cpp
@@ -32,9 +32,9 @@ TEST_F(PointCloud2ViewMapperTest, InvalidCorePreservesHeaderOnlyBehavior) {
   msg.is_dense = true;
   msg.core.shm_name = shm_name;
   msg.core.publisher_instance_id = test::publisher_instance_id(shm_name);
-  msg.core.slot_id = 0;
+  msg.core.block_id = 0;
   msg.core.device_id = 0;
-  msg.core.generation = 42;
+  msg.core.uid = 42;
   msg.core.byte_size = 24;
 
   pointcloud2::PointCloud2ViewMapper mapper;

--- a/ros2_cuda_ipc_core/test/test_buffer_metadata_cache.cpp
+++ b/ros2_cuda_ipc_core/test/test_buffer_metadata_cache.cpp
@@ -121,10 +121,9 @@ TEST(BufferMetadataCacheTest, ReusesMappingAcrossCallbackLocalBufferRefs) {
 
   auto reservation = buffer_metadata::BufferRef::reserve_for_publish(first);
   ASSERT_TRUE(reservation.has_value());
-  const auto slot_id = reservation->slot_id;
-  const auto generation = reservation->generation;
-  ASSERT_TRUE(
-      buffer_metadata::BufferRef::commit_publish(first, slot_id, generation));
+  const auto block_id = reservation->block_id;
+  const auto uid = reservation->uid;
+  ASSERT_TRUE(buffer_metadata::BufferRef::commit_publish(first, block_id, uid));
   reservation.reset();
 
   for (int i = 0; i < 1000; ++i) {
@@ -133,7 +132,7 @@ TEST(BufferMetadataCacheTest, ReusesMappingAcrossCallbackLocalBufferRefs) {
     EXPECT_EQ(mapping.get(), first.get());
     {
       auto buffer_ref =
-          buffer_metadata::BufferRef::acquire(mapping, slot_id, generation);
+          buffer_metadata::BufferRef::acquire(mapping, block_id, uid);
       ASSERT_TRUE(buffer_ref.valid());
     }
   }
@@ -180,17 +179,17 @@ TEST(BufferMetadataCacheTest, ClearPreservesMappingForActiveBufferRef) {
   ASSERT_TRUE(mapping);
   auto reservation = buffer_metadata::BufferRef::reserve_for_publish(mapping);
   ASSERT_TRUE(reservation.has_value());
-  const auto slot_id = reservation->slot_id;
-  const auto generation = reservation->generation;
+  const auto block_id = reservation->block_id;
+  const auto uid = reservation->uid;
   ASSERT_TRUE(
-      buffer_metadata::BufferRef::commit_publish(mapping, slot_id, generation));
+      buffer_metadata::BufferRef::commit_publish(mapping, block_id, uid));
   reservation.reset();
 
   std::weak_ptr<buffer_metadata::BufferMetadata> weak_mapping = mapping;
 
   {
     auto active_buffer_ref =
-        buffer_metadata::BufferRef::acquire(mapping, slot_id, generation);
+        buffer_metadata::BufferRef::acquire(mapping, block_id, uid);
     ASSERT_TRUE(active_buffer_ref.valid());
     mapping.reset();
     cache.clear();

--- a/ros2_cuda_ipc_core/test/test_buffer_ref.cpp
+++ b/ros2_cuda_ipc_core/test/test_buffer_ref.cpp
@@ -32,7 +32,7 @@ void cancel(
         reservation) {
   if (reservation) {
     EXPECT_TRUE(ros2_cuda_ipc_core::buffer_metadata::BufferRef::cancel_publish(
-        mapping, reservation->slot_id, reservation->generation));
+        mapping, reservation->block_id, reservation->uid));
   }
 }
 
@@ -49,27 +49,27 @@ TEST(BufferRefTest, AcquireReleaseLifecycle) {
   auto reservation = buffer_metadata::BufferRef::reserve_for_publish(mapping);
   ASSERT_TRUE(reservation.has_value());
   EXPECT_EQ(buffer_metadata::BufferRef::current_refcount(mapping,
-                                                         reservation->slot_id),
+                                                         reservation->block_id),
             std::optional<uint32_t>(1));
 
   std::optional<buffer_metadata::BufferRef::PublisherReservation> other;
   {
     auto buffer_ref = buffer_metadata::BufferRef::acquire(
-        mapping, reservation->slot_id, reservation->generation);
+        mapping, reservation->block_id, reservation->uid);
     ASSERT_TRUE(buffer_ref.valid());
 
     other = buffer_metadata::BufferRef::reserve_for_publish(mapping);
     ASSERT_TRUE(other.has_value());
-    EXPECT_NE(other->slot_id, reservation->slot_id);
+    EXPECT_NE(other->block_id, reservation->block_id);
 
     auto ref = buffer_metadata::BufferRef::current_refcount(
-        mapping, reservation->slot_id);
+        mapping, reservation->block_id);
     ASSERT_TRUE(ref.has_value());
     EXPECT_EQ(ref.value(), 2u);
   }
 
   auto ref_after = buffer_metadata::BufferRef::current_refcount(
-      mapping, reservation->slot_id);
+      mapping, reservation->block_id);
   ASSERT_TRUE(ref_after.has_value());
   EXPECT_EQ(ref_after.value(), 1u);
 
@@ -78,13 +78,13 @@ TEST(BufferRefTest, AcquireReleaseLifecycle) {
   auto reservation_after =
       buffer_metadata::BufferRef::reserve_for_publish(mapping);
   ASSERT_TRUE(reservation_after.has_value());
-  EXPECT_EQ(reservation_after->slot_id, reservation->slot_id);
+  EXPECT_EQ(reservation_after->block_id, reservation->block_id);
   cancel(mapping, reservation_after);
 
   ::shm_unlink(shm_name.c_str());
 }
 
-TEST(BufferRefTest, GenerationMismatchReturnsInvalid) {
+TEST(BufferRefTest, UidMismatchReturnsInvalid) {
   const std::string shm_name = make_unique_shm_name("buffer_ref_mismatch");
   auto mapping = buffer_metadata::BufferMetadata::create(
       shm_name, test::publisher_instance_id(shm_name), 1);
@@ -93,7 +93,7 @@ TEST(BufferRefTest, GenerationMismatchReturnsInvalid) {
   auto reservation = buffer_metadata::BufferRef::reserve_for_publish(mapping);
   ASSERT_TRUE(reservation.has_value());
   auto buffer_ref = buffer_metadata::BufferRef::acquire(
-      mapping, reservation->slot_id, reservation->generation + 1);
+      mapping, reservation->block_id, reservation->uid + 1);
   EXPECT_FALSE(buffer_ref.valid());
   cancel(mapping, reservation);
 
@@ -129,7 +129,7 @@ TEST(BufferRefTest, HeaderPublisherInstanceMismatchReturnsInvalid) {
   ::shm_unlink(shm_name.c_str());
 }
 
-TEST(BufferRefTest, SameSlotAndGenerationAreSeparatedByInstance) {
+TEST(BufferRefTest, SameBlockAndUidAreSeparatedByInstance) {
   const std::string first_name =
       make_unique_shm_name("buffer_ref_instance_first");
   const std::string second_name =
@@ -146,12 +146,12 @@ TEST(BufferRefTest, SameSlotAndGenerationAreSeparatedByInstance) {
   auto second = buffer_metadata::BufferRef::reserve_for_publish(second_mapping);
   ASSERT_TRUE(first.has_value());
   ASSERT_TRUE(second.has_value());
-  ASSERT_EQ(first->slot_id, second->slot_id);
-  ASSERT_EQ(first->generation, second->generation);
+  ASSERT_EQ(first->block_id, second->block_id);
+  ASSERT_EQ(first->uid, second->uid);
 
   EXPECT_FALSE(buffer_metadata::BufferMetadata::attach(first_name, second_id));
   auto buffer_ref = buffer_metadata::BufferRef::acquire(
-      first_mapping, first->slot_id, first->generation);
+      first_mapping, first->block_id, first->uid);
   EXPECT_TRUE(buffer_ref.valid());
   cancel(first_mapping, first);
   cancel(second_mapping, second);
@@ -190,14 +190,14 @@ TEST(BufferRefTest, MappingLifetimeFollowsUsersAfterUnlink) {
   ASSERT_TRUE(reservation);
   {
     auto buffer_ref = buffer_metadata::BufferRef::acquire(
-        mapping, reservation->slot_id, reservation->generation);
+        mapping, reservation->block_id, reservation->uid);
     ASSERT_TRUE(buffer_ref.valid());
     ASSERT_EQ(::shm_unlink(shm_name.c_str()), 0);
     mapping.reset();
     EXPECT_FALSE(weak_mapping.expired());
   }
   EXPECT_TRUE(buffer_metadata::BufferRef::cancel_publish(
-      reservation->mapping, reservation->slot_id, reservation->generation));
+      reservation->mapping, reservation->block_id, reservation->uid));
   reservation.reset();
   EXPECT_TRUE(weak_mapping.expired());
 }
@@ -230,7 +230,7 @@ TEST(BufferRefTest, CommitAppliesFixedGracePeriod) {
   auto reservation = buffer_metadata::BufferRef::reserve_for_publish(mapping);
   ASSERT_TRUE(reservation.has_value());
   ASSERT_TRUE(buffer_metadata::BufferRef::commit_publish(
-      mapping, reservation->slot_id, reservation->generation));
+      mapping, reservation->block_id, reservation->uid));
   EXPECT_EQ(buffer_metadata::BufferRef::current_refcount(mapping, 0),
             std::optional<uint32_t>(0));
   const auto timestamp =
@@ -256,10 +256,10 @@ TEST(BufferRefTest, ActiveBufferRefBlocksReuseAfterGracePeriod) {
   auto reservation = buffer_metadata::BufferRef::reserve_for_publish(mapping);
   ASSERT_TRUE(reservation.has_value());
   ASSERT_TRUE(buffer_metadata::BufferRef::commit_publish(
-      mapping, reservation->slot_id, reservation->generation));
+      mapping, reservation->block_id, reservation->uid));
   std::optional<buffer_metadata::BufferRef> buffer_ref;
   buffer_ref.emplace(buffer_metadata::BufferRef::acquire(
-      mapping, reservation->slot_id, reservation->generation));
+      mapping, reservation->block_id, reservation->uid));
   ASSERT_TRUE(buffer_ref->valid());
   std::this_thread::sleep_for(std::chrono::milliseconds(105));
   EXPECT_FALSE(
@@ -271,7 +271,7 @@ TEST(BufferRefTest, ActiveBufferRefBlocksReuseAfterGracePeriod) {
   ::shm_unlink(shm_name.c_str());
 }
 
-TEST(BufferRefTest, PublisherAndSubscriberRaceIsGenerationSafe) {
+TEST(BufferRefTest, PublisherAndSubscriberRaceIsUidSafe) {
   const std::string shm_name = make_unique_shm_name("buffer_ref_reserve_race");
   auto mapping = buffer_metadata::BufferMetadata::create(
       shm_name, test::publisher_instance_id(shm_name), 1);
@@ -280,7 +280,7 @@ TEST(BufferRefTest, PublisherAndSubscriberRaceIsGenerationSafe) {
   auto initial = buffer_metadata::BufferRef::reserve_for_publish(mapping);
   ASSERT_TRUE(initial.has_value());
   ASSERT_TRUE(buffer_metadata::BufferRef::commit_publish(
-      mapping, initial->slot_id, initial->generation));
+      mapping, initial->block_id, initial->uid));
   std::this_thread::sleep_for(std::chrono::milliseconds(105));
 
   for (int iteration = 0; iteration < 1000; ++iteration) {
@@ -298,7 +298,7 @@ TEST(BufferRefTest, PublisherAndSubscriberRaceIsGenerationSafe) {
         std::this_thread::yield();
       }
       subscriber.emplace(buffer_metadata::BufferRef::acquire(
-          mapping, initial->slot_id, initial->generation));
+          mapping, initial->block_id, initial->uid));
     });
     start.store(true, std::memory_order_release);
     publisher_thread.join();
@@ -313,7 +313,7 @@ TEST(BufferRefTest, PublisherAndSubscriberRaceIsGenerationSafe) {
   ::shm_unlink(shm_name.c_str());
 }
 
-TEST(BufferRefTest, OnlyOnePublisherCanReserveSingleSlot) {
+TEST(BufferRefTest, OnlyOnePublisherCanReserveSingleBlock) {
   const std::string shm_name = make_unique_shm_name("buffer_ref_pub_race");
   auto mapping = buffer_metadata::BufferMetadata::create(
       shm_name, test::publisher_instance_id(shm_name), 1);

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_manager.cpp
@@ -29,12 +29,12 @@ std::string unique_name() {
 }  // namespace
 
 using ros2_cuda_ipc_core::publisher::GpuBufferManager;
-using ros2_cuda_ipc_core::publisher::PublishSlot;
+using ros2_cuda_ipc_core::publisher::PublishBlock;
 
-static_assert(!std::is_copy_constructible_v<PublishSlot>);
-static_assert(!std::is_copy_assignable_v<PublishSlot>);
-static_assert(std::is_nothrow_move_constructible_v<PublishSlot>);
-static_assert(std::is_nothrow_move_assignable_v<PublishSlot>);
+static_assert(!std::is_copy_constructible_v<PublishBlock>);
+static_assert(!std::is_copy_assignable_v<PublishBlock>);
+static_assert(std::is_nothrow_move_constructible_v<PublishBlock>);
+static_assert(std::is_nothrow_move_assignable_v<PublishBlock>);
 
 class GpuBufferManagerTest : public ::testing::Test {
  protected:
@@ -55,28 +55,28 @@ class GpuBufferManagerTest : public ::testing::Test {
 TEST_F(GpuBufferManagerTest, PreparePublishCommitsAndReturnsDescriptor) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
-  auto slot = manager.acquire_for_publish();
-  ASSERT_TRUE(slot.has_value());
+  auto block = manager.acquire_for_publish();
+  ASSERT_TRUE(block.has_value());
 
-  auto result = slot->prepare_publish(nullptr);
+  auto result = block->prepare_publish(nullptr);
   ASSERT_TRUE(result) << result.error().to_string();
-  EXPECT_EQ(result.value().slot_id, 0u);
-  EXPECT_FALSE(slot->valid());
+  EXPECT_EQ(result.value().block_id, 0u);
+  EXPECT_FALSE(block->valid());
   EXPECT_FALSE(manager.acquire_for_publish().has_value());
 }
 
-TEST_F(GpuBufferManagerTest, PreparePublishOnCompletedSlotFails) {
+TEST_F(GpuBufferManagerTest, PreparePublishOnCompletedBlockFails) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
-  auto slot = manager.acquire_for_publish();
-  ASSERT_TRUE(slot.has_value());
+  auto block = manager.acquire_for_publish();
+  ASSERT_TRUE(block.has_value());
 
-  ASSERT_TRUE(slot->prepare_publish(nullptr));
-  const auto result = slot->prepare_publish(nullptr);
+  ASSERT_TRUE(block->prepare_publish(nullptr));
+  const auto result = block->prepare_publish(nullptr);
   EXPECT_FALSE(result);
 }
 
-TEST_F(GpuBufferManagerTest, ReadyEventFailureQuarantinesSlot) {
+TEST_F(GpuBufferManagerTest, ReadyEventFailureQuarantinesBlock) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
   const auto actual_name = manager.shm_name();
@@ -86,8 +86,8 @@ TEST_F(GpuBufferManagerTest, ReadyEventFailureQuarantinesSlot) {
   ASSERT_TRUE(mapping);
 
   {
-    auto slot = manager.acquire_for_publish();
-    ASSERT_TRUE(slot.has_value());
+    auto block = manager.acquire_for_publish();
+    ASSERT_TRUE(block.has_value());
 
     CUdevice device = 0;
     ASSERT_EQ(cuDeviceGet(&device, 0), CUDA_SUCCESS);
@@ -103,7 +103,7 @@ TEST_F(GpuBufferManagerTest, ReadyEventFailureQuarantinesSlot) {
     ASSERT_EQ(cuCtxPopCurrent(&popped_context), CUDA_SUCCESS);
     ASSERT_EQ(popped_context, foreign_context);
 
-    const auto result = slot->prepare_publish(foreign_stream);
+    const auto result = block->prepare_publish(foreign_stream);
     ASSERT_EQ(cuCtxPushCurrent(foreign_context), CUDA_SUCCESS);
     ASSERT_EQ(cuStreamDestroy(foreign_stream), CUDA_SUCCESS);
     ASSERT_EQ(cuCtxPopCurrent(&popped_context), CUDA_SUCCESS);
@@ -112,7 +112,7 @@ TEST_F(GpuBufferManagerTest, ReadyEventFailureQuarantinesSlot) {
 
     ASSERT_FALSE(result);
     EXPECT_NE(result.error().to_string().find("CUDA_ERROR"), std::string::npos);
-    EXPECT_FALSE(slot->valid());
+    EXPECT_FALSE(block->valid());
   }
 
   const auto refcount =
@@ -129,26 +129,24 @@ TEST_F(GpuBufferManagerTest, ReadyEventFailureQuarantinesSlot) {
   EXPECT_TRUE(manager.acquire_for_publish().has_value());
 }
 
-TEST_F(GpuBufferManagerTest, CommitFailureQuarantinesSlot) {
+TEST_F(GpuBufferManagerTest, CommitFailureQuarantinesBlock) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
   auto mapping = ros2_cuda_ipc_core::buffer_metadata::BufferMetadata::attach(
       manager.shm_name(), manager.publisher_instance_id());
   ASSERT_TRUE(mapping);
-  auto slot = manager.acquire_for_publish();
-  ASSERT_TRUE(slot.has_value());
+  auto block = manager.acquire_for_publish();
+  ASSERT_TRUE(block.has_value());
 
-  const auto generation =
-      ros2_cuda_ipc_core::buffer_metadata::BufferRef::current_generation(
-          mapping, 0);
-  ASSERT_TRUE(generation.has_value());
-  mapping->slot(0)->generation.store(*generation + 1,
-                                     std::memory_order_release);
+  const auto uid =
+      ros2_cuda_ipc_core::buffer_metadata::BufferRef::current_uid(mapping, 0);
+  ASSERT_TRUE(uid.has_value());
+  mapping->block(0)->uid.store(*uid + 1, std::memory_order_release);
 
-  const auto result = slot->prepare_publish(nullptr);
+  const auto result = block->prepare_publish(nullptr);
   ASSERT_FALSE(result);
-  EXPECT_FALSE(slot->valid());
-  slot.reset();
+  EXPECT_FALSE(block->valid());
+  block.reset();
 
   const auto refcount =
       ros2_cuda_ipc_core::buffer_metadata::BufferRef::current_refcount(mapping,
@@ -167,12 +165,12 @@ TEST_F(GpuBufferManagerTest, CommitFailureQuarantinesSlot) {
 TEST_F(GpuBufferManagerTest, RuntimeCreatedStreamCanPreparePublish) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
-  auto slot = manager.acquire_for_publish();
-  ASSERT_TRUE(slot.has_value());
+  auto block = manager.acquire_for_publish();
+  ASSERT_TRUE(block.has_value());
 
   cudaStream_t stream = nullptr;
   ASSERT_EQ(cudaStreamCreate(&stream), cudaSuccess);
-  const auto result = slot->prepare_publish(stream);
+  const auto result = block->prepare_publish(stream);
   ASSERT_TRUE(result) << result.error().to_string();
   ASSERT_EQ(cudaStreamSynchronize(stream), cudaSuccess);
   ASSERT_EQ(cudaStreamDestroy(stream), cudaSuccess);
@@ -181,12 +179,12 @@ TEST_F(GpuBufferManagerTest, RuntimeCreatedStreamCanPreparePublish) {
 TEST_F(GpuBufferManagerTest, DriverCreatedStreamCanPreparePublish) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
-  auto slot = manager.acquire_for_publish();
-  ASSERT_TRUE(slot.has_value());
+  auto block = manager.acquire_for_publish();
+  ASSERT_TRUE(block.has_value());
 
   CUstream stream = nullptr;
   ASSERT_EQ(cuStreamCreate(&stream, CU_STREAM_DEFAULT), CUDA_SUCCESS);
-  const auto result = slot->prepare_publish(stream);
+  const auto result = block->prepare_publish(stream);
   ASSERT_TRUE(result) << result.error().to_string();
   ASSERT_EQ(cuStreamSynchronize(stream), CUDA_SUCCESS);
   ASSERT_EQ(cuStreamDestroy(stream), CUDA_SUCCESS);
@@ -196,8 +194,8 @@ TEST_F(GpuBufferManagerTest, UncommittedDestructionCancelsReservation) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
   {
-    auto slot = manager.acquire_for_publish();
-    ASSERT_TRUE(slot.has_value());
+    auto block = manager.acquire_for_publish();
+    ASSERT_TRUE(block.has_value());
   }
   EXPECT_TRUE(manager.acquire_for_publish().has_value());
 }
@@ -206,21 +204,21 @@ TEST_F(GpuBufferManagerTest, CommittedDestructionKeepsGracePeriod) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
   {
-    auto slot = manager.acquire_for_publish();
-    ASSERT_TRUE(slot.has_value());
-    ASSERT_TRUE(slot->prepare_publish(nullptr));
+    auto block = manager.acquire_for_publish();
+    ASSERT_TRUE(block.has_value());
+    ASSERT_TRUE(block->prepare_publish(nullptr));
   }
   EXPECT_FALSE(manager.acquire_for_publish().has_value());
   std::this_thread::sleep_for(std::chrono::milliseconds(150));
   EXPECT_TRUE(manager.acquire_for_publish().has_value());
 }
 
-TEST_F(GpuBufferManagerTest, MovedFromSlotIsInert) {
+TEST_F(GpuBufferManagerTest, MovedFromBlockIsInert) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
   auto source = manager.acquire_for_publish();
   ASSERT_TRUE(source.has_value());
-  PublishSlot destination(std::move(*source));
+  PublishBlock destination(std::move(*source));
   EXPECT_FALSE(source->valid());
   EXPECT_EQ(source->device_ptr(), nullptr);
   const auto result = source->prepare_publish(nullptr);
@@ -237,8 +235,8 @@ TEST_F(GpuBufferManagerTest, ResetDoesNotPreventReservationCancellation) {
   ASSERT_TRUE(manager.initialise());
   const std::string actual_name = manager.shm_name();
   const auto instance_id = manager.publisher_instance_id();
-  auto slot = manager.acquire_for_publish();
-  ASSERT_TRUE(slot.has_value());
+  auto block = manager.acquire_for_publish();
+  ASSERT_TRUE(block.has_value());
   auto mapping = ros2_cuda_ipc_core::buffer_metadata::BufferMetadata::attach(
       actual_name, instance_id);
   ASSERT_TRUE(mapping);
@@ -249,7 +247,7 @@ TEST_F(GpuBufferManagerTest, ResetDoesNotPreventReservationCancellation) {
   ASSERT_EQ(*ref_before, 1u);
 
   manager.reset();
-  slot.reset();
+  block.reset();
 
   const auto ref_after =
       ros2_cuda_ipc_core::buffer_metadata::BufferRef::current_refcount(mapping,
@@ -269,9 +267,9 @@ TEST_F(GpuBufferManagerTest, AcquireAfterGracePeriod) {
   auto manager = make_manager();
   ASSERT_TRUE(manager.initialise());
   {
-    auto slot = manager.acquire_for_publish();
-    ASSERT_TRUE(slot.has_value());
-    ASSERT_TRUE(slot->prepare_publish(nullptr));
+    auto block = manager.acquire_for_publish();
+    ASSERT_TRUE(block.has_value());
+    ASSERT_TRUE(block->prepare_publish(nullptr));
   }
 
   std::this_thread::sleep_for(std::chrono::milliseconds(105));

--- a/ros2_cuda_ipc_core/test/test_gpu_buffer_pool.cpp
+++ b/ros2_cuda_ipc_core/test/test_gpu_buffer_pool.cpp
@@ -5,7 +5,7 @@
 
 #include "ros2_cuda_ipc_core/publisher/gpu_buffer_pool.hpp"
 
-TEST(GpuBufferPoolTest, RejectsZeroSlotCount) {
+TEST(GpuBufferPoolTest, RejectsZeroBlockCount) {
   ros2_cuda_ipc_core::publisher::GpuBufferPool pool(0);
   EXPECT_FALSE(pool.initialise(1024, 0));
 }

--- a/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
+++ b/ros2_cuda_ipc_core/test/test_mapper_utils.hpp
@@ -57,14 +57,14 @@ inline subscriber::IpcHandleKey make_key(
 }
 
 inline ros2_cuda_ipc_msgs::msg::BufferCore make_cached_buffer_core_message(
-    const std::string& shm_name, uint32_t slot_id, uint32_t generation,
+    const std::string& shm_name, uint32_t block_id, uint32_t uid,
     uint8_t key_seed) {
   ros2_cuda_ipc_msgs::msg::BufferCore msg;
   msg.shm_name = shm_name;
   msg.publisher_instance_id = publisher_instance_id(shm_name);
   msg.device_id = 0;
-  msg.slot_id = slot_id;
-  msg.generation = generation;
+  msg.block_id = block_id;
+  msg.uid = uid;
   msg.byte_size = 64;
   std::ostringstream vmm_socket_path;
   vmm_socket_path << "/tmp/ros2_cuda_ipc_test_socket_" << std::hex
@@ -105,13 +105,13 @@ inline ros2_cuda_ipc_msgs::msg::BufferCore make_seeded_buffer_core_message(
     ADD_FAILURE() << "BufferRef::reserve_for_publish failed for " << shm_name;
     return ros2_cuda_ipc_msgs::msg::BufferCore{};
   }
-  auto msg = make_cached_buffer_core_message(shm_name, reservation->slot_id,
-                                             reservation->generation, key_seed);
-  if (!buffer_metadata::BufferRef::commit_publish(mapping, reservation->slot_id,
-                                                  reservation->generation)) {
+  auto msg = make_cached_buffer_core_message(shm_name, reservation->block_id,
+                                             reservation->uid, key_seed);
+  if (!buffer_metadata::BufferRef::commit_publish(
+          mapping, reservation->block_id, reservation->uid)) {
     ADD_FAILURE() << "BufferRef::commit_publish failed for " << shm_name;
     (void)buffer_metadata::BufferRef::cancel_publish(
-        mapping, reservation->slot_id, reservation->generation);
+        mapping, reservation->block_id, reservation->uid);
     (void)::shm_unlink(shm_name.c_str());
     return ros2_cuda_ipc_msgs::msg::BufferCore{};
   }

--- a/ros2_cuda_ipc_core/test/test_publisher_messages.cpp
+++ b/ros2_cuda_ipc_core/test/test_publisher_messages.cpp
@@ -21,8 +21,8 @@ ros2_cuda_ipc_core::transport::BufferDescriptor make_descriptor() {
   ros2_cuda_ipc_core::transport::BufferDescriptor descriptor;
   descriptor.buffer_metadata_shm_name = "/publisher_messages";
   descriptor.publisher_instance_id[0] = 42;
-  descriptor.slot_id = 7;
-  descriptor.generation = 11;
+  descriptor.block_id = 7;
+  descriptor.uid = 11;
   descriptor.device_id = 2;
   descriptor.byte_size = 120;
   descriptor.vmm_socket_path =
@@ -41,8 +41,8 @@ TEST(PublisherMessagesTest,
 
   EXPECT_EQ(message.shm_name, descriptor.buffer_metadata_shm_name);
   EXPECT_EQ(message.publisher_instance_id, descriptor.publisher_instance_id);
-  EXPECT_EQ(message.slot_id, descriptor.slot_id);
-  EXPECT_EQ(message.generation, descriptor.generation);
+  EXPECT_EQ(message.block_id, descriptor.block_id);
+  EXPECT_EQ(message.uid, descriptor.uid);
   EXPECT_EQ(message.device_id, 2u);
   EXPECT_EQ(message.byte_size, descriptor.byte_size);
   EXPECT_EQ(message.vmm_socket_path,
@@ -95,7 +95,7 @@ TEST(PublisherMessagesTest,
   EXPECT_EQ(message.width, 10u);
   ASSERT_EQ(message.fields.size(), 1u);
   EXPECT_EQ(message.fields[0].name, "x");
-  EXPECT_EQ(message.core.slot_id, descriptor.slot_id);
+  EXPECT_EQ(message.core.block_id, descriptor.block_id);
 }
 
 }  // namespace

--- a/ros2_cuda_ipc_core/test/test_read_handle.cpp
+++ b/ros2_cuda_ipc_core/test/test_read_handle.cpp
@@ -50,13 +50,13 @@ std::optional<ros2_cuda_ipc_core::subscriber::ReadHandle> make_read_handle(
     return std::nullopt;
   }
   if (!ros2_cuda_ipc_core::buffer_metadata::BufferRef::commit_publish(
-          mapping, reservation->slot_id, reservation->generation)) {
+          mapping, reservation->block_id, reservation->uid)) {
     (void)ros2_cuda_ipc_core::buffer_metadata::BufferRef::cancel_publish(
-        mapping, reservation->slot_id, reservation->generation);
+        mapping, reservation->block_id, reservation->uid);
     return std::nullopt;
   }
   auto buffer_ref = ros2_cuda_ipc_core::buffer_metadata::BufferRef::acquire(
-      mapping, reservation->slot_id, reservation->generation);
+      mapping, reservation->block_id, reservation->uid);
   if (!buffer_ref.valid()) {
     return std::nullopt;
   }

--- a/ros2_cuda_ipc_msgs/msg/BufferCore.msg
+++ b/ros2_cuda_ipc_msgs/msg/BufferCore.msg
@@ -8,10 +8,10 @@ string shm_name
 # Identity of the publisher initialisation that owns this buffer
 uint8[16] publisher_instance_id
 
-# Identification of the GPU buffer slot
+# Identification of the GPU buffer block
 uint32 device_id
-uint32 slot_id
-uint32 generation
+uint32 block_id
+uint32 uid
 
 # Total bytes in the GPU buffer
 uint64 byte_size

--- a/ros2_cuda_ipc_py/README.md
+++ b/ros2_cuda_ipc_py/README.md
@@ -110,7 +110,7 @@ framework tensor/array
         -> retained native read state
             -> imported CUDA resource
             -> publication buffer reference
-                -> shared-memory slot refcount
+                -> shared-memory block refcount
 ```
 
 The first successful `__dlpack__(stream)` transfers the imported resource and

--- a/ros2_cuda_ipc_py/ros2_cuda_ipc_py/_descriptor.py
+++ b/ros2_cuda_ipc_py/ros2_cuda_ipc_py/_descriptor.py
@@ -49,8 +49,8 @@ def buffer_core_descriptor(message):
             _field(message, "publisher_instance_id")
         ),
         "device_id": _field(message, "device_id"),
-        "slot_id": _field(message, "slot_id"),
-        "generation": _field(message, "generation"),
+        "block_id": _field(message, "block_id"),
+        "uid": _field(message, "uid"),
         "byte_size": _field(message, "byte_size"),
     }
 

--- a/ros2_cuda_ipc_py/src/native_module.cpp
+++ b/ros2_cuda_ipc_py/src/native_module.cpp
@@ -144,10 +144,9 @@ ros2_cuda_ipc_msgs::msg::BufferCore buffer_core_from_descriptor(
       required(descriptor, "publisher_instance_id"), "publisher_instance_id");
   message.device_id = unsigned_integer<uint32_t>(
       required(descriptor, "device_id"), "device_id");
-  message.slot_id =
-      unsigned_integer<uint32_t>(required(descriptor, "slot_id"), "slot_id");
-  message.generation = unsigned_integer<uint32_t>(
-      required(descriptor, "generation"), "generation");
+  message.block_id =
+      unsigned_integer<uint32_t>(required(descriptor, "block_id"), "block_id");
+  message.uid = unsigned_integer<uint32_t>(required(descriptor, "uid"), "uid");
   message.byte_size = unsigned_integer<uint64_t>(
       required(descriptor, "byte_size"), "byte_size");
   return message;
@@ -554,7 +553,7 @@ class PyBufferMapper {
     if (!view) {
       throw MappingError(
           "BufferCore was rejected by the C++ mapper (buffer reference, "
-          "generation, "
+          "uid, "
           "VMM-FD import failure)");
     }
     return PyReadHandle(std::move(*view));
@@ -578,7 +577,7 @@ class PyImageMapper {
     if (!view.valid()) {
       throw MappingError(
           "GpuImage was rejected by the C++ mapper (buffer reference, "
-          "generation, "
+          "uid, "
           "VMM-FD import failure)");
     }
     // Keep the C++ implementation's complete bounds check as the final
@@ -618,9 +617,9 @@ class TestBufferRefProbe {
   TestBufferRefProbe(
       std::shared_ptr<ros2_cuda_ipc_core::buffer_metadata::BufferMetadata>
           mapping,
-      uint32_t slot_id, std::string shm_name)
+      uint32_t block_id, std::string shm_name)
       : mapping_(std::move(mapping)),
-        slot_id_(slot_id),
+        block_id_(block_id),
         shm_name_(std::move(shm_name)) {}
 
   ~TestBufferRefProbe() {
@@ -632,7 +631,7 @@ class TestBufferRefProbe {
   uint32_t refcount() const {
     const auto value =
         ros2_cuda_ipc_core::buffer_metadata::BufferRef::current_refcount(
-            mapping_, slot_id_);
+            mapping_, block_id_);
     return value.value_or(0);
   }
 
@@ -640,7 +639,7 @@ class TestBufferRefProbe {
 
  private:
   std::shared_ptr<ros2_cuda_ipc_core::buffer_metadata::BufferMetadata> mapping_;
-  uint32_t slot_id_;
+  uint32_t block_id_;
   std::string shm_name_;
 };
 
@@ -685,8 +684,8 @@ py::tuple make_test_image() {
   message.core.shm_name = shm_name;
   message.core.publisher_instance_id = instance_id;
   message.core.device_id = 0;
-  message.core.slot_id = reservation->slot_id;
-  message.core.generation = reservation->generation;
+  message.core.block_id = reservation->block_id;
+  message.core.uid = reservation->uid;
   message.core.byte_size = 24;
 
   ros2_cuda_ipc_core::subscriber::IpcHandleKey key{};
@@ -707,9 +706,9 @@ py::tuple make_test_image() {
     throw std::runtime_error("test ImageViewMapper fixture failed");
   }
   if (!ros2_cuda_ipc_core::buffer_metadata::BufferRef::commit_publish(
-          mapping, reservation->slot_id, reservation->generation)) {
+          mapping, reservation->block_id, reservation->uid)) {
     (void)ros2_cuda_ipc_core::buffer_metadata::BufferRef::cancel_publish(
-        mapping, reservation->slot_id, reservation->generation);
+        mapping, reservation->block_id, reservation->uid);
     (void)::shm_unlink(shm_name.c_str());
     throw std::runtime_error("test BufferRef::commit_publish failed");
   }
@@ -721,8 +720,8 @@ py::tuple make_test_image() {
   core["publisher_instance_id"] =
       bytes_to_list(message.core.publisher_instance_id);
   core["device_id"] = message.core.device_id;
-  core["slot_id"] = message.core.slot_id;
-  core["generation"] = message.core.generation;
+  core["block_id"] = message.core.block_id;
+  core["uid"] = message.core.uid;
   core["byte_size"] = message.core.byte_size;
   py::dict stamp;
   stamp["sec"] = 0;
@@ -739,7 +738,7 @@ py::tuple make_test_image() {
   descriptor["encoding"] = message.encoding;
 
   auto probe = std::make_shared<TestBufferRefProbe>(
-      mapping, reservation->slot_id, shm_name);
+      mapping, reservation->block_id, shm_name);
   return py::make_tuple(PyImageView(std::move(view)), probe, descriptor);
 }
 

--- a/ros2_cuda_ipc_py/test/test_python_api.py
+++ b/ros2_cuda_ipc_py/test/test_python_api.py
@@ -52,10 +52,10 @@ def test_views_expose_storage_and_buffer_metadata_without_debug_helpers():
     assert buffer.device_ptr != 0
     assert not hasattr(image, "device_ptr")
     assert not hasattr(image._native, "device_ptr")
-    assert not hasattr(image, "slot_id")
-    assert not hasattr(image, "generation")
-    assert not hasattr(image._native, "slot_id")
-    assert not hasattr(image._native, "generation")
+    assert not hasattr(image, "block_id")
+    assert not hasattr(image, "uid")
+    assert not hasattr(image._native, "block_id")
+    assert not hasattr(image._native, "uid")
     assert image.dtype == "uint8"
     assert not hasattr(image, "dtype_code")
     assert not hasattr(image._native, "dtype_code")
@@ -87,8 +87,8 @@ def test_generated_rclpy_message_crosses_the_descriptor_boundary():
         "publisher_instance_id"
     ]
     message.core.device_id = descriptor["core"]["device_id"]
-    message.core.slot_id = descriptor["core"]["slot_id"]
-    message.core.generation = descriptor["core"]["generation"]
+    message.core.block_id = descriptor["core"]["block_id"]
+    message.core.uid = descriptor["core"]["uid"]
     message.core.byte_size = descriptor["core"]["byte_size"]
 
     converted = gpu_image_descriptor(message)
@@ -142,10 +142,10 @@ def test_view_exceeding_allocation_bounds_is_rejected():
         ImageMapper().map(invalid)
 
 
-def test_stale_generation_is_reported_as_mapping_error():
+def test_stale_uid_is_reported_as_mapping_error():
     _native_view, _probe, descriptor = _fixture()
     stale = copy.deepcopy(descriptor)
-    stale["core"]["generation"] += 1
+    stale["core"]["uid"] += 1
 
     with pytest.raises(MappingError, match="C\\+\\+ mapper"):
         ImageMapper().map(stale)


### PR DESCRIPTION
## Summary

- Rename the publisher buffer API and implementation terminology from slots to blocks.
- Update ROS message identifiers from `slot_id`/`generation` to `block_id`/`uid`, and the example launch argument from `slot_count` to `block_count`.
- Refresh the Python boundary, documentation, tests, and `CHANGELOG.md` to match the new names.

## Why

The implementation uses reusable GPU buffer blocks, so the public API, wire fields, examples, and documentation should use one consistent vocabulary. The ROS message and public API identifier changes are breaking changes and are called out in the unreleased changelog.

## Validation

- `git diff --check`
- clang-format pre-commit hook passed
- Workspace build of the affected packages completed successfully