### PR TITLE
Add typed subscriber facades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ This document records the user-visible changes between releases of
 
 ## Unreleased
 
+- Added `ImageReader` and `PointCloud2Reader` typed subscriber facades. Each
+  reader composes `BufferMapper` with the corresponding typed
+  `from_message()` validation while reusing its mapper cache across calls.
+- Migrated the C++ fanout example and `gpu_image_transport` to the typed
+  reader facade, and added facade coverage for mapping, validation, and read
+  handle lifetime. The low-level `BufferMapper`, `ReadHandle`, and typed
+  `from_message()` APIs remain available.
+
 - Added the independent `ros2_cuda_ipc_image` and
   `ros2_cuda_ipc_pointcloud2` packages for typed read handles, modality
   metadata validation, and `GpuImage`/`GpuPointCloud2` message helpers.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -8,8 +8,8 @@ who want to try the demo first.
 
 - `ros2_cuda_ipc_msgs`: message definitions for GPU-backed buffers.
 - `ros2_cuda_ipc_core`: untyped CUDA memory sharing, buffer reference handling, and synchronization.
-- `ros2_cuda_ipc_image`: `ImageReadHandle`, image metadata validation, and image message helpers.
-- `ros2_cuda_ipc_pointcloud2`: `PointCloud2ReadHandle`, PointCloud2/PointField validation, and point-cloud message helpers.
+- `ros2_cuda_ipc_image`: `ImageReader`, `ImageReadHandle`, image metadata validation, and image message helpers.
+- `ros2_cuda_ipc_pointcloud2`: `PointCloud2Reader`, `PointCloud2ReadHandle`, PointCloud2/PointField validation, and point-cloud message helpers.
 - `examples/multi_process_image_fanout`: primary multi-process sample.
 - `utils/gpu_image_transport`: utility bridge from `GpuImage` messages to CPU image topics.
 - `utils/cuda_ipc_poc`: CUDA IPC and VMM-FD environment checks.
@@ -18,7 +18,9 @@ who want to try the demo first.
 
 - `ros2_cuda_ipc_core::subscriber::BufferMapper`: maps a `BufferCore` and a consumer stream to an optional `ReadHandle`.
 - `ros2_cuda_ipc_core::subscriber::ReadHandle`: the normal pointer API. It waits for producer readiness, owns the buffer reference, and defers resource/buffer reference release until consumer completion.
+- `ros2_cuda_ipc_image::ImageReader`: typed subscriber facade that composes `BufferMapper` and `ImageReadHandle::from_message()` while reusing the mapper cache across calls.
 - `ros2_cuda_ipc_image::ImageReadHandle`: typed image metadata adapter that owns a `ReadHandle`.
+- `ros2_cuda_ipc_pointcloud2::PointCloud2Reader`: typed subscriber facade that composes `BufferMapper` and `PointCloud2ReadHandle::from_message()` while reusing the mapper cache across calls.
 - `ros2_cuda_ipc_pointcloud2::PointCloud2ReadHandle`: typed PointCloud2 metadata adapter that owns a `ReadHandle`.
 - `ros2_cuda_ipc_core::publisher::GpuBufferPool`: the sole owner of publisher-local `GpuBufferBlock` resources, their metadata mappings, and reservation/reuse state.
 - `ros2_cuda_ipc_core::publisher::GpuBufferManager`: publisher facade that orchestrates initialization, reset, preparation order, and quarantine.
@@ -59,6 +61,11 @@ The protocol guarantees and known limitations are specified in
 Receiving code subscribes to `ros2_cuda_ipc_msgs::msg::BufferCore` and calls
 `BufferMapper::map(message, consumer_stream)`. Mapping acquires the buffer reference and
 imports or looks up the GPU resource before returning a `ReadHandle`.
+
+For typed `GpuImage` and `GpuPointCloud2` subscriptions, the corresponding
+`ImageReader` or `PointCloud2Reader` composes that mapping with typed metadata
+validation. The low-level `BufferMapper` and `from_message()` APIs remain
+available when an application needs to control those steps separately.
 
 The consumer stream must remain valid until the corresponding `ReadHandle` is
 destroyed and its completion event has been recorded. A failed optional map

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ ros2 topic echo /fanout/inference_like/status
 
 - `ros2_cuda_ipc_msgs`: ROS 2 message definitions for GPU-backed buffers.
 - `ros2_cuda_ipc_core`: untyped CUDA memory sharing, buffer lifetime, and synchronization APIs.
-- `ros2_cuda_ipc_image`: typed `GpuImage` metadata validation, `ImageReadHandle`, and image message helpers.
-- `ros2_cuda_ipc_pointcloud2`: typed `GpuPointCloud2`/`PointField` validation, `PointCloud2ReadHandle`, and point-cloud message helpers.
+- `ros2_cuda_ipc_image`: typed `GpuImage` metadata validation, `ImageReader`, `ImageReadHandle`, and image message helpers.
+- `ros2_cuda_ipc_pointcloud2`: typed `GpuPointCloud2`/`PointField` validation, `PointCloud2Reader`, `PointCloud2ReadHandle`, and point-cloud message helpers.
 - `ros2_cuda_ipc_py`: `rclpy`/pybind11 subscriber mapping with zero-copy CuPy views.
 - `examples/multi_process_image_fanout`: primary runnable demo.
 - `utils/gpu_image_transport`: utility nodes that map `GpuImage` messages to CPU image topics.

--- a/doc/design.md
+++ b/doc/design.md
@@ -41,7 +41,9 @@ message helper は、それぞれの typed package に属する。PointCloud2 pa
 | `BufferMapper` | `BufferCore` を import し、consumer stream に bind した read を作る mapper |
 | `MappedPublication` | detail内部の、import済みだがconsumer stream未bindのpublication |
 | `ReadHandle` | 一つの GPU read の所有者。imported resource と buffer reference を保持する move-only handle |
+| `ros2_cuda_ipc_image::ImageReader` | `BufferMapper` と `ImageReadHandle::from_message()` を合成する typed subscriber facade |
 | `ros2_cuda_ipc_image::ImageReadHandle` | `ReadHandle` と画像メタデータを組み合わせる move-only typed handle |
+| `ros2_cuda_ipc_pointcloud2::PointCloud2Reader` | `BufferMapper` と `PointCloud2ReadHandle::from_message()` を合成する typed subscriber facade |
 | `ros2_cuda_ipc_pointcloud2::PointCloud2ReadHandle` | `ReadHandle` と点群メタデータを組み合わせる move-only typed handle |
 | buffer reference | shared-memory block の refcount を保持し、publisher による再利用を防ぐ subscriber 側の所有権 |
 
@@ -86,12 +88,12 @@ ROS message
     -> optional<ReadHandle>
     -> GPU pointer + byte size
 
-ros2_cuda_ipc_image::ImageReadHandle
+ros2_cuda_ipc_image::ImageReader::read
     -> BufferMapper::map(message.core, consumer_stream)
     -> ReadHandle
     -> ImageReadHandle::from_message
 
-ros2_cuda_ipc_pointcloud2::PointCloud2ReadHandle
+ros2_cuda_ipc_pointcloud2::PointCloud2Reader::read
     -> BufferMapper::map(message.core, consumer_stream)
     -> ReadHandle
     -> PointCloud2ReadHandle::from_message
@@ -235,19 +237,20 @@ typed layerはIPC import、refcount取得、producer event waitを行わない�
 内包する move-only object である。raw pointerが必要なC++ callerは
 `handle.read.data<T>()` または `handle.read.device_ptr()` を使う。
 
-画像の通常の stream-bound mapping は次のように行う。
+画像の通常の stream-bound mapping は、typed facadeを使うと次のように行う。
 
 ```cpp
-auto read = buffer_mapper.map(message.core, consumer_stream);
-if (!read) {
-  return;
-}
-auto image = ImageReadHandle::from_message(message, std::move(*read));
+ros2_cuda_ipc_image::ImageReader reader;
+auto image = reader.read(message, consumer_stream);
 if (!image) {
   return;
 }
 launch_kernel(image->read.data<uint8_t>(), consumer_stream);
 ```
+
+`PointCloud2Reader` も同じ構成で、`GpuPointCloud2` の`core` mappingと
+`PointCloud2ReadHandle::from_message()`によるmetadata validationを合成する。
+`BufferMapper` と各`from_message()`は、低レベル制御が必要な利用者向けに引き続き公開する。
 
 ## API 契約と制約
 

--- a/examples/multi_process_image_fanout/src/encoder_like_node.cpp
+++ b/examples/multi_process_image_fanout/src/encoder_like_node.cpp
@@ -15,8 +15,8 @@
 #include "multi_process_image_fanout/status_format.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_cuda_ipc_core/detail/nvtx_scoped_range.hpp"
-#include "ros2_cuda_ipc_core/subscriber/buffer_mapper.hpp"
 #include "ros2_cuda_ipc_image/image_read_handle.hpp"
+#include "ros2_cuda_ipc_image/image_reader.hpp"
 #include "ros2_cuda_ipc_msgs/msg/gpu_image.hpp"
 #include "std_msgs/msg/string.hpp"
 
@@ -77,10 +77,7 @@ class EncoderLikeNode : public rclcpp::Node {
           if (!ensure_cuda_state(static_cast<int>(message.core.device_id))) {
             return;
           }
-          auto read = buffer_mapper_.map(message.core, stream_);
-          auto view = read ? ros2_cuda_ipc_image::ImageReadHandle::from_message(
-                                 message, std::move(*read))
-                           : std::nullopt;
+          auto view = reader_.read(message, stream_);
           if (!view) {
             RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,
                                  "Skipping GPU image mapping failure");
@@ -405,7 +402,7 @@ class EncoderLikeNode : public rclcpp::Node {
   uint8_t* device_luma_ = nullptr;
   uint64_t* device_checksum_ = nullptr;
   int current_device_id_ = -1;
-  ros2_cuda_ipc_core::subscriber::BufferMapper buffer_mapper_;
+  ros2_cuda_ipc_image::ImageReader reader_;
   uint32_t output_width_ = 0;
   uint32_t output_height_ = 0;
   std::size_t output_pixel_count_ = 0;

--- a/examples/multi_process_image_fanout/src/encoder_like_node.cpp
+++ b/examples/multi_process_image_fanout/src/encoder_like_node.cpp
@@ -80,7 +80,7 @@ class EncoderLikeNode : public rclcpp::Node {
           auto view = reader_.read(message, stream_);
           if (!view) {
             RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,
-                                 "Skipping GPU image mapping failure");
+                                 "Skipping GPU image read failure");
             return;
           }
           on_image(*view);

--- a/examples/multi_process_image_fanout/src/inference_like_node.cpp
+++ b/examples/multi_process_image_fanout/src/inference_like_node.cpp
@@ -15,8 +15,8 @@
 #include "multi_process_image_fanout/status_format.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_cuda_ipc_core/detail/nvtx_scoped_range.hpp"
-#include "ros2_cuda_ipc_core/subscriber/buffer_mapper.hpp"
 #include "ros2_cuda_ipc_image/image_read_handle.hpp"
+#include "ros2_cuda_ipc_image/image_reader.hpp"
 #include "ros2_cuda_ipc_msgs/msg/gpu_image.hpp"
 #include "std_msgs/msg/string.hpp"
 
@@ -70,10 +70,7 @@ class InferenceLikeNode : public rclcpp::Node {
           if (!ensure_cuda_state(static_cast<int>(message.core.device_id))) {
             return;
           }
-          auto read = buffer_mapper_.map(message.core, stream_);
-          auto view = read ? ros2_cuda_ipc_image::ImageReadHandle::from_message(
-                                 message, std::move(*read))
-                           : std::nullopt;
+          auto view = reader_.read(message, stream_);
           if (!view) {
             RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,
                                  "Skipping GPU image mapping failure");
@@ -387,7 +384,7 @@ class InferenceLikeNode : public rclcpp::Node {
   float* device_gray_ = nullptr;
   InferenceStats* device_stats_ = nullptr;
   int current_device_id_ = -1;
-  ros2_cuda_ipc_core::subscriber::BufferMapper buffer_mapper_;
+  ros2_cuda_ipc_image::ImageReader reader_;
   std::size_t gray_element_count_ = 0;
   std::string input_topic_name_;
   std::string status_topic_name_;

--- a/examples/multi_process_image_fanout/src/inference_like_node.cpp
+++ b/examples/multi_process_image_fanout/src/inference_like_node.cpp
@@ -73,7 +73,7 @@ class InferenceLikeNode : public rclcpp::Node {
           auto view = reader_.read(message, stream_);
           if (!view) {
             RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,
-                                 "Skipping GPU image mapping failure");
+                                 "Skipping GPU image read failure");
             return;
           }
           on_image(*view);

--- a/examples/multi_process_image_fanout/src/preview_node.cpp
+++ b/examples/multi_process_image_fanout/src/preview_node.cpp
@@ -15,8 +15,8 @@
 #include "multi_process_image_fanout/status_format.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_cuda_ipc_core/detail/nvtx_scoped_range.hpp"
-#include "ros2_cuda_ipc_core/subscriber/buffer_mapper.hpp"
 #include "ros2_cuda_ipc_image/image_read_handle.hpp"
+#include "ros2_cuda_ipc_image/image_reader.hpp"
 #include "ros2_cuda_ipc_msgs/msg/gpu_image.hpp"
 #include "sensor_msgs/msg/image.hpp"
 
@@ -83,10 +83,7 @@ class PreviewNode : public rclcpp::Node {
               cudaSuccess) {
             return;
           }
-          auto read = buffer_mapper_.map(message.core, stream_);
-          auto view = read ? ros2_cuda_ipc_image::ImageReadHandle::from_message(
-                                 message, std::move(*read))
-                           : std::nullopt;
+          auto view = reader_.read(message, stream_);
           if (!view) {
             RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,
                                  "Skipping GPU image mapping failure");
@@ -246,7 +243,7 @@ class PreviewNode : public rclcpp::Node {
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr publisher_;
   cudaStream_t stream_ = nullptr;
   int current_device_id_ = -1;
-  ros2_cuda_ipc_core::subscriber::BufferMapper buffer_mapper_;
+  ros2_cuda_ipc_image::ImageReader reader_;
   std::size_t received_ = 0;
   std::size_t copy_every_n_ = 1;
   std::size_t log_every_n_ = 30;

--- a/examples/multi_process_image_fanout/src/preview_node.cpp
+++ b/examples/multi_process_image_fanout/src/preview_node.cpp
@@ -86,7 +86,7 @@ class PreviewNode : public rclcpp::Node {
           auto view = reader_.read(message, stream_);
           if (!view) {
             RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,
-                                 "Skipping GPU image mapping failure");
+                                 "Skipping GPU image read failure");
             return;
           }
           on_image(*view);

--- a/ros2_cuda_ipc_image/CMakeLists.txt
+++ b/ros2_cuda_ipc_image/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(ros2_cuda_ipc_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 
 add_library(${PROJECT_NAME}
+  src/image_reader.cpp
   src/image_read_handle.cpp
 )
 

--- a/ros2_cuda_ipc_image/include/ros2_cuda_ipc_image/image_reader.hpp
+++ b/ros2_cuda_ipc_image/include/ros2_cuda_ipc_image/image_reader.hpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cuda.h>
+
+#include <optional>
+
+#include "ros2_cuda_ipc_core/subscriber/buffer_mapper.hpp"
+#include "ros2_cuda_ipc_image/image_read_handle.hpp"
+#include "ros2_cuda_ipc_msgs/msg/gpu_image.hpp"
+
+namespace ros2_cuda_ipc_image {
+
+/// Maps and validates one GpuImage message for a consumer stream.
+///
+/// The mapper is kept across calls so its metadata cache can be reused. The
+/// returned ImageReadHandle owns the mapped read and its stream-bound
+/// lifetime.
+class ImageReader {
+ public:
+  ImageReader() = default;
+  ~ImageReader() = default;
+
+  ImageReader(const ImageReader&) = delete;
+  ImageReader& operator=(const ImageReader&) = delete;
+  ImageReader(ImageReader&&) noexcept = default;
+  ImageReader& operator=(ImageReader&&) noexcept = default;
+
+  std::optional<ImageReadHandle> read(
+      const ros2_cuda_ipc_msgs::msg::GpuImage& message,
+      CUstream consumer_stream);
+
+ private:
+  ros2_cuda_ipc_core::subscriber::BufferMapper mapper_;
+};
+
+}  // namespace ros2_cuda_ipc_image

--- a/ros2_cuda_ipc_image/src/image_reader.cpp
+++ b/ros2_cuda_ipc_image/src/image_reader.cpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#include "ros2_cuda_ipc_image/image_reader.hpp"
+
+#include <utility>
+
+namespace ros2_cuda_ipc_image {
+
+std::optional<ImageReadHandle> ImageReader::read(
+    const ros2_cuda_ipc_msgs::msg::GpuImage& message,
+    CUstream consumer_stream) {
+  auto mapped = mapper_.map(message.core, consumer_stream);
+  if (!mapped) {
+    return std::nullopt;
+  }
+  return ImageReadHandle::from_message(message, std::move(*mapped));
+}
+
+}  // namespace ros2_cuda_ipc_image

--- a/ros2_cuda_ipc_image/test/test_image_read_handle.cpp
+++ b/ros2_cuda_ipc_image/test/test_image_read_handle.cpp
@@ -5,6 +5,7 @@
 
 #include "ros2_cuda_ipc_core/subscriber/buffer_mapper.hpp"
 #include "ros2_cuda_ipc_image/image_read_handle.hpp"
+#include "ros2_cuda_ipc_image/image_reader.hpp"
 #include "test_mapper_utils.hpp"
 
 namespace ros2_cuda_ipc_image {
@@ -63,6 +64,34 @@ TEST_F(ImageReadHandleTest, CopiesAndValidatesMessageMetadata) {
   ASSERT_TRUE(image);
   EXPECT_EQ(image->header.frame_id, "camera_frame");
   EXPECT_TRUE(image->sanity_check());
+  image.reset();
+  EXPECT_EQ(
+      ros2_cuda_ipc_core::buffer_metadata::BufferRef::current_refcount(mapping),
+      0u);
+  ::shm_unlink(name.c_str());
+}
+
+TEST_F(ImageReadHandleTest, ReaderMapsAndValidatesMessage) {
+  const auto core =
+      ros2_cuda_ipc_core::test::make_seeded_buffer_core_message(45);
+  const auto name = ros2_cuda_ipc_core::test::metadata_shm_name(core);
+  auto mapping =
+      ros2_cuda_ipc_core::buffer_metadata::BufferMetadata::attach(name);
+  ASSERT_TRUE(mapping);
+
+  ros2_cuda_ipc_msgs::msg::GpuImage message;
+  message.header.frame_id = "camera_frame";
+  message.core = core;
+  message.dtype = static_cast<uint8_t>(DType::U8);
+  message.shape = {2, 3, 4};
+  message.strides = {12, 4, 1};
+
+  ImageReader reader;
+  auto image = reader.read(message, CU_STREAM_LEGACY);
+  ASSERT_TRUE(image);
+  EXPECT_EQ(image->header.frame_id, "camera_frame");
+  EXPECT_TRUE(image->sanity_check());
+
   image.reset();
   EXPECT_EQ(
       ros2_cuda_ipc_core::buffer_metadata::BufferRef::current_refcount(mapping),

--- a/ros2_cuda_ipc_pointcloud2/CMakeLists.txt
+++ b/ros2_cuda_ipc_pointcloud2/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(sensor_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 
 add_library(${PROJECT_NAME}
+  src/pointcloud2_reader.cpp
   src/pointcloud2_read_handle.cpp
 )
 

--- a/ros2_cuda_ipc_pointcloud2/include/ros2_cuda_ipc_pointcloud2/pointcloud2_reader.hpp
+++ b/ros2_cuda_ipc_pointcloud2/include/ros2_cuda_ipc_pointcloud2/pointcloud2_reader.hpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cuda.h>
+
+#include <optional>
+
+#include "ros2_cuda_ipc_core/subscriber/buffer_mapper.hpp"
+#include "ros2_cuda_ipc_msgs/msg/gpu_point_cloud2.hpp"
+#include "ros2_cuda_ipc_pointcloud2/pointcloud2_read_handle.hpp"
+
+namespace ros2_cuda_ipc_pointcloud2 {
+
+/// Maps and validates one GpuPointCloud2 message for a consumer stream.
+///
+/// The mapper is kept across calls so its metadata cache can be reused. The
+/// returned PointCloud2ReadHandle owns the mapped read and its stream-bound
+/// lifetime.
+class PointCloud2Reader {
+ public:
+  PointCloud2Reader() = default;
+  ~PointCloud2Reader() = default;
+
+  PointCloud2Reader(const PointCloud2Reader&) = delete;
+  PointCloud2Reader& operator=(const PointCloud2Reader&) = delete;
+  PointCloud2Reader(PointCloud2Reader&&) noexcept = default;
+  PointCloud2Reader& operator=(PointCloud2Reader&&) noexcept = default;
+
+  std::optional<PointCloud2ReadHandle> read(
+      const ros2_cuda_ipc_msgs::msg::GpuPointCloud2& message,
+      CUstream consumer_stream);
+
+ private:
+  ros2_cuda_ipc_core::subscriber::BufferMapper mapper_;
+};
+
+}  // namespace ros2_cuda_ipc_pointcloud2

--- a/ros2_cuda_ipc_pointcloud2/src/pointcloud2_reader.cpp
+++ b/ros2_cuda_ipc_pointcloud2/src/pointcloud2_reader.cpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 Daisuke Kato
+// SPDX-License-Identifier: MIT
+
+#include "ros2_cuda_ipc_pointcloud2/pointcloud2_reader.hpp"
+
+#include <utility>
+
+namespace ros2_cuda_ipc_pointcloud2 {
+
+std::optional<PointCloud2ReadHandle> PointCloud2Reader::read(
+    const ros2_cuda_ipc_msgs::msg::GpuPointCloud2& message,
+    CUstream consumer_stream) {
+  auto mapped = mapper_.map(message.core, consumer_stream);
+  if (!mapped) {
+    return std::nullopt;
+  }
+  return PointCloud2ReadHandle::from_message(message, std::move(*mapped));
+}
+
+}  // namespace ros2_cuda_ipc_pointcloud2

--- a/ros2_cuda_ipc_pointcloud2/test/test_pointcloud2_read_handle.cpp
+++ b/ros2_cuda_ipc_pointcloud2/test/test_pointcloud2_read_handle.cpp
@@ -5,6 +5,7 @@
 
 #include "ros2_cuda_ipc_core/subscriber/buffer_mapper.hpp"
 #include "ros2_cuda_ipc_pointcloud2/pointcloud2_read_handle.hpp"
+#include "ros2_cuda_ipc_pointcloud2/pointcloud2_reader.hpp"
 #include "sensor_msgs/msg/point_field.hpp"
 #include "test_mapper_utils.hpp"
 
@@ -85,6 +86,42 @@ TEST_F(PointCloud2ReadHandleTest, RejectsZeroCountAndEndOffsetFields) {
                   mapping),
               0u);
   }
+  ::shm_unlink(name.c_str());
+}
+
+TEST_F(PointCloud2ReadHandleTest, ReaderMapsAndValidatesMessage) {
+  const auto core =
+      ros2_cuda_ipc_core::test::make_seeded_buffer_core_message(46);
+  const auto name = ros2_cuda_ipc_core::test::metadata_shm_name(core);
+  auto mapping =
+      ros2_cuda_ipc_core::buffer_metadata::BufferMetadata::attach(name);
+  ASSERT_TRUE(mapping);
+
+  ros2_cuda_ipc_msgs::msg::GpuPointCloud2 message;
+  message.header.frame_id = "lidar";
+  message.core = core;
+  message.height = 1;
+  message.width = 2;
+  message.point_step = 12;
+  message.row_step = 24;
+  message.is_dense = true;
+  sensor_msgs::msg::PointField field;
+  field.name = "x";
+  field.datatype = sensor_msgs::msg::PointField::FLOAT32;
+  field.offset = 0;
+  field.count = 1;
+  message.fields = {field};
+
+  PointCloud2Reader reader;
+  auto cloud = reader.read(message, CU_STREAM_LEGACY);
+  ASSERT_TRUE(cloud);
+  EXPECT_EQ(cloud->header.frame_id, "lidar");
+  EXPECT_EQ(cloud->fields.front().name, "x");
+
+  cloud.reset();
+  EXPECT_EQ(
+      ros2_cuda_ipc_core::buffer_metadata::BufferRef::current_refcount(mapping),
+      0u);
   ::shm_unlink(name.c_str());
 }
 

--- a/utils/gpu_image_transport/README.md
+++ b/utils/gpu_image_transport/README.md
@@ -1,15 +1,16 @@
 # gpu_image_transport
 
 `gpu_image_transport` provides utility ROS 2 nodes for mapping
-`ros2_cuda_ipc_msgs::msg::GpuImage` messages into imported Views and then
+`ros2_cuda_ipc_msgs::msg::GpuImage` messages into typed imported Views and then
 republishing CPU-backed image topics.
 
 This package is not an `image_transport` plugin package. It does not register
 pluginlib transports like the packages in
 `ros-perception/image_transport_plugins`; it subscribes to GPU-backed
-`GpuImage` messages, maps each message explicitly, waits on the exported CUDA
-ready event, copies the image payload to pinned host memory, and republishes it
-as standard ROS messages.
+`GpuImage` messages, reads each message through
+`ros2_cuda_ipc_image::ImageReader`, waits on the exported CUDA ready event,
+copies the image payload to pinned host memory, and republishes it as standard
+ROS messages.
 
 ## Nodes
 

--- a/utils/gpu_image_transport/include/gpu_image_transport/gpu_image_transport_base.hpp
+++ b/utils/gpu_image_transport/include/gpu_image_transport/gpu_image_transport_base.hpp
@@ -12,8 +12,8 @@
 
 #include "rclcpp/rclcpp.hpp"
 #include "ros2_cuda_ipc_core/detail/nvtx_scoped_range.hpp"
-#include "ros2_cuda_ipc_core/subscriber/buffer_mapper.hpp"
 #include "ros2_cuda_ipc_image/image_read_handle.hpp"
+#include "ros2_cuda_ipc_image/image_reader.hpp"
 #include "ros2_cuda_ipc_msgs/msg/gpu_image.hpp"
 
 namespace gpu_image_transport {
@@ -48,7 +48,7 @@ class GpuImageTransportNodeBase : public rclcpp::Node {
   std::string output_topic_;
   uint8_t* pinned_host_buffer_ = nullptr;
   std::size_t pinned_host_capacity_ = 0;
-  ros2_cuda_ipc_core::subscriber::BufferMapper buffer_mapper_;
+  ros2_cuda_ipc_image::ImageReader reader_;
 };
 
 }  // namespace gpu_image_transport

--- a/utils/gpu_image_transport/src/gpu_image_transport_base.cpp
+++ b/utils/gpu_image_transport/src/gpu_image_transport_base.cpp
@@ -32,7 +32,7 @@ GpuImageTransportNodeBase::GpuImageTransportNodeBase(
         auto view = reader_.read(message, stream_);
         if (!view) {
           RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,
-                               "Failed to map received GPU image");
+                               "Failed to read received GPU image");
           return;
         }
         on_image(*view);

--- a/utils/gpu_image_transport/src/gpu_image_transport_base.cpp
+++ b/utils/gpu_image_transport/src/gpu_image_transport_base.cpp
@@ -29,17 +29,10 @@ GpuImageTransportNodeBase::GpuImageTransportNodeBase(
   subscription_ = create_subscription<ros2_cuda_ipc_msgs::msg::GpuImage>(
       input_topic_, rclcpp::QoS(rclcpp::KeepLast(1)).reliable(),
       [this](const ros2_cuda_ipc_msgs::msg::GpuImage& message) {
-        auto read = buffer_mapper_.map(message.core, stream_);
-        if (!read) {
-          RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,
-                               "Failed to map received GPU image");
-          return;
-        }
-        auto view = ros2_cuda_ipc_image::ImageReadHandle::from_message(
-            message, std::move(*read));
+        auto view = reader_.read(message, stream_);
         if (!view) {
           RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 2000,
-                               "Received invalid GPU image metadata");
+                               "Failed to map received GPU image");
           return;
         }
         on_image(*view);


### PR DESCRIPTION
## Summary

- Add `ros2_cuda_ipc_image::ImageReader` and `ros2_cuda_ipc_pointcloud2::PointCloud2Reader`.
- Compose the existing `BufferMapper` mapping and typed `from_message()` validation while reusing each reader's mapper cache across calls.
- Migrate the multi-process image fanout consumers and `gpu_image_transport` to the facade.
- Add facade coverage and document the new API in `CHANGELOG.md`, `README.md`, `DEVELOPING.md`, and design docs.

The existing low-level `BufferMapper`, `ReadHandle`, and typed `from_message()` APIs remain available. Ownership, stream semantics, synchronization, wire format, Python/DLPack paths, and validation behavior are unchanged.

## Validation

- `colcon build --packages-select ros2_cuda_ipc_image ros2_cuda_ipc_pointcloud2`
- `colcon build --packages-select gpu_image_transport multi_process_image_fanout`
- `colcon test --packages-select ros2_cuda_ipc_core ros2_cuda_ipc_image ros2_cuda_ipc_pointcloud2`
- All available tests passed; CUDA-device-dependent tests were skipped because this environment has no CUDA device.